### PR TITLE
Transform plugins schema validation

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ProjectionTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ProjectionTransform.java
@@ -106,6 +106,12 @@ public class ProjectionTransform extends Transform<StructuredRecord, StructuredR
     super.configurePipeline(pipelineConfigurer);
     // call init so any invalid config is caught here to fail application creation
     init();
+    Schema outputSchema = null;
+    if (pipelineConfigurer.getStageConfigurer().getInputSchema() != null) {
+      //validate the input schema and get the output schema for it
+      outputSchema = getOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
+    }
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
   }
 
   @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ScriptFilterTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ScriptFilterTransform.java
@@ -87,7 +87,7 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
     Preconditions.checkArgument(!Strings.isNullOrEmpty(scriptFilterConfig.script), "Filter script must be specified.");
     // try evaluating the script to fail application creation if the script is invalid
     init(null);
-
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
     // TODO: CDAP-4169 verify existence of configured lookup tables
   }
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ScriptTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ScriptTransform.java
@@ -119,6 +119,9 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
     // try evaluating the script to fail application creation if the script is invalid
     init(null);
 
+    // init intializes schema if present in the config
+    Schema outputSchema = (schema == null) ? pipelineConfigurer.getStageConfigurer().getInputSchema() : schema;
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     // TODO: CDAP-4169 verify existence of configured lookup tables
   }
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/StructuredRecordToGenericRecordTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/StructuredRecordToGenericRecordTransform.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
@@ -33,6 +34,12 @@ import org.apache.avro.generic.GenericRecord;
 @Description("Transforms a StructuredRecord into an Avro GenericRecord.")
 public class StructuredRecordToGenericRecordTransform extends Transform<StructuredRecord, GenericRecord> {
   private final StructuredToAvroTransformer transformer = new StructuredToAvroTransformer(null);
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
+  }
 
   @Override
   public void transform(StructuredRecord structuredRecord, Emitter<GenericRecord> emitter) throws Exception {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ValidatorTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ValidatorTransform.java
@@ -129,6 +129,7 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
     } catch (ScriptException e) {
       throw new IllegalArgumentException("Invalid validation script: " + e.getMessage(), e);
     }
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
   }
 
   @Override

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/MockPipelineConfigurer.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/MockPipelineConfigurer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.transform;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.hydrator.plugin.validator.CoreValidator;
+
+import javax.annotation.Nullable;
+
+/**
+ * Mock test configurer used to test configure pipeline's validation of input schema and setting of output shcema.
+ */
+public class MockPipelineConfigurer implements PipelineConfigurer {
+  private static final String CORE_VALIDATOR = "core";
+  private final Schema inputSchema;
+  private Schema outputSchema;
+
+
+  public MockPipelineConfigurer(Schema inputSchema) {
+    this.inputSchema = inputSchema;
+  }
+
+  @Nullable
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  @Override
+  public StageConfigurer getStageConfigurer() {
+    return new StageConfigurer() {
+      @Nullable
+      @Override
+      public Schema getInputSchema() {
+        return inputSchema;
+      }
+
+      @Override
+      public void setOutputSchema(@Nullable Schema schema) {
+        outputSchema = schema;
+      }
+    };
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String s, String s1, String s2, PluginProperties pluginProperties) {
+    if (s1.equals(CORE_VALIDATOR)) {
+      return (T) new CoreValidator();
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String s, String s1, String s2,
+                         PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String s, String s1, String s2, PluginProperties pluginProperties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String s, String s1, String s2,
+                                     PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Override
+  public void addStream(Stream stream) {
+
+  }
+
+  @Override
+  public void addStream(String s) {
+
+  }
+
+  @Override
+  public void addDatasetModule(String s, Class<? extends DatasetModule> aClass) {
+
+  }
+
+  @Override
+  public void addDatasetType(Class<? extends Dataset> aClass) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass) {
+
+  }
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/ScriptFilterTransformTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/ScriptFilterTransformTest.java
@@ -157,4 +157,16 @@ public class ScriptFilterTransformTest {
     transform.transform(input, emitter);
     Assert.assertEquals(input, emitter.getEmitted().iterator().next());
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
+    config.script = "function shouldFilter(inputRecord) { return inputRecord.x * 1024 < 2048; }";
+    Schema schema = Schema.recordOf("number", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    ScriptFilterTransform transform = new ScriptFilterTransform(config);
+    MockPipelineConfigurer pipelineConfigurer = new MockPipelineConfigurer(schema);
+    transform.configurePipeline(pipelineConfigurer);
+    Assert.assertEquals(schema, pipelineConfigurer.getOutputSchema());
+  }
+
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/StructuredRecordToGenericRecordTransformTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/StructuredRecordToGenericRecordTransformTest.java
@@ -56,4 +56,12 @@ public class StructuredRecordToGenericRecordTransformTest {
     Assert.assertEquals(2, value.get("field2"));
     Assert.assertEquals(3.0, value.get("field3"));
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    StructuredRecordToGenericRecordTransform transformer = new StructuredRecordToGenericRecordTransform();
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(eventSchema);
+    transformer.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(eventSchema, mockPipelineConfigurer.getOutputSchema());
+  }
 }

--- a/python-evaluator-transform/src/main/java/co/cask/hydrator/transforms/PythonEvaluator.java
+++ b/python-evaluator-transform/src/main/java/co/cask/hydrator/transforms/PythonEvaluator.java
@@ -26,6 +26,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
@@ -147,6 +148,20 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
 
     private StructuredRecord decode(Map nativeObject) {
       return decodeRecord(nativeObject, schema);
+    }
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    super.configurePipeline(pipelineConfigurer);
+    if (config.schema != null) {
+      try {
+        pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(config.schema));
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Unable to parse schema: " + e.getMessage(), e);
+      }
+    } else {
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
     }
   }
 

