### PR TITLE
Add maven memory settings to travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ language: java
 jdk:
   - oraclejdk7
 
+# memory values same as surefire plugin config
+before_install: echo "MAVEN_OPTS='-Xmx5000m -XX:MaxPermSize=1024m'" > ~/.mavenrc
+
+script: mvn test
+
+install: mvn install -DskipTests=true -q
+
 branches:
   only:
     - develop


### PR DESCRIPTION
- Add maven memory config in travis config file
- This fixes the GC overlimit issue on travis builds. 

Passed build here: https://travis-ci.org/caskdata/hydrator-plugins/builds/89334576

CI build running.
