### PR TITLE
Batch sink for Cassandra

### DIFF
--- a/Cassandra/Cassandra.json
+++ b/Cassandra/Cassandra.json
@@ -1,0 +1,62 @@
+{
+  "id": "Cassandra",
+  "groups" : {
+    "position": [ "group1" ],
+    "group1": {
+      "display" : "Cassandra Configuration",
+      "position" : [ "initialAddress", "port", "keyspace", "partitioner", "columnFamily", "primaryKey", "columns" ],
+      "fields" : {
+        "initialAddress": {
+          "widget": "textbox",
+          "label": "Initial Address",
+          "properties": {
+            "width": "large"
+          }
+        },
+        "port": {
+          "widget": "textbox",
+          "label": "Port",
+          "properties": {
+            "width": "medium"
+          }
+        },
+
+        "keyspace": {
+          "widget": "textbox",
+          "label": "Keyspace",
+          "properties": {
+            "width": "medium"
+          }
+        },
+        "partitioner" : {
+          "widget": "textbox",
+          "label": "Partitioner",
+          "properties": {
+            "width": "large"
+          }
+        },
+        "columnFamily" : {
+          "widget": "textbox",
+          "label": "Column Family",
+          "properties": {
+            "width":"medium"
+          }
+        },
+        "primaryKey" : {
+          "widget": "textbox",
+          "label": "Primary Key",
+          "properties": {
+            "width":"large"
+          }
+        },
+        "columns" : {
+          "widget": "textbox",
+          "label": "Columns",
+          "properties": {
+            "width": "large"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Cassandra/pom.xml
+++ b/Cassandra/pom.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>co.cask.plugin.etl</groupId>
+  <artifactId>cassandra-plugins</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Cassandra Plugins</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <cdap.version>3.2.0-SNAPSHOT</cdap.version>
+    <es.version>1.6.0</es.version>
+    <es-hadoop.version>2.1.0</es-hadoop.version>
+    <fastutil.version>6.6.1</fastutil.version>
+    <commons-httpclient.version>3.1</commons-httpclient.version>
+    <hadoop.version>2.3.0</hadoop.version>
+    <cassandraunit.version>2.0.2.2</cassandraunit.version>
+    <cassandra.version>2.1.0</cassandra.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>jsr250-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-batch</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-common</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.3.0</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-core</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-json</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-server</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+          <groupId>javax.servlet</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jasper-compiler</artifactId>
+          <groupId>tomcat</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jasper-runtime</artifactId>
+          <groupId>tomcat</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jsp-api</artifactId>
+          <groupId>javax.servlet.jsp</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-api</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject.extensions</groupId>
+          <artifactId>guice-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey.contribs</groupId>
+          <artifactId>jersey-guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>${cassandra.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.cassandraunit</groupId>
+      <artifactId>cassandra-unit</artifactId>
+      <version>${cassandraunit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>2.0.5</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <instructions>
+              <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+              <Embed-Transitive>true</Embed-Transitive>
+              <Embed-Directory>lib</Embed-Directory>
+              <!--Only @Plugin classes in the export packages will be included as plugin-->
+              <Export-Package>co.cask.plugin.etl.sink.*;org.apache.cassandra.hadoop.cql3</Export-Package>
+              <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+              <Embed-Transitive>true</Embed-Transitive>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>bundle</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+

--- a/Cassandra/src/main/java/co/cask/plugin/etl/sink/BatchCassandraSink.java
+++ b/Cassandra/src/main/java/co/cask/plugin/etl/sink/BatchCassandraSink.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.plugin.etl.sink;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.etl.common.StructuredRecordStringConverter;
+import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.batch.BatchSink;
+import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
+import com.google.common.base.Preconditions;
+import org.apache.cassandra.hadoop.ConfigHelper;
+import org.apache.cassandra.hadoop.cql3.CqlConfigHelper;
+import org.apache.cassandra.hadoop.cql3.CqlOutputFormat;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link BatchSink} that writes data to Cassandra.
+ * This {@link BatchCassandraSink} takes a {@link StructuredRecord} in,
+ * converts it to columns, and writes it to the Cassandra server.
+ */
+@Plugin(type = "sink")
+@Name("Cassandra")
+@Description("CDAP Cassandra Batch Sink takes the structured record from the input source " +
+  "and converts each field to a byte buffer, then puts it in the keyspace and column family specified by the user. " +
+  "The Cassandra server should be running prior to creating the adapter, " +
+  "and the keyspace and column family should be created.")
+public class BatchCassandraSink extends BatchSink<StructuredRecord, Map<String, ByteBuffer>, List<ByteBuffer>> {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchCassandraSink.class);
+
+  private final CassandraBatchConfig config;
+
+  public BatchCassandraSink(CassandraBatchConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) {
+    Job job = context.getHadoopJob();
+    Configuration conf = job.getConfiguration();
+
+    ConfigHelper.setOutputColumnFamily(conf, config.keyspace, config.columnFamily);
+    ConfigHelper.setOutputInitialAddress(conf, config.initialAddress);
+    ConfigHelper.setOutputPartitioner(conf, config.partitioner);
+    ConfigHelper.setOutputRpcPort(conf, config.port);
+
+    // The query needs to include the non-primary key columns. Creating the query
+    // For example, the query might be "UPDATE keyspace.columnFamily SET column1 = ?, column2 = ? "
+    // The primary keys are then added by Cassandra
+    String query = String.format("UPDATE %s.%s SET ", config.keyspace, config.columnFamily);
+    for (String column : config.columns.split(",")) {
+      if (!Arrays.asList(config.primaryKey.split(",")).contains(column)) {
+        query += column + " = ?, ";
+      }
+    }
+    query = query.substring(0, query.lastIndexOf(",")) + " "; //to remove the last comma
+    CqlConfigHelper.setOutputCql(job.getConfiguration(), query);
+
+    // ideally, we will use CqlBulkOutputFormat once Cassandra implements the patch
+    // to make the Hadoop-CQL package compatible with Hadoop
+    job.setOutputFormatClass(CqlOutputFormat.class);
+  }
+
+  @Override
+  public void transform(StructuredRecord record,
+                        Emitter<KeyValue<Map<String, ByteBuffer>, List<ByteBuffer>>> emitter) throws Exception {
+    Map<String, ByteBuffer> keys = new LinkedHashMap<>();
+    for (String key : config.primaryKey.split(",")) {
+      Preconditions.checkNotNull(record.get(key), String.format("Primary key %s is not present in this record: %s",
+                                                                key, StructuredRecordStringConverter
+                                                                       .toDelimitedString(record, ";")));
+      keys.put(key, encodeObject(record.get(key), record.getSchema().getField(key).getSchema()));
+    }
+    emitter.emit(new KeyValue<>(keys, getColumns(record)));
+  }
+
+  private List<ByteBuffer> getColumns(StructuredRecord record) throws Exception {
+    List<ByteBuffer> columns = new ArrayList<>();
+    List<String> primaryKeys = Arrays.asList(config.primaryKey.split(","));
+    for (String columnName : config.columns.split(",")) {
+
+      //Cassandra allows multiple primary keys, so splitting that list on a comma
+      // and checking that the current column isn't a primary key
+      if (!primaryKeys.contains(columnName)) {
+        columns.add(encodeObject(record.get(columnName),
+                                 record.getSchema().getField(columnName).getSchema()));
+      }
+    }
+    return columns;
+  }
+
+  private ByteBuffer encodeObject(Object object, Schema schema) throws IOException {
+    switch (schema.getType()) {
+      case NULL:
+        return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+      case BOOLEAN:
+        byte[] bytes = new byte[1];
+        bytes[0] = (byte) ((boolean) object ? 1 : 0);
+        return ByteBuffer.wrap(bytes);
+      case INT:
+        return ByteBufferUtil.bytes((int) object);
+      case LONG:
+        return ByteBufferUtil.bytes((long) object);
+      case FLOAT:
+        return ByteBufferUtil.bytes((float) object);
+      case DOUBLE:
+        return ByteBufferUtil.bytes((double) object);
+      case BYTES:
+        return ByteBuffer.wrap((byte[]) object);
+      case STRING:
+      case ENUM:
+        // Currently there is no standard container to represent enum type
+        return ByteBufferUtil.bytes((String) object);
+      case UNION:
+        if (schema.isNullableSimple()) {
+          return object == null ? ByteBufferUtil.EMPTY_BYTE_BUFFER : encodeObject(object, schema.getNonNullable());
+        }
+    }
+    throw new IOException("Unsupported field type - only simple types are supported: " + schema);
+  }
+
+  /**
+   * Config class for Batch Cassandra
+   */
+  public static class CassandraBatchConfig extends PluginConfig {
+    @Name(Cassandra.PARITIONER)
+    @Description("The partitioner for the keyspace")
+    private String partitioner;
+
+    @Name(Cassandra.PORT)
+    @Description("The rpc port for Cassandra. For example, 9160. " +
+      "Please also check the configuration to make sure that start_rpc is true in cassandra.yaml")
+    private String port;
+
+    @Name(Cassandra.COLUMN_FAMILY)
+    @Description("The column family to inject data into. Create the column family before starting the adapter.")
+    private String columnFamily;
+
+    @Name(Cassandra.KEYSPACE)
+    @Description("The keyspace to inject data into. Create the keyspace before starting the adapter.")
+    private String keyspace;
+
+    @Name(Cassandra.INITIAL_ADDRESS)
+    @Description("The initial address to connect to. For example, \"localhost\".")
+    private String initialAddress;
+
+    @Name(Cassandra.COLUMNS)
+    @Description("A comma-separated list of columns in the column family. " +
+      "The columns should be listed in the same order as they are stored in the column family.")
+    private String columns;
+
+    @Name(Cassandra.PRIMARY_KEY)
+    @Description("A comma-separated list of primary keys. For example, \"key1,key2\"")
+    private String primaryKey;
+
+    public CassandraBatchConfig(String partitioner, String port, String columnFamily, String keyspace,
+                                String initialAddress, String columns, String primaryKey) {
+      this.partitioner = partitioner;
+      this.initialAddress = initialAddress;
+      this.port = port;
+      this.columnFamily = columnFamily;
+      this.keyspace = keyspace;
+      this.columns = columns;
+      this.primaryKey = primaryKey;
+    }
+  }
+
+  /**
+   * Properties for Cassandra
+   */
+  public static class Cassandra {
+    public static final String PARITIONER = "partitioner";
+    public static final String PORT = "port";
+    public static final String COLUMN_FAMILY = "columnFamily";
+    public static final String KEYSPACE = "keyspace";
+    public static final String INITIAL_ADDRESS = "initialAddress";
+    public static final String COLUMNS = "columns";
+    public static final String PRIMARY_KEY = "primaryKey";
+  }
+}

--- a/Cassandra/src/main/java/co/cask/plugin/etl/source/StreamBatchSource.java
+++ b/Cassandra/src/main/java/co/cask/plugin/etl/source/StreamBatchSource.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.plugin.etl.source;
+
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.stream.GenericStreamEventData;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.etl.common.ETLUtils;
+import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchSource;
+import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.io.LongWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link BatchSource} for {@link Stream} to use {@link Stream} as Source.
+ */
+@SuppressWarnings("unused")
+@Plugin(type = "source")
+@Name("Stream")
+@Description("Batch source for a stream.")
+public class StreamBatchSource extends BatchSource<LongWritable, Object, StructuredRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StreamBatchSource.class);
+  private static final String FORMAT_SETTING_PREFIX = "format.setting.";
+  private static final Schema DEFAULT_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("ts", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("body", Schema.of(Schema.Type.BYTES))
+  );
+  private static final String NAME_DESCRIPTION = "Name of the stream. Must be a valid stream name. " +
+    "If it doesn't exist, it will be created.";
+  private static final String DURATION_DESCRIPTION = "Size of the time window to read with each run of the pipeline. " +
+    "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
+    "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of '5m' means each run of " +
+    "the pipeline will read 5 minutes of events from the stream.";
+  private static final String DELAY_DESCRIPTION = "Optional delay for reading stream events. The value must be " +
+    "of the same format as the duration value. For example, a duration of '5m' and a delay of '10m' means each run " +
+    "of the pipeline will read events from 15 minutes before its logical start time to 10 minutes before its " +
+    "logical start time. The default value is 0.";
+  private static final String FORMAT_DESCRIPTION = "Optional format of the stream. Any format supported by CDAP " +
+    "is also supported. For example, a value of 'csv' will attempt to parse stream events as comma separated values. " +
+    "If no format is given, event bodies will be treated as bytes, resulting in a three field schema: " +
+    "'ts' of type long, 'headers' of type map of string to string, and 'body' of type bytes.";
+  private static final String SCHEMA_DESCRIPTION = "Optional schema for the body of stream events. Schema is used " +
+    "in conjunction with format to parse stream events. Some formats like the avro format require schema, " +
+    "while others do not. The schema given is for the body of the stream, so the final schema of records output " +
+    "by the source will contain an additional field named 'ts' for the timestamp and a field named 'headers' " +
+    "for the headers as as the first and second fields of the schema.";
+
+  private StreamBatchConfig streamBatchConfig;
+
+  // its possible the input records could have different schemas, though that isn't the case today.
+  private Map<Schema, Schema> schemaCache = Maps.newHashMap();
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    streamBatchConfig.validate();
+    pipelineConfigurer.addStream(new Stream(streamBatchConfig.name));
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) {
+    long duration = ETLUtils.parseDuration(streamBatchConfig.duration);
+    long delay = Strings.isNullOrEmpty(streamBatchConfig.delay) ? 0 : ETLUtils.parseDuration(streamBatchConfig.delay);
+    long endTime = context.getLogicalStartTime() - delay;
+    long startTime = endTime - duration;
+
+    LOG.info("Setting input to Stream : {}", streamBatchConfig.name);
+
+    FormatSpecification formatSpec = streamBatchConfig.getFormatSpec();
+
+    StreamBatchReadable stream;
+    if (formatSpec == null) {
+      stream = new StreamBatchReadable(streamBatchConfig.name, startTime, endTime);
+    } else {
+      stream = new StreamBatchReadable(streamBatchConfig.name, startTime, endTime, formatSpec);
+    }
+    context.setInput(stream);
+  }
+
+  @Override
+  public void transform(KeyValue<LongWritable, Object> input, Emitter<StructuredRecord> emitter) throws Exception {
+    // if not format spec was given, the value is a StreamEvent
+    if (Strings.isNullOrEmpty(streamBatchConfig.format)) {
+      StreamEvent event = (StreamEvent) input.getValue();
+      Map<String, String> headers = Objects.firstNonNull(event.getHeaders(), ImmutableMap.<String, String>of());
+      StructuredRecord output = StructuredRecord.builder(DEFAULT_SCHEMA)
+        .set("ts", input.getKey().get())
+        .set("headers", headers)
+        .set("body", event.getBody())
+        .build();
+      emitter.emit(output);
+    } else {
+      // otherwise, it will be a GenericStreamEventData
+      @SuppressWarnings("unchecked")
+      GenericStreamEventData<StructuredRecord> event = (GenericStreamEventData<StructuredRecord>) input.getValue();
+      StructuredRecord record = event.getBody();
+      Schema inputSchema = record.getSchema();
+      Schema outputSchema = schemaCache.get(inputSchema);
+      // if we haven't seen this schema before, generate the output schema (add ts and header fields)
+      if (outputSchema == null) {
+        List<Schema.Field> fields = Lists.newArrayList();
+        fields.add(DEFAULT_SCHEMA.getField("ts"));
+        fields.add(DEFAULT_SCHEMA.getField("headers"));
+        fields.addAll(inputSchema.getFields());
+        outputSchema = Schema.recordOf(inputSchema.getRecordName(), fields);
+        schemaCache.put(inputSchema, outputSchema);
+      }
+
+      // easier to just deal with an empty map than deal with nullables, so the headers field is non-nullable.
+      Map<String, String> headers = Objects.firstNonNull(event.getHeaders(), ImmutableMap.<String, String>of());
+      StructuredRecord.Builder builder = StructuredRecord.builder(outputSchema);
+      builder.set("ts", input.getKey().get());
+      builder.set("headers", headers);
+
+      for (Schema.Field field : inputSchema.getFields()) {
+        String fieldName = field.getName();
+        builder.set(fieldName, record.get(fieldName));
+      }
+      emitter.emit(builder.build());
+    }
+  }
+
+  /**
+   * {@link PluginConfig} class for {@link StreamBatchSource}
+   */
+  public static class StreamBatchConfig extends PluginConfig {
+
+    @Description(NAME_DESCRIPTION)
+    private String name;
+
+    @Description(DURATION_DESCRIPTION)
+    private String duration;
+
+    @Description(DELAY_DESCRIPTION)
+    @Nullable
+    private String delay;
+
+    @Description(FORMAT_DESCRIPTION)
+    @Nullable
+    private String format;
+
+    @Description(SCHEMA_DESCRIPTION)
+    @Nullable
+    private String schema;
+
+    private void validate() {
+      // check the schema if there is one
+      if (!Strings.isNullOrEmpty(schema)) {
+        parseSchema();
+      }
+      // check duration and delay
+      long durationInMs = ETLUtils.parseDuration(duration);
+      Preconditions.checkArgument(durationInMs > 0, "Duration must be greater than 0");
+      if (!Strings.isNullOrEmpty(delay)) {
+        ETLUtils.parseDuration(delay);
+      }
+    }
+
+    private FormatSpecification getFormatSpec() {
+      FormatSpecification formatSpec = null;
+      if (!Strings.isNullOrEmpty(format)) {
+        // try to parse the schema if there is one
+        Schema schemaObj = parseSchema();
+
+        // strip format.settings. from any properties and use them in the format spec
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (Map.Entry<String, String> entry : getProperties().getProperties().entrySet()) {
+          if (entry.getKey().startsWith(FORMAT_SETTING_PREFIX)) {
+            String key = entry.getKey();
+            builder.put(key.substring(FORMAT_SETTING_PREFIX.length(), key.length()), entry.getValue());
+          }
+        }
+        formatSpec = new FormatSpecification(format, schemaObj, builder.build());
+      }
+      return formatSpec;
+    }
+
+    private Schema parseSchema() {
+      try {
+        return Strings.isNullOrEmpty(schema) ? null : Schema.parseJson(schema);
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Invalid schema: " + e.getMessage());
+      }
+    }
+  }
+  /**
+   * Properties for the StreamBatchSource as well as the real-time StreamSink
+   */
+  public static class StreamProperties {
+    public static final String NAME = "name";
+    public static final String SCHEMA = "schema";
+    public static final String FORMAT = "format";
+    public static final String DELAY = "delay";
+    public static final String DURATION = "duration";
+    public static final String BODY_FIELD = "body.field";
+    public static final String DEFAULT_BODY_FIELD = "body";
+    public static final String HEADERS_FIELD = "headers.field";
+    public static final String DEFAULT_HEADERS_FIELD = "headers";
+  }
+}
+

--- a/Cassandra/src/main/java/org/apache/cassandra/config/Config.java
+++ b/Cassandra/src/main/java/org/apache/cassandra/config/Config.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.cassandra.config;
+
+import org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions;
+import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions;
+import org.apache.cassandra.config.RequestSchedulerOptions;
+import org.apache.cassandra.config.SeedProviderDef;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.util.NativeAllocator;
+import org.supercsv.io.CsvListReader;
+import org.supercsv.prefs.CsvPreference;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * TODO: remove once guava is removed from cdap-api
+ * This is a copy of the Configuration class in Cassandra, except it replaces usage of Sets.newConcurrentHashSet()
+ * with Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>()) to avoid guava version conflicts.
+ *
+ * A class that contains configuration properties for the cassandra node it runs within.
+ *
+ * Properties declared as volatile can be mutated via JMX.
+ */
+public class Config
+{
+  /*
+   * Prefix for Java properties for internal Cassandra configuration options
+   */
+  public static final String PROPERTY_PREFIX = "cassandra.";
+
+
+  public String cluster_name = "Test Cluster";
+  public String authenticator;
+  public String authorizer;
+  public volatile int permissions_validity_in_ms = 2000;
+  public int permissions_cache_max_entries = 1000;
+  public volatile int permissions_update_interval_in_ms = -1;
+
+  /* Hashing strategy Random or OPHF */
+  public String partitioner;
+
+  public Boolean auto_bootstrap = true;
+  public volatile boolean hinted_handoff_enabled_global = true;
+  public String hinted_handoff_enabled;
+  public Set<String> hinted_handoff_enabled_by_dc = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+  public volatile Integer max_hint_window_in_ms = 3 * 3600 * 1000; // three hours
+
+  public SeedProviderDef seed_provider;
+  public DiskAccessMode disk_access_mode = DiskAccessMode.auto;
+
+  public DiskFailurePolicy disk_failure_policy = DiskFailurePolicy.ignore;
+  public CommitFailurePolicy commit_failure_policy = CommitFailurePolicy.stop;
+
+  /* initial token in the ring */
+  public String initial_token;
+  public Integer num_tokens = 1;
+
+  public volatile Long request_timeout_in_ms = 10000L;
+
+  public volatile Long read_request_timeout_in_ms = 5000L;
+
+  public volatile Long range_request_timeout_in_ms = 10000L;
+
+  public volatile Long write_request_timeout_in_ms = 2000L;
+
+  public volatile Long counter_write_request_timeout_in_ms = 5000L;
+
+  public volatile Long cas_contention_timeout_in_ms = 1000L;
+
+  public volatile Long truncate_request_timeout_in_ms = 60000L;
+
+  public Integer streaming_socket_timeout_in_ms = 0;
+
+  public boolean cross_node_timeout = false;
+
+  public volatile Double phi_convict_threshold = 8.0;
+
+  public Integer concurrent_reads = 32;
+  public Integer concurrent_writes = 32;
+  public Integer concurrent_counter_writes = 32;
+
+  @Deprecated
+  public Integer concurrent_replicates = null;
+
+  public Integer memtable_flush_writers = null;
+  public Integer memtable_heap_space_in_mb;
+  public Integer memtable_offheap_space_in_mb;
+  public Float memtable_cleanup_threshold = null;
+
+  public Integer storage_port = 7000;
+  public Integer ssl_storage_port = 7001;
+  public String listen_address;
+  public String listen_interface;
+  public Boolean listen_interface_prefer_ipv6 = false;
+  public String broadcast_address;
+  public String internode_authenticator;
+
+  public Boolean start_rpc = true;
+  public String rpc_address;
+  public String rpc_interface;
+  public Boolean rpc_interface_prefer_ipv6 = false;
+  public String broadcast_rpc_address;
+  public Integer rpc_port = 9160;
+  public Integer rpc_listen_backlog = 50;
+  public String rpc_server_type = "sync";
+  public Boolean rpc_keepalive = true;
+  public Integer rpc_min_threads = 16;
+  public Integer rpc_max_threads = Integer.MAX_VALUE;
+  public Integer rpc_send_buff_size_in_bytes;
+  public Integer rpc_recv_buff_size_in_bytes;
+  public Integer internode_send_buff_size_in_bytes;
+  public Integer internode_recv_buff_size_in_bytes;
+
+  public Boolean start_native_transport = false;
+  public Integer native_transport_port = 9042;
+  public Integer native_transport_max_threads = 128;
+  public Integer native_transport_max_frame_size_in_mb = 256;
+  public volatile Long native_transport_max_concurrent_connections = -1L;
+  public volatile Long native_transport_max_concurrent_connections_per_ip = -1L;
+
+  @Deprecated
+  public Integer thrift_max_message_length_in_mb = 16;
+
+  public Integer thrift_framed_transport_size_in_mb = 15;
+  public Boolean snapshot_before_compaction = false;
+  public Boolean auto_snapshot = true;
+
+  /* if the size of columns or super-columns are more than this, indexing will kick in */
+  public Integer column_index_size_in_kb = 64;
+  public Integer batch_size_warn_threshold_in_kb = 5;
+  public Integer concurrent_compactors;
+  public volatile Integer compaction_throughput_mb_per_sec = 16;
+
+  public Integer max_streaming_retries = 3;
+
+  public volatile Integer stream_throughput_outbound_megabits_per_sec = 200;
+  public volatile Integer inter_dc_stream_throughput_outbound_megabits_per_sec = 0;
+
+  public String[] data_file_directories;
+
+  public String saved_caches_directory;
+
+  // Commit Log
+  public String commitlog_directory;
+  public Integer commitlog_total_space_in_mb;
+  public CommitLogSync commitlog_sync;
+  public Double commitlog_sync_batch_window_in_ms;
+  public Integer commitlog_sync_period_in_ms;
+  public int commitlog_segment_size_in_mb = 32;
+
+  @Deprecated
+  public int commitlog_periodic_queue_size = -1;
+
+  public String endpoint_snitch;
+  public Boolean dynamic_snitch = true;
+  public Integer dynamic_snitch_update_interval_in_ms = 100;
+  public Integer dynamic_snitch_reset_interval_in_ms = 600000;
+  public Double dynamic_snitch_badness_threshold = 0.1;
+
+  public String request_scheduler;
+  public RequestSchedulerId request_scheduler_id;
+  public RequestSchedulerOptions request_scheduler_options;
+
+  public ServerEncryptionOptions server_encryption_options = new ServerEncryptionOptions();
+  public ClientEncryptionOptions client_encryption_options = new ClientEncryptionOptions();
+  // this encOptions is for backward compatibility (a warning is logged by DatabaseDescriptor)
+  public ServerEncryptionOptions encryption_options;
+
+  public InternodeCompression internode_compression = InternodeCompression.none;
+
+  @Deprecated
+  public Integer index_interval = null;
+
+  public int hinted_handoff_throttle_in_kb = 1024;
+  public int batchlog_replay_throttle_in_kb = 1024;
+  public int max_hints_delivery_threads = 1;
+  public int sstable_preemptive_open_interval_in_mb = 50;
+
+  public volatile boolean incremental_backups = false;
+  public boolean trickle_fsync = false;
+  public int trickle_fsync_interval_in_kb = 10240;
+
+  public Long key_cache_size_in_mb = null;
+  public volatile int key_cache_save_period = 14400;
+  public volatile int key_cache_keys_to_save = Integer.MAX_VALUE;
+
+  public long row_cache_size_in_mb = 0;
+  public volatile int row_cache_save_period = 0;
+  public volatile int row_cache_keys_to_save = Integer.MAX_VALUE;
+
+  public Long counter_cache_size_in_mb = null;
+  public volatile int counter_cache_save_period = 7200;
+  public volatile int counter_cache_keys_to_save = Integer.MAX_VALUE;
+
+  public String memory_allocator = NativeAllocator.class.getSimpleName();
+
+  private static boolean isClientMode = false;
+
+  public Integer file_cache_size_in_mb;
+
+  public boolean inter_dc_tcp_nodelay = true;
+
+  public MemtableAllocationType memtable_allocation_type = MemtableAllocationType.heap_buffers;
+
+  private static boolean outboundBindAny = false;
+
+  public volatile int tombstone_warn_threshold = 1000;
+  public volatile int tombstone_failure_threshold = 100000;
+
+  public volatile Long index_summary_capacity_in_mb;
+  public volatile int index_summary_resize_interval_in_minutes = 60;
+
+  private static final CsvPreference STANDARD_SURROUNDING_SPACES_NEED_QUOTES = new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE)
+    .surroundingSpacesNeedQuotes(true).build();
+
+  /*
+   * Strategy to use for coalescing messages in OutboundTcpConnection.
+   * Can be fixed, movingaverage, timehorizon, disabled. Setting is case and leading/trailing
+   * whitespace insensitive. You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+   */
+  public String otc_coalescing_strategy = "DISABLED";
+
+  /*
+   * How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+   * messgae is received before it will be sent with any accompanying messages. For moving average this is the
+   * maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+   * for coalescing to be enabled.
+   */
+  public static final int otc_coalescing_window_us_default = 200;
+  public int otc_coalescing_window_us = otc_coalescing_window_us_default;
+
+  public static boolean getOutboundBindAny()
+  {
+    return outboundBindAny;
+  }
+
+  public static void setOutboundBindAny(boolean value)
+  {
+    outboundBindAny = value;
+  }
+
+  public static boolean isClientMode()
+  {
+    return isClientMode;
+  }
+
+  public static void setClientMode(boolean clientMode)
+  {
+    isClientMode = clientMode;
+  }
+
+  public void configHintedHandoff() throws ConfigurationException
+  {
+    if (hinted_handoff_enabled != null && !hinted_handoff_enabled.isEmpty())
+    {
+      if (hinted_handoff_enabled.equalsIgnoreCase("true"))
+      {
+        hinted_handoff_enabled_global = true;
+      }
+      else if (hinted_handoff_enabled.equalsIgnoreCase("false"))
+      {
+        hinted_handoff_enabled_global = false;
+      }
+      else
+      {
+        try
+        {
+          hinted_handoff_enabled_by_dc.addAll(parseHintedHandoffEnabledDCs(hinted_handoff_enabled));
+        }
+        catch (IOException e)
+        {
+          throw new ConfigurationException("Invalid hinted_handoff_enabled parameter " + hinted_handoff_enabled, e);
+        }
+      }
+    }
+  }
+
+  public static List<String> parseHintedHandoffEnabledDCs(final String dcNames) throws IOException
+  {
+    final CsvListReader csvListReader = new CsvListReader(new StringReader(dcNames), STANDARD_SURROUNDING_SPACES_NEED_QUOTES);
+    return csvListReader.read();
+  }
+
+  public static enum CommitLogSync
+  {
+    periodic,
+    batch
+  }
+  public static enum InternodeCompression
+  {
+    all, none, dc
+  }
+
+  public static enum DiskAccessMode
+  {
+    auto,
+    mmap,
+    mmap_index_only,
+    standard,
+  }
+
+  public static enum MemtableAllocationType
+  {
+    unslabbed_heap_buffers,
+    heap_buffers,
+    offheap_buffers,
+    offheap_objects
+  }
+
+  public static enum DiskFailurePolicy
+  {
+    best_effort,
+    stop,
+    ignore,
+    stop_paranoid,
+    die
+  }
+
+  public static enum CommitFailurePolicy
+  {
+    stop,
+    stop_commit,
+    ignore,
+    die,
+  }
+
+  public static enum RequestSchedulerId
+  {
+    keyspace
+  }
+}