--- a/python-evaluator-transform/src/test/java/co/cask/hydrator/transforms/MockPipelineConfigurer.java
+++ b/python-evaluator-transform/src/test/java/co/cask/hydrator/transforms/MockPipelineConfigurer.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.transforms;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+
+import javax.annotation.Nullable;
+
+/**
+ * Mock test configurer used to test configure pipeline's validation of input schema and setting of output shcema.
+ */
+public class MockPipelineConfigurer implements PipelineConfigurer {
+  private final Schema inputSchema;
+  Schema outputSchema;
+
+  public MockPipelineConfigurer(Schema inputSchema) {
+    this.inputSchema = inputSchema;
+  }
+
+  @Nullable
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  @Override
+  public StageConfigurer getStageConfigurer() {
+    return new StageConfigurer() {
+      @Nullable
+      @Override
+      public Schema getInputSchema() {
+        return inputSchema;
+      }
+
+      @Override
+      public void setOutputSchema(@Nullable Schema schema) {
+        outputSchema = schema;
+      }
+    };
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String s, String s1, String s2, PluginProperties pluginProperties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String s, String s1, String s2,
+                         PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String s, String s1, String s2, PluginProperties pluginProperties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String s, String s1, String s2,
+                                     PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Override
+  public void addStream(Stream stream) {
+
+  }
+
+  @Override
+  public void addStream(String s) {
+
+  }
+
+  @Override
+  public void addDatasetModule(String s, Class<? extends DatasetModule> aClass) {
+
+  }
+
+  @Override
+  public void addDatasetType(Class<? extends Dataset> aClass) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass) {
+
+  }
+}

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVFormatter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVFormatter.java
@@ -129,6 +129,7 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
       if (fields.get(0).getSchema().getType() != Schema.Type.STRING) {
         throw new IllegalArgumentException("Output field type should be String");
       }
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(schema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
@@ -91,7 +91,8 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
 
     // Check if schema specified is a valid schema or no.
     try {
-      Schema.parseJson(config.schema);
+      Schema outputSchema = Schema.parseJson(config.schema);
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CloneRecord.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CloneRecord.java
@@ -49,6 +49,7 @@ public final class CloneRecord extends Transform<StructuredRecord, StructuredRec
       throw new IllegalArgumentException("Number of copies specified '" + config.copies + "' is incorrect. Specify " +
                                        "proper integer range");
     }
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
   }
 
   @Override

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Compressor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Compressor.java
@@ -123,6 +123,7 @@ public final class Compressor extends Transform<StructuredRecord, StructuredReco
       for (Field field : outFields) {
         outSchemaMap.put(field.getName(), field.getSchema().getType());
       }
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decoder.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decoder.java
@@ -100,7 +100,8 @@ public final class Decoder extends Transform<StructuredRecord, StructuredRecord>
     parseConfiguration(config.decode);
     // Check if schema specified is a valid schema or no. 
     try {
-      Schema.parseJson(config.schema);
+      Schema outputSchema = Schema.parseJson(config.schema);
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decompressor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decompressor.java
@@ -101,6 +101,7 @@ public final class Decompressor extends Transform<StructuredRecord, StructuredRe
       for (Field field : outFields) {
         outSchemaMap.put(field.getName(), field.getSchema().getType());
       }
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format. " +
         e.getMessage());

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encoder.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encoder.java
@@ -97,7 +97,8 @@ public final class Encoder extends Transform<StructuredRecord, StructuredRecord>
     parseConfiguration(config.encode);
     // Check if schema specified is a valid schema or no. 
     try {
-      Schema.parseJson(config.schema);
+      Schema outputSchema = Schema.parseJson(config.schema);
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Hasher.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Hasher.java
@@ -71,6 +71,7 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
       throw new IllegalArgumentException("Invalid hasher '" + config.hash + "' specified. Allowed hashers are md2, " +
                                            "md5, sha1, sha256, sha384 and sha512");  
     }
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
   }
 
   @Override

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/JSONFormatter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/JSONFormatter.java
@@ -90,6 +90,7 @@ public final class JSONFormatter extends Transform<StructuredRecord, StructuredR
         throw new IllegalArgumentException("Output field name should be of type String. Please change type to " +
                                              "String or Bytes");
       }
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(out);
     } catch (IOException e) {
       throw new IllegalArgumentException("Output Schema specified is not a valid JSON. Please check the Schema JSON");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/JSONParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/JSONParser.java
@@ -52,7 +52,8 @@ public final class JSONParser extends Transform<StructuredRecord, StructuredReco
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
     try {
-      Schema.parseJson(config.schema);
+      Schema outputSchema = Schema.parseJson(config.schema);
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Output Schema specified is not a valid JSON. Please check the Schema JSON");
     }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/StreamFormatter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/StreamFormatter.java
@@ -114,6 +114,7 @@ public final class StreamFormatter extends Transform<StructuredRecord, Structure
                                              "Map<String, String>.");
       }
 
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(out);
     } catch (IOException e) {
       throw new IllegalArgumentException("Output Schema specified is not a valid JSON. Please check the schema JSON");
     }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVFormatterTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVFormatterTest.java
