### PR TITLE
fix pom dependencies

### DIFF
--- a/cassandra-plugins/pom.xml
+++ b/cassandra-plugins/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>cdap-test</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-formats</artifactId>
+    </dependency>
+    <dependency>
       <groupId>co.cask.hydrator</groupId>
       <artifactId>core-plugins</artifactId>
       <version>${project.version}</version>

--- a/elasticsearch-plugins/pom.xml
+++ b/elasticsearch-plugins/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>cdap-etl-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-formats</artifactId>
+    </dependency>
+    <dependency>
       <groupId>co.cask.hydrator</groupId>
       <artifactId>core-plugins</artifactId>
       <version>${project.version}</version>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>cdap-etl-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-formats</artifactId>
+    </dependency>
+    <dependency>
       <groupId>co.cask.hydrator</groupId>
       <artifactId>core-plugins</artifactId>
       <version>${project.version}</version>

--- a/kafka-plugins/pom.xml
+++ b/kafka-plugins/pom.xml
@@ -33,6 +33,10 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-formats</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-core</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
         <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-formats</artifactId>
         <version>${cdap.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>co.cask.cdap</groupId>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -30,6 +30,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-formats</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <version>${apache-commons.version}</version>


### PR DESCRIPTION
Several dependencies marked as provided should have been compile
or test. cdap-formats is compile, cdap-proto and etl-core are only
needed for test.
