### PR TITLE
bring back maven plugins which got removed during resolving conflicts

### DIFF
--- a/hive-plugins/pom.xml
+++ b/hive-plugins/pom.xml
@@ -23,9 +23,9 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
 
-  <modelVersion>4.0.0</modelVersion>
-
+  <name>Hive Hydrator Plugins</name>
   <artifactId>hive-plugins</artifactId>
+  <modelVersion>4.0.0</modelVersion>
 
   <repositories>
     <repository>

--- a/hive-plugins/src/main/java/co/cask/plugin/etl/batch/HiveConfig.java
+++ b/hive-plugins/src/main/java/co/cask/plugin/etl/batch/HiveConfig.java
@@ -45,6 +45,9 @@ public class HiveConfig extends PluginConfig {
     dbName = "default";
   }
 
+  /**
+   * Hive config variables
+   */
   public static class Hive {
     public static final String METASTORE_URI = "metastoreURI";
     public static final String DB_NAME = "databaseName";

--- a/hive-plugins/src/main/java/co/cask/plugin/etl/batch/sink/HiveBatchSink.java
+++ b/hive-plugins/src/main/java/co/cask/plugin/etl/batch/sink/HiveBatchSink.java
@@ -121,6 +121,9 @@ public class HiveBatchSink extends BatchSink<StructuredRecord, NullWritable, HCa
     emitter.emit(new KeyValue<>(NullWritable.get(), hCatRecord));
   }
 
+  /**
+   * Output format provider for Hive Sink
+   */
   public static class SinkOutputFormatProvider implements OutputFormatProvider {
     private final Map<String, String> conf;
 

--- a/hive-plugins/src/main/java/co/cask/plugin/etl/batch/source/HiveSourceConfig.java
+++ b/hive-plugins/src/main/java/co/cask/plugin/etl/batch/source/HiveSourceConfig.java
@@ -27,8 +27,8 @@ import javax.annotation.Nullable;
  */
 public class HiveSourceConfig extends HiveConfig {
   @Name(Hive.PARTITIONS)
-  @Description("Hive expression filter for scan defining partitions to read. For example if your table is partitioned " +
-    "on 'type' and you want to read 'type1' partition: 'type = \"type1\"'" +
+  @Description("Hive expression filter for scan defining partitions to read. For example if your table is " +
+    "partitioned on 'type' and you want to read 'type1' partition: 'type = \"type1\"'" +
     "This filter must reference only partition columns. Values from other columns will cause the pipeline to fail.")
   @Nullable
   public String partitions;

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <packaging>pom</packaging>
 
   <name>Hydrator Plugin Collection</name>
-  
+
   <url>http://docs.cdap.io/cdap/current/en/included-applications/index.html</url>
 
   <licenses>
@@ -390,22 +390,112 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+        <configuration>
+          <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=1024m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -Djava.net.preferIPv4Stack=true</argLine>
+          <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
+          <reuseForks>false</reuseForks>
+          <reportFormat>plain</reportFormat>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+          </systemPropertyVariables>
+          <includes>
+            <include>**/*TestsSuite.java</include>
+            <include>**/*TestSuite.java</include>
+            <include>**/Test*.java</include>
+            <include>**/*Test.java</include>
+            <include>**/*TestCase.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*TestRun.java</exclude>
+          </excludes>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>2.14</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.10</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-core</artifactId>
+            <version>1.6</version>
+            <exclusions>
+              <exclusion>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>rat-check</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>LICENSE*.txt</exclude>
+                <!-- This file should be not be there, but I am excluding it for now -->
+                <exclude>*.rst</exclude>
+                <exclude>*.md</exclude>
+                <exclude>**/*.cdap</exclude>
+                <exclude>**/*.yaml</exclude>
+                <exclude>**/*.md</exclude>
+                <exclude>logs/**</exclude>
+                <exclude>.git/**</exclude>
+                <exclude>.idea/**</exclude>
+                <exclude>**/grok/patterns/**</exclude>
+                <exclude>conf/**</exclude>
+                <exclude>data/**</exclude>
+                <exclude>plugins/**</exclude>
+                <exlcude>**/*.patch</exlcude>
+                <exclude>**/logrotate.d/**</exclude>
+                <exclude>**/limits.d/**</exclude>
+                <exclude>**/*.json</exclude>
+                <exclude>**/*.json.template</exclude>
+                <exclude>**/MANIFEST.MF</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.12.1</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>process-test-classes</phase>
+            <configuration>
+              <configLocation>checkstyle.xml</configLocation>
+              <suppressionsLocation>suppressions.xml</suppressionsLocation>
+              <encoding>UTF-8</encoding>
+              <consoleOutput>true</consoleOutput>
+              <failsOnError>true</failsOnError>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <excludes>**/org/apache/cassandra/**</excludes>
+            </configuration>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>default</id>
-      <modules>
-        <module>cassandra-plugins</module>
-        <module>elasticsearch-plugins</module>
-        <module>mongodb-plugins</module>
-        <module>hbase-plugins</module>
-        <module>hdfs-plugins</module>
-        <module>transform-plugins</module>
-        <module>kafka-plugins</module>
-        <module>hive-plugins</module>
-      </modules>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
Some required maven plugins got removed while resolving conflicts from develop where my branch and also the the develop got rid of bundle plugin in main pom

https://github.com/caskdata/hydrator-plugins/pull/28/files#diff-600376dffeb79835ede4a0b285078036L391
While resolving conflicts I removed the other new addition plugins which should be there. I am adding them back.  