@@ -38,13 +38,6 @@ public class CSVFormatterTest {
                                                        Schema.Field.of("d", Schema.of(Schema.Type.STRING)),
                                                        Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
 
-  private static final Schema INPUT2 = Schema.recordOf("input2",
-                                                       Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
-                                                       Schema.Field.of("b", Schema.of(Schema.Type.STRING)),
-                                                       Schema.Field.of("c", Schema.of(Schema.Type.INT)),
-                                                       Schema.Field.of("d", Schema.of(Schema.Type.DOUBLE)),
-                                                       Schema.Field.of("e", Schema.of(Schema.Type.BOOLEAN)));
-
   @Test
   public void testDefaultCSVFormatter() throws Exception {
     CSVFormatter.Config config = new CSVFormatter.Config("DELIMITED", "VBAR", OUTPUT.toString());
@@ -70,5 +63,15 @@ public class CSVFormatterTest {
                           .set("d", "9")
                           .set("e", "10").build(), emitter);
     Assert.assertEquals("6|7|8|9|10\r\n", emitter.getEmitted().get(0).get("body"));
+  }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    CSVFormatter.Config config = new CSVFormatter.Config("DELIMITED", "VBAR", OUTPUT.toString());
+    Transform<StructuredRecord, StructuredRecord> transform = new CSVFormatter(config);
+
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT1);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT, mockPipelineConfigurer.getOutputSchema());
   }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVParserTest.java