--- a/Cassandra/src/main/java/org/apache/cassandra/io/compress/CompressedThrottledReader.java
+++ b/Cassandra/src/main/java/org/apache/cassandra/io/compress/CompressedThrottledReader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.apache.cassandra.io.compress.CompressedRandomAccessReader;
+import org.apache.cassandra.io.compress.CompressionMetadata;
+
+import java.io.FileNotFoundException;
+
+/**
+ * TODO: remove once guava removed from cdap-api
+ * Copied from Cassandra to avoid guava conflicts from method signature change to RateLimiter.acquire(int x).
+ */
+public class CompressedThrottledReader extends CompressedRandomAccessReader
+{
+  private final RateLimiter limiter;
+
+  public CompressedThrottledReader(String file, CompressionMetadata metadata, RateLimiter limiter) throws FileNotFoundException
+  {
+    super(file, metadata, null);
+    this.limiter = limiter;
+  }
+
+  protected void reBuffer()
+  {
+    limiter.acquire(buffer.length);
+    super.reBuffer();
+  }
+
+  public static org.apache.cassandra.io.compress.CompressedThrottledReader open(String file, CompressionMetadata metadata, RateLimiter limiter)
+  {
+    try
+    {
+      return new org.apache.cassandra.io.compress.CompressedThrottledReader(file, metadata, limiter);
+    }
+    catch (FileNotFoundException e)
+    {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/Cassandra/src/test/java/co/cask/plugin/etl/pluginsTest/BaseETLBatchTest.java
+++ b/Cassandra/src/test/java/co/cask/plugin/etl/pluginsTest/BaseETLBatchTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.plugin.etl.pluginsTest;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.template.etl.api.PipelineConfigurable;
+import co.cask.cdap.template.etl.api.batch.BatchSource;
+import co.cask.cdap.template.etl.batch.ETLBatchTemplate;
+import co.cask.cdap.template.etl.common.ETLConfig;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
+import co.cask.plugin.etl.sink.BatchCassandraSink;
+import com.google.gson.Gson;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import co.cask.plugin.etl.source.StreamBatchSource;
+
+import java.io.IOException;
+
+/**
+ * Base test class that sets up plugins and the batch template.
+ */
+public class BaseETLBatchTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  protected static final Id.Namespace NAMESPACE = Id.Namespace.DEFAULT;
+  protected static final Id.ApplicationTemplate TEMPLATE_ID = Id.ApplicationTemplate.from("ETLBatch");
+
+  @BeforeClass
+  public static void setupTest() throws IOException {
+    addTemplatePlugins(TEMPLATE_ID, "batch-plugins-1.0.0.jar",
+                       StreamBatchSource.class, BatchCassandraSink.class);
+    deployTemplate(NAMESPACE, TEMPLATE_ID, ETLBatchTemplate.class,
+                   PipelineConfigurable.class.getPackage().getName(),
+                   BatchSource.class.getPackage().getName(),
+                   ETLConfig.class.getPackage().getName());
+  }
+}

--- a/Cassandra/src/test/java/co/cask/plugin/etl/pluginsTest/ETLCassandraTest.java
+++ b/Cassandra/src/test/java/co/cask/plugin/etl/pluginsTest/ETLCassandraTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.plugin.etl.pluginsTest;
+
+import co.cask.cdap.api.data.format.Formats;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.proto.AdapterConfig;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.test.AdapterManager;
+import co.cask.cdap.test.StreamManager;
+import co.cask.plugin.etl.sink.BatchCassandraSink;
+import co.cask.plugin.etl.source.StreamBatchSource;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import org.apache.cassandra.hadoop.ConfigHelper;
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.hadoop.conf.Configuration;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *  Unit test for batch {@link BatchCassandraSink} class.
+ */
+public class ETLCassandraTest extends BaseETLBatchTest {
+  private static final Gson GSON = new Gson();
+  private static final String STREAM_NAME = "myStream";
+
+  private static final Schema BODY_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("num", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private Cassandra.Client client;
+
+  @Before
+  public void beforeTest() throws Exception {
+    EmbeddedCassandraServerHelper.startEmbeddedCassandra(30*1000);
+
+    client = ConfigHelper.createConnection(new Configuration(), "localhost", 9171);
+    client.execute_cql3_query(
+      ByteBufferUtil.bytes("CREATE KEYSPACE testkeyspace " +
+                             "WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"),
+      Compression.NONE, ConsistencyLevel.ALL);
+
+    client.execute_cql3_query(ByteBufferUtil.bytes("USE testkeyspace"), Compression.NONE, ConsistencyLevel.ALL);
+
+    client.execute_cql3_query(
+      ByteBufferUtil.bytes("CREATE TABLE testtable ( ticker text PRIMARY KEY, price double, num int );"),
+      Compression.NONE, ConsistencyLevel.ALL);
+  }
+
+  @After
+  public void afterTest() throws Exception {
+    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+  }
+
+  @Test
+  public void testCassandraSink() throws Exception {
+    StreamManager streamManager = getStreamManager(STREAM_NAME);
+    streamManager.createStream();
+    streamManager.send(ImmutableMap.of("header1", "bar"), "AAPL|10|500.32");
+    streamManager.send(ImmutableMap.of("header1", "bar"), "CDAP|13|212.36");
+
+    ETLStage source = new ETLStage("Stream", ImmutableMap.<String, String>builder()
+      .put(StreamBatchSource.StreamProperties.NAME, STREAM_NAME)
+      .put(StreamBatchSource.StreamProperties.DURATION, "10m")
+      .put(StreamBatchSource.StreamProperties.DELAY, "0d")
+      .put(StreamBatchSource.StreamProperties.FORMAT, Formats.CSV)
+      .put(StreamBatchSource.StreamProperties.SCHEMA, BODY_SCHEMA.toString())
+      .put("format.setting.delimiter", "|")
+      .build());
+
+    ETLStage sink = new ETLStage("Cassandra", new ImmutableMap.Builder<String, String>()
+      .put(BatchCassandraSink.Cassandra.INITIAL_ADDRESS, "localhost")
+      .put(BatchCassandraSink.Cassandra.PORT, "9171")
+      .put(BatchCassandraSink.Cassandra.PARITIONER, "org.apache.cassandra.dht.Murmur3Partitioner")
+      .put(BatchCassandraSink.Cassandra.KEYSPACE, "testkeyspace")
+      .put(BatchCassandraSink.Cassandra.COLUMN_FAMILY, "testtable")
+      .put(BatchCassandraSink.Cassandra.COLUMNS, "ticker,num,price")
+      .put(BatchCassandraSink.Cassandra.PRIMARY_KEY, "ticker")
+      .build());
+
+    List<ETLStage> transforms = new ArrayList<>();
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, transforms);
+    Id.Adapter adapterId = Id.Adapter.from(NAMESPACE, "cassandraSinkTest");
+    AdapterConfig adapterConfig = new AdapterConfig("", TEMPLATE_ID.getId(), GSON.toJsonTree(etlConfig));
+    AdapterManager manager = createAdapter(adapterId, adapterConfig);
+
+    manager.start();
+    manager.waitForOneRunToFinish(5, TimeUnit.MINUTES);
+    manager.stop();
+
+    CqlResult result = client.execute_cql3_query(ByteBufferUtil.bytes("SELECT * from testtable"),
+                                                 Compression.NONE, ConsistencyLevel.ALL);
+    Assert.assertEquals(2, result.getRowsSize());
+    Assert.assertEquals(3, result.getRows().get(0).getColumns().size());
+
+    //first entry - "AAPL"
+    Assert.assertEquals(ByteBufferUtil.bytes("ticker"), result.getRows().get(0).getColumns().get(0).bufferForName());
+    Assert.assertEquals(ByteBufferUtil.bytes("AAPL"), result.getRows().get(0).getColumns().get(0).bufferForValue());
+    Assert.assertEquals(ByteBufferUtil.bytes("num"), result.getRows().get(0).getColumns().get(1).bufferForName());
+    Assert.assertEquals(ByteBufferUtil.bytes(10), result.getRows().get(0).getColumns().get(1).bufferForValue());
+    Assert.assertEquals(ByteBufferUtil.bytes("price"), result.getRows().get(0).getColumns().get(2).bufferForName());
+    Assert.assertEquals(ByteBufferUtil.bytes(500.32), result.getRows().get(0).getColumns().get(2).bufferForValue());
+
+    //second entry - "CDAP"
+    Assert.assertEquals(ByteBufferUtil.bytes("ticker"), result.getRows().get(1).getColumns().get(0).bufferForName());
+    Assert.assertEquals(ByteBufferUtil.bytes("CDAP"), result.getRows().get(1).getColumns().get(0).bufferForValue());
+    Assert.assertEquals(ByteBufferUtil.bytes("num"), result.getRows().get(1).getColumns().get(1).bufferForName());
+    Assert.assertEquals(ByteBufferUtil.bytes(13), result.getRows().get(1).getColumns().get(1).bufferForValue());
+    Assert.assertEquals(ByteBufferUtil.bytes("price"), result.getRows().get(1).getColumns().get(2).bufferForName());
+    Assert.assertEquals(ByteBufferUtil.bytes(212.36), result.getRows().get(1).getColumns().get(2).bufferForValue());
+  }
+}


### PR DESCRIPTION
Several files have been copied over from the cdap repository because they are not exported.

The files in org.apache.cassandra are Cassandra files copied because of conflicting guava versions (with cdap-api). ETLUtils, StructuredRecordStringConverter, StreamBatchSource, BaseETLBatchTest, and TestConfiguration are all cdap files that have been copied. The only relevant files to look at are the pom, cassandra.json, BatchCassandraSink, and ETLCassandraTest.