@@ -153,4 +153,15 @@ public class CSVParserTest {
     transform.transform(StructuredRecord.builder(INPUT1)
                           .set("body", ",stringA,3,4.32,true").build(), emitter);
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    CSVParser.Config config = new CSVParser.Config("DEFAULT", "body", OUTPUT1.toString());
+    Transform<StructuredRecord, StructuredRecord> transform = new CSVParser(config);
+
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT1);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT1, mockPipelineConfigurer.getOutputSchema());
+  }
+
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/CloneRecordTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/CloneRecordTest.java
@@ -33,13 +33,6 @@ public class CloneRecordTest {
                                                       Schema.Field.of("d", Schema.of(Schema.Type.STRING)),
                                                       Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
 
-  private static final Schema OUTPUT = Schema.recordOf("output",
-                                                       Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
-                                                       Schema.Field.of("b", Schema.of(Schema.Type.STRING)),
-                                                       Schema.Field.of("c", Schema.of(Schema.Type.STRING)),
-                                                       Schema.Field.of("d", Schema.of(Schema.Type.STRING)),
-                                                       Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
-
   @Test
   public void testCloneRecord() throws Exception {
     CloneRecord.Config config = new CloneRecord.Config(5);
@@ -54,5 +47,16 @@ public class CloneRecordTest {
                           .set("d", "4")
                           .set("e", "5").build(), emitter);
     Assert.assertEquals(5, emitter.getEmitted().size());
+  }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    CloneRecord.Config config = new CloneRecord.Config(5);
+    Transform<StructuredRecord, StructuredRecord> transform = new CloneRecord(config);
+
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(INPUT, mockPipelineConfigurer.getOutputSchema());
   }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/CompressorTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/CompressorTest.java
@@ -106,6 +106,14 @@ public class CompressorTest {
     Assert.assertArrayEquals(expected, actual);
   }
 
+  @Test
+  public void testSchemaValidation() throws Exception {
+    Transform<StructuredRecord, StructuredRecord> transform =
+      new Compressor(new Compressor.Config("a:GZIP", OUTPUT.toString()));
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT, mockPipelineConfigurer.getOutputSchema());
+  }
 
   private static byte[] compressGZIP(byte[] input) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/DecoderTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/DecoderTest.java
@@ -193,4 +193,13 @@ public class DecoderTest {
     Assert.assertEquals(2, emitterDecoded.getEmitted().get(0).getSchema().getFields().size());
     Assert.assertEquals(test, emitterDecoded.getEmitted().get(0).get("a"));
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    Transform<StructuredRecord, StructuredRecord> decoder =
+      new Decoder(new Decoder.Config("a:BASE64", OUTPUT.toString()));
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+    decoder.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT, mockPipelineConfigurer.getOutputSchema());
+  }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/DecompressorTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/DecompressorTest.java
@@ -127,4 +127,13 @@ public class DecompressorTest {
     zos.close();
     return out.toByteArray();
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    Transform<StructuredRecord, StructuredRecord> transform =
+      new Decompressor(new Decompressor.Config("a:ZIP", OUTPUT.toString()));
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT, mockPipelineConfigurer.getOutputSchema());
+  }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/EncoderTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/EncoderTest.java
@@ -153,4 +153,13 @@ public class EncoderTest {
     Assert.assertEquals(2, emitter.getEmitted().get(0).getSchema().getFields().size());
     Assert.assertArrayEquals(expected, actual);
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    Transform<StructuredRecord, StructuredRecord> transform =
+      new Encoder(new Encoder.Config("a:BASE32", OUTPUTSTR.toString()));
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUTSTR, mockPipelineConfigurer.getOutputSchema());
+  }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/HasherTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/HasherTest.java
@@ -34,13 +34,6 @@ public class HasherTest {
                                                       Schema.Field.of("d", Schema.of(Schema.Type.INT)),
                                                       Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
 
-  private static final Schema OUTPUT = Schema.recordOf("output",
-                                                      Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
-                                                      Schema.Field.of("b", Schema.of(Schema.Type.STRING)),
-                                                      Schema.Field.of("c", Schema.of(Schema.Type.STRING)),
-                                                      Schema.Field.of("d", Schema.of(Schema.Type.INT)),
-                                                      Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
-
   @Test
   public void testHasherMD2() throws Exception {
     Transform<StructuredRecord, StructuredRecord> transform =
@@ -177,5 +170,14 @@ public class HasherTest {
     Assert.assertEquals("Field C", emitter.getEmitted().get(0).get("c"));
     Assert.assertEquals(4, emitter.getEmitted().get(0).get("d"));
     Assert.assertEquals(DigestUtils.sha512Hex("Field E"), emitter.getEmitted().get(0).get("e"));
+  }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    Transform<StructuredRecord, StructuredRecord> transform =
+      new Hasher(new Hasher.Config("SHA512", "a,b,e"));
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(INPUT, mockPipelineConfigurer.getOutputSchema());
   }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/JSONFormatterTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/JSONFormatterTest.java
@@ -35,10 +35,6 @@ public class JSONFormatterTest {
                                                         Schema.Field.of("c", Schema.of(Schema.Type.STRING)),
                                                         Schema.Field.of("d", Schema.of(Schema.Type.STRING)),
                                                         Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
-  private static final Schema INPUT2 = Schema.recordOf("input2",
-                                                        Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
-                                                        Schema.Field.of("b", Schema.of(Schema.Type.STRING)),
-                                                        Schema.Field.of("e", Schema.of(Schema.Type.STRING)));
   @Test
   public void testJSONFormatter() throws Exception {
     JSONFormatter.Config config = new JSONFormatter.Config(OUTPUT1.toString());
@@ -54,5 +50,15 @@ public class JSONFormatterTest {
 
     Assert.assertEquals("{\"a\":\"1\",\"b\":\"2\",\"c\":\"3\",\"d\":\"4\",\"e\":\"5\"}",
                         emitter.getEmitted().get(0).get("body"));
+  }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    JSONFormatter.Config config = new JSONFormatter.Config(OUTPUT1.toString());
+    Transform<StructuredRecord, StructuredRecord> transform = new JSONFormatter(config);
+
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT1);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT1, mockPipelineConfigurer.getOutputSchema());
   }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/JSONParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/JSONParserTest.java
@@ -68,4 +68,14 @@ public class JSONParserTest {
     Assert.assertEquals("2", emitter.getEmitted().get(0).get("b"));
     Assert.assertEquals("5", emitter.getEmitted().get(0).get("e"));
   }
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    JSONParser.Config config = new JSONParser.Config("body", OUTPUT2.toString());
+    Transform<StructuredRecord, StructuredRecord> transform = new JSONParser(config);
+
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT1);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT2, mockPipelineConfigurer.getOutputSchema());
+  }
 }

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/MockPipelineConfigurer.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/MockPipelineConfigurer.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+
+import javax.annotation.Nullable;
+
+/**
+ * Mock test configurer used to test configure pipeline's validation of input schema and setting of output shcema.
+ */
+public class MockPipelineConfigurer implements PipelineConfigurer {
+  private final Schema inputSchema;
+  Schema outputSchema;
+
+  public MockPipelineConfigurer(Schema inputSchema) {
+    this.inputSchema = inputSchema;
+  }
+
+  @Nullable
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  @Override
+  public StageConfigurer getStageConfigurer() {
+    return new StageConfigurer() {
+      @Nullable
+      @Override
+      public Schema getInputSchema() {
+        return inputSchema;
+      }
+
+      @Override
+      public void setOutputSchema(@Nullable Schema schema) {
+        outputSchema = schema;
+      }
+    };
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String s, String s1, String s2, PluginProperties pluginProperties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String s, String s1, String s2,
+                         PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String s, String s1, String s2, PluginProperties pluginProperties) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String s, String s1, String s2,
+                                     PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return null;
+  }
+
+  @Override
+  public void addStream(Stream stream) {
+
+  }
+
+  @Override
+  public void addStream(String s) {
+
+  }
+
+  @Override
+  public void addDatasetModule(String s, Class<? extends DatasetModule> aClass) {
+
+  }
+
+  @Override
+  public void addDatasetType(Class<? extends Dataset> aClass) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass) {
+
+  }
+}

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/StreamFormatterTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/StreamFormatterTest.java
@@ -59,4 +59,15 @@ public class StreamFormatterTest {
     Assert.assertEquals("2", header.get("b"));
     Assert.assertEquals("3", header.get("c"));
   }
+
+
+  @Test
+  public void testSchemaValidation() throws Exception {
+    StreamFormatter.Config config = new StreamFormatter.Config("b,c", null, "CSV", OUTPUT.toString());
+    Transform<StructuredRecord, StructuredRecord> transform = new StreamFormatter(config);
+
+    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT);
+    transform.configurePipeline(mockPipelineConfigurer);
+    Assert.assertEquals(OUTPUT, mockPipelineConfigurer.getOutputSchema());
+  }
 }


### PR DESCRIPTION
After CDAP-4229, Plugins can validate input schema and set output schema from that stage. Added implementation for the transforms to use them.
