### PR TITLE
Update Hydrator Plugin Documentation

### DIFF
--- a/cassandra-plugins/docs/Cassandra-batchsink.md
+++ b/cassandra-plugins/docs/Cassandra-batchsink.md
@@ -35,6 +35,11 @@ The columns should be listed in the same order as they are stored in the column 
 Example
 -------
 
+This example connects to Apache Cassandra, which is running locally, and writes the data to
+the specified column family (*employees*), which is in the *megacorp* keyspace.
+This column family has four columns and two primary keys, and Apache Cassandra
+uses the default *Murmur3* partitioner:
+
     {
         "name": "Cassandra",
         "properties": {
@@ -47,8 +52,3 @@ Example
             "primaryKey": "fname,lname"
         }
     }
-
-This example connects to Apache Cassandra, which is running locally, and writes the data to
-the specified column family (*employees*), which is in the *megacorp* keyspace.
-This column family has four columns and two primary keys, and Apache Cassandra
-uses the default *Murmur3* partitioner.

--- a/cassandra-plugins/docs/Cassandra-batchsink.md
+++ b/cassandra-plugins/docs/Cassandra-batchsink.md
@@ -1,3 +1,5 @@
+# Cassandra Batch Sink
+
 Description
 -----------
 Batch sink to use Apache Cassandra as a sink.

--- a/cassandra-plugins/docs/Cassandra-batchsource.md
+++ b/cassandra-plugins/docs/Cassandra-batchsource.md
@@ -1,3 +1,5 @@
+# Cassandra Batch Source
+
 Description
 -----------
 Batch source to use Apache Cassandra as a source.
@@ -39,6 +41,10 @@ and each property should be separated by a colon from its corresponding value.
 Example
 -------
 
+This example connects to Apache Cassandra, which is running locally, and reads in records in the
+specified keyspace (*megacorp*) and column family (*employee*) which match the query to (in this case) select all records.
+All data from the column family will be read on each run:
+
     {
         "name": "Cassandra",
         "properties": {
@@ -59,7 +65,3 @@ Example
             }"
         }
     }
-
-This example connects to Apache Cassandra, which is running locally, and reads in records in the
-specified keyspace (*megacorp*) and column family (*employee*) which match the query to (in this case) select all records.
-All data from the column family will be read on each run.

--- a/cassandra-plugins/docs/Cassandra-realtimesink.md
+++ b/cassandra-plugins/docs/Cassandra-realtimesink.md
@@ -1,3 +1,5 @@
+# Cassandra Real-time Sink
+
 Description
 -----------
 Real-time sink to use Apache Cassandra as a sink.
@@ -38,6 +40,9 @@ The columns should be listed in the same order as they are stored in the column 
 Example
 -------
 
+This example connects to Apache Cassandra, which is running locally, and writes the data to
+the specified keyspace (*megacorp*) and column family (*purchases*):
+
     {
         "name": "Cassandra",
         "properties": {
@@ -49,6 +54,3 @@ Example
             "compression": "NONE"
         }
     }
-
-This example connects to Apache Cassandra, which is running locally, and writes the data to
-the specified keyspace (*megacorp*) and column family (*purchases*).

--- a/core-plugins/docs/AmazonSQS-realtimesource.md
+++ b/core-plugins/docs/AmazonSQS-realtimesource.md
@@ -1,3 +1,5 @@
+# Amazon SQS Real-time Source
+
 Description
 -----------
 
@@ -28,6 +30,9 @@ Properties
 Example
 -------
 
+This example reads from a queue named 'queue_name' which is hosted on a server that's
+located in the 'us-west-1' region:
+
     {
         "name": "AmazonSQS",
         "properties": {
@@ -38,5 +43,3 @@ Example
         }
     }
 
-This example reads from a queue named 'queue_name' which is hosted on a server that's
-located in the 'us-west-1' region.

--- a/core-plugins/docs/Cube-batchsink.md
+++ b/core-plugins/docs/Cube-batchsink.md
@@ -1,3 +1,5 @@
+# Cube Batch Sink
+
 Description
 -----------
 
@@ -27,9 +29,9 @@ new Cube dataset needs to be created. See [Cube dataset configuration details] f
 
 **dataset.cube.properties:** Provides any dataset properties to be used
 if a new Cube dataset needs to be created; provided as a JSON Map. For
-example, if aggregations are desired on fields `'abc'` and `'xyz'`, the
+example, if aggregations are desired on fields ``'abc'`` and ``'xyz'``, the
 property should have the value:
-`{"dataset.cube.aggregation.agg1.dimensions":"abc", "dataset.cube.aggregation.agg2.dimensions":"xyz"}`.
+``{"dataset.cube.aggregation.agg1.dimensions":"abc", "dataset.cube.aggregation.agg2.dimensions":"xyz"}``.
 See [Cube dataset configuration details] for more information.
 
   [Cube dataset configuration details]: http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html
@@ -38,8 +40,8 @@ See [Cube dataset configuration details] for more information.
 timestamp to be used in the CubeFact. If not provided, the current time of the record
 processing will be used as the CubeFact timestamp.
 
-Name of the StructuredRecord's field that contains timestamp to be used in CubeFact.
-If not provided, the current time of the record processing will be used as CubeFact timestamp.
+Name of the StructuredRecord's field that contains the timestamp to be used in CubeFact.
+If not provided, the current time of the record processing will be used as a CubeFact timestamp.
 
 **cubeFact.timestamp.format:** Format of the value of timestamp field; example: "HH:mm:ss" (used if
 ``cubeFact.timestamp.field`` is provided).
@@ -56,7 +58,7 @@ Example
 This configuration specifies writing data into a Cube dataset named "myCube"; it provides
 dataset properties (``dataset.*``) for creating a new dataset, if one with the given name
 doesn't exist; it then configures measurements to aggregate and specifies the timestamp
-format for facts being written into the Cube
+format for facts being written into the Cube:
 
     {
         "name": "myCube",
@@ -74,7 +76,7 @@ format for facts being written into the Cube
     }
 
 Once the data is there, you could run queries using an ``AbstractCubeHttpHandler``. (You'd
-need to deploy an application containing a service using it.) A sample query
+need to deploy an application containing a service using it.) A sample query:
 
     {
         "aggregation": "byName",
@@ -87,7 +89,7 @@ need to deploy an application containing a service using it.) A sample query
         "limit": 1000
     }
 
-Example result
+Example result:
 
     [
         {

--- a/core-plugins/docs/Cube-realtimesink.md
+++ b/core-plugins/docs/Cube-realtimesink.md
@@ -1,3 +1,5 @@
+# Cube Real-time Sink
+
 Description
 -----------
 
@@ -26,9 +28,9 @@ new Cube dataset needs to be created. See [Cube dataset configuration details] f
 
 **dataset.cube.properties:** Provides any dataset properties to be used
 if a new Cube dataset needs to be created; provided as a JSON Map. For
-example, if aggregations are desired on fields `'abc'` and `'xyz'`, the
+example, if aggregations are desired on fields ``'abc'`` and ``'xyz'``, the
 property should have the value:
-`{"dataset.cube.aggregation.agg1.dimensions":"abc", "dataset.cube.aggregation.agg2.dimensions":"xyz"}`.
+``{"dataset.cube.aggregation.agg1.dimensions":"abc", "dataset.cube.aggregation.agg2.dimensions":"xyz"}``.
 See [Cube dataset configuration details] for more information.
 
   [Cube dataset configuration details]: http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html
@@ -50,7 +52,7 @@ Example
 This configuration specifies writing data into a Cube dataset named "myCube"; it provides
 dataset properties (``dataset.*``) for creating a new dataset, if one with the given name
 doesn't exist; it then configures measurements to aggregate and specifies the timestamp
-format for facts being written into the Cube
+format for facts being written into the Cube:
 
     {
         "name": "myCube",
@@ -68,7 +70,7 @@ format for facts being written into the Cube
     }
 
 Once the data is there, you could run queries using an ``AbstractCubeHttpHandler``. (You'd
-need to deploy an application containing a service using it.) A sample query::
+need to deploy an application containing a service using it.) A sample query:
 
     {
         "aggregation": "byName",
@@ -81,7 +83,7 @@ need to deploy an application containing a service using it.) A sample query::
         "limit": 1000
     }
 
-Example result
+Example result:
 
     [
         {

--- a/core-plugins/docs/DataGenerator-realtimesource.md
+++ b/core-plugins/docs/DataGenerator-realtimesource.md
@@ -1,3 +1,5 @@
+# Data Generator Real-time Source
+
 Description
 -----------
 

--- a/core-plugins/docs/Database-batchsink.md
+++ b/core-plugins/docs/Database-batchsink.md
@@ -1,3 +1,5 @@
+# Database Batch Sink
+
 Description
 -----------
 
@@ -42,6 +44,12 @@ defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
 Example
 -------
 
+This example connects to a database using the specified 'connectionString', which means
+it will connect to the 'prod' database of a PostgreSQL instance running on 'localhost'.
+Each input record will be written to a row of the 'users' table, with the value for each
+column taken from the value of the field in the record. For example, the 'id' field in
+the record will be written to the 'id' column of that row:
+
     {
         "name": "Database",
         "properties": {
@@ -54,9 +62,3 @@ Example
             "jdbcPluginType": "jdbc"
         }
     }
-
-This example connects to a database using the specified 'connectionString', which means
-it will connect to the 'prod' database of a PostgreSQL instance running on 'localhost'.
-Each input record will be written to a row of the 'users' table, with the value for each
-column taken from the value of the field in the record. For example, the 'id' field in
-the record will be written to the 'id' column of that row.

--- a/core-plugins/docs/Database-batchsource.md
+++ b/core-plugins/docs/Database-batchsource.md
@@ -1,3 +1,5 @@
+# Database Batch Source
+
 Description
 -----------
 
@@ -20,7 +22,7 @@ You can also specify a number of WHERE clauses or ORDER BY clauses. However, LIM
 should not be used in this query.
 
 **countQuery:** The SELECT query to use to get the count of records to import from the
-specified table. Examples::
+specified table. Examples:
 
   SELECT COUNT(*) from <my_table> where <my_column> 1
   SELECT COUNT(my_column) from my_table
@@ -32,7 +34,7 @@ query to reflect an accurate number of records to import.
 Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
 the names returned from the database are used as-is. Note that setting this property provides predictability
 of column name cases across different databases but might result in column name conflicts if multiple column
-names are the same when the case is ignored. (Optional)
+names are the same when the case is ignored (Optional).
 
 **connectionString:** JDBC connection string including database name.
 
@@ -51,6 +53,11 @@ defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
 Example
 -------
 
+This example connects to a database using the specified 'connectionString', which means
+it will connect to the 'prod' database of a PostgreSQL instance running on 'localhost'.
+It will run the 'importQuery' against the 'users' table to read four columns from the table.
+The column types will be used to derive the record field types output by the source:
+
     {
         "name": "Database",
         "properties": {
@@ -64,10 +71,6 @@ Example
         }
     }
 
-This example connects to a database using the specified 'connectionString', which means
-it will connect to the 'prod' database of a PostgreSQL instance running on 'localhost'.
-It will run the 'importQuery' against the 'users' table to read four columns from the table.
-The column types will be used to derive the record field types output by the source.
 For example, if the 'id' column is a primary key of type int and the other columns are
 non-nullable varchars, output records will have this schema:
 
@@ -79,4 +82,3 @@ non-nullable varchars, output records will have this schema:
     | email          | string              |
     | phone          | string              |
     +======================================+
-

--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -1,3 +1,5 @@
+# File Batch Source
+
 Description
 -----------
 
@@ -21,7 +23,7 @@ For example, the property names needed for S3 are "fs.s3n.awsSecretAccessKey"
 and "fs.s3n.awsAccessKeyId".
 
 **path:** Path to file(s) to be read. If a directory is specified,
-terminate the path name with a \'/\'.
+terminate the path name with a '/'.
 
 **fileRegex:** Regex to filter out filenames in the path.
 To use the *TimeFilter*, input ``timefilter``. The TimeFilter assumes that it is
@@ -42,6 +44,13 @@ subclass of FileInputFormat. Defaults to CombineTextInputFormat.
 Example
 -------
 
+This example connects to Amazon S3 and reads in files found in the specified directory while
+using the stateful Timefilter, which ensures that each file is read only once. The Timefilter
+requires that files be named with either the convention "yy-MM-dd-HH..." (S3) or "...'.'yy-MM-dd-HH..."
+(Cloudfront). The stateful metadata is stored in a table named 'timeTable'. With the maxSplitSize
+set to 1MB, if the total size of the files being read is larger than 1MB, CDAP will
+configure Hadoop to use more than one mapper:
+
     {
         "name": "FileBatchSource",
         "properties": {
@@ -56,10 +65,3 @@ Example
             "maxSplitSize": "1048576"
         }
     }
-
-This example connects to Amazon S3 and reads in files found in the specified directory while
-using the stateful Timefilter, which ensures that each file is read only once. The Timefilter
-requires that files be named with either the convention "yy-MM-dd-HH..." (S3) or "...'.'yy-MM-dd-HH..."
-(Cloudfront). The stateful metadata is stored in a table named 'timeTable'. With the maxSplitSize
-set to 1MB, if the total size of the files being read is larger than 1MB, CDAP will
-configure Hadoop to use more than one mapper.

--- a/core-plugins/docs/JMS-realtimesource.md
+++ b/core-plugins/docs/JMS-realtimesource.md
@@ -1,3 +1,5 @@
+# JMS Real-time Source
+
 Description
 -----------
 
@@ -37,6 +39,11 @@ JSON file for the JMS plugin. Defaults to ``JMSProvider``.
 Example
 -------
 
+This example will read from an instance of Apache ActiveMQ running on port 61616 on 'localhost'.
+It will poll the 'purchases' topic, reading up to 50 messages with each poll. A record is
+emitted for each message read from the topic. The record consists of a single field named 'message'
+containing the contents of the message:
+
     {
         "name":"JMS",
         "properties":{
@@ -47,9 +54,3 @@ Example
             "jms.plugin.custom.properties": "{\"topic.purchases\":\"purchases\"}"
         }
     }
-
-This example will read from an instance of Apache ActiveMQ running on port 61616 on 'localhost'.
-It will poll the 'purchases' topic, reading up to 50 messages with each poll. A record is
-emitted for each message read from the topic. The record consists of a single field named 'message'
-containing the contents of the message.
-

--- a/core-plugins/docs/KVTable-batchsink.md
+++ b/core-plugins/docs/KVTable-batchsink.md
@@ -1,3 +1,5 @@
+# KeyValueTable Batch Sink
+
 Description
 -----------
 
@@ -22,6 +24,8 @@ Properties
 Example
 -------
 
+This example writes to a KeyValueTable named 'items':
+
     {
         "name": "KVTable",
         "properties": {
@@ -31,7 +35,7 @@ Example
         }
     }
 
-This example writes to a KeyValueTable named 'items'. It takes records with the following schema as input:
+It takes records with the following schema as input:
 
     +======================================+
     | field name     | type                |

--- a/core-plugins/docs/KVTable-batchsource.md
+++ b/core-plugins/docs/KVTable-batchsource.md
@@ -1,3 +1,5 @@
+# KeyValueTable Batch Source
+
 Description
 -----------
 
@@ -18,6 +20,8 @@ Properties
 Example
 -------
 
+This example reads from a KeyValueTable named 'items':
+
     {
         "name": "KVTable",
         "properties": {
@@ -25,7 +29,7 @@ Example
         }
     }
 
-This example reads from a KeyValueTable named 'items'. It outputs records with this schema:
+It outputs records with this schema:
 
     +====================+
     | field name | type  |
@@ -33,4 +37,3 @@ This example reads from a KeyValueTable named 'items'. It outputs records with t
     | key        | bytes |
     | value      | bytes |
     +====================+
-

--- a/core-plugins/docs/Kafka-realtimesource.md
+++ b/core-plugins/docs/Kafka-realtimesource.md
@@ -1,3 +1,5 @@
+# Kafka Real-time Source
+
 Description
 -----------
 
@@ -41,6 +43,10 @@ If no format is given, Kafka message payloads will be treated as bytes, resultin
 Example
 -------
 
+This example reads from ten partitions of the 'purchases' topic of a Kafka instance.
+It connects to Kafka via a ZooKeeper instance running on 'localhost'. It then 
+parses Kafka messages using the 'csv' format into records with the specified schema:
+
     {
         "name": "Kafka",
         "properties": {
@@ -61,9 +67,6 @@ Example
         }
     }
 
-This example reads from ten partitions of the 'purchases' topic of a Kafka instance.
-It connects to Kafka via a ZooKeeper instance running on 'localhost'. It then 
-parses Kafka messages using the 'csv' format into records with the specified schema.
 For each Kafka message read, it will output a record with the schema:
 
     +================================+

--- a/core-plugins/docs/Logparser-transform.md
+++ b/core-plugins/docs/Logparser-transform.md
@@ -1,3 +1,5 @@
+# Log Parser Transform
+
 Description
 -----------
 
@@ -17,10 +19,14 @@ Properties
 **logFormat:** Log format to parse. Currently supports S3, CLF, and Cloudfront formats.
 
 **inputName:** Name of the field in the input schema which encodes the
-log information. The given field must be of type String or Bytes.
+log information. The given field must be of type ``String`` or ``Bytes``.
 
 Example
 -------
+
+This example searches for an input Schema field named 'body', and then attempts to parse
+the Combined Log Format entries found in the field for the URI, IP, browser, device,
+HTTP status code, and timestamp:
 
     {
         "name": "LogParser",
@@ -30,9 +36,7 @@ Example
         }
     }
 
-This example searches for an input Schema field named 'body', and then attempts to parse
-the Combined Log Format entries found in the field for the URI, IP, browser, device,
-HTTP status code, and timestamp. The Transform will emit records with this schema:
+The Transform will emit records with this schema:
 
     +============================+
     | field name    | type       |

--- a/core-plugins/docs/Projection-transform.md
+++ b/core-plugins/docs/Projection-transform.md
@@ -7,7 +7,7 @@ The Projection transform lets you drop, rename, and cast fields to a different t
 Fields are first dropped, then cast, then renamed.
 
 For example, suppose the transform is configured to drop field 'B' and rename field 'A' to 'B'.
-If the transform receives this input record
+If the transform receives this input record:
 
     +============================+
     | field name | type | value  |
@@ -16,7 +16,7 @@ If the transform receives this input record
     | B          | int  | 20     |
     +============================+
 
-field 'B' will first be dropped
+field 'B' will first be dropped:
 
     +============================+
     | field name | type | value  |
@@ -24,7 +24,7 @@ field 'B' will first be dropped
     | A          | int  | 10     |
     +============================+
 
-and then field 'A' will be renamed to 'B'
+and then field 'A' will be renamed to 'B':
 
     +============================+
     | field name | type | value  |

--- a/core-plugins/docs/Projection-transform.md
+++ b/core-plugins/docs/Projection-transform.md
@@ -1,3 +1,5 @@
+# Projection Transform
+
 Description
 -----------
 
@@ -66,6 +68,9 @@ converted to an int.
 Example
 -------
 
+This example drops the ``'ts'`` and ``'headers'`` fields. It also changes the type of the ``'cost'``
+field to a double and renames it ``'price'``. 
+
     {
         "name": "Projection",
         "properties": {
@@ -75,9 +80,7 @@ Example
         }
     }
  
-This example drops the ``'ts'`` and ``'headers'`` fields. It also changes the type of the ``'cost'``
-field to a double and renames it ``'price'``. For example, if the transform receives this
-input record:
+For example, if the transform receives this input record:
 
     +=========================================================+
     | field name | type                | value                |
@@ -96,4 +99,3 @@ It will transform it to this output record:
     | id         | string              | "abc123"             |
     | price      | double              | 8.88                 |
     +=========================================================+
-

--- a/core-plugins/docs/S3-batchsource.md
+++ b/core-plugins/docs/S3-batchsource.md
@@ -1,3 +1,5 @@
+# Amazon S3 Batch Source
+
 Description
 -----------
 
@@ -39,6 +41,13 @@ subclass of FileInputFormat. Defaults to TextInputFormat.
 Example
 -------
 
+This example connects to Amazon S3 and reads in files found in the specified directory while
+using the stateful ``timefilter``, which ensures that each file is read only once. The ``timefilter``
+requires that files be named with either the convention "yy-MM-dd-HH..." (S3) or "...'.'yy-MM-dd-HH..."
+(Cloudfront). The stateful metadata is stored in a table named 'timeTable'. With the maxSplitSize
+set to 1MB, if the total size of the files being read is larger than 1MB, CDAP will
+configure Hadoop to use one mapper per MB:
+
     {
         "name": "S3",
         "properties": {
@@ -50,10 +59,3 @@ Example
             "maxSplitSize": "1048576"
         }
     }
-
-This example connects to Amazon S3 and reads in files found in the specified directory while
-using the stateful ``timefilter``, which ensures that each file is read only once. The ``timefilter``
-requires that files be named with either the convention "yy-MM-dd-HH..." (S3) or "...'.'yy-MM-dd-HH..."
-(Cloudfront). The stateful metadata is stored in a table named 'timeTable'. With the maxSplitSize
-set to 1MB, if the total size of the files being read is larger than 1MB, CDAP will
-configure Hadoop to use one mapper per MB.

--- a/core-plugins/docs/S3Avro-batchsink.md
+++ b/core-plugins/docs/S3Avro-batchsink.md
@@ -1,3 +1,5 @@
+# Amazon S3 Avro Batch Sink
+
 Description
 -----------
 
@@ -34,6 +36,11 @@ example: the format ``'yyyy-MM-dd-HH-mm'`` will create a file path ending in
 Example
 -------
 
+This example will write to an S3 output located at ``s3n://logs``. It will write data in
+Avro format using the given schema. Every time the pipeline runs, a new output directory
+from the base path (``s3n://logs``) will be created which will have the directory name
+corresponding to the start time in ``yyyy-MM-dd-HH-mm`` format:
+
     {
         "name": "S3Avro",
         "properties": {
@@ -52,8 +59,3 @@ Example
             }"
         }
     }
-
-This example will write to an S3 output located at ``s3n://logs``. It will write data in
-Avro format using the given schema. Every time the pipeline runs, a new output directory
-from the base path (``s3n://logs``) will be created which will have the directory name
-corresponding to the start time in ``yyyy-MM-dd-HH-mm`` format.

--- a/core-plugins/docs/S3Parquet-batchsink.md
+++ b/core-plugins/docs/S3Parquet-batchsink.md
@@ -1,3 +1,5 @@
+# Amazon S3 Parquet Batch Sink
+
 Description
 -----------
 
@@ -34,6 +36,11 @@ example: the format ``'yyyy-MM-dd-HH-mm'`` will create a file path ending in
 Example
 -------
 
+This example will write to an S3 output located at ``s3n://logs``. It will write data in
+Parquet format using the given schema. Every time the pipeline runs, a new output directory
+from the base path (``s3n://logs``) will be created which will have the directory name
+corresponding to the start time in ``yyyy-MM-dd-HH-mm`` format:
+
     {
         "name": "S3Parquet",
         "properties": {
@@ -52,13 +59,3 @@ Example
             }"
         }
     }
-
-This example will connect to Amazon S3 and write files following the pattern
-'yyyy-MM-dd-HH-mm'. It will write data in Parquet format using the given schema. Every
-time the pipeline runs, the most recent run will be stored in S3 under the directory
-'logs'.
-
-This example will write to an S3 output located at ``s3n://logs``. It will write data in
-Parquet format using the given schema. Every time the pipeline runs, a new output directory
-from the base path (``s3n://logs``) will be created which will have the directory name
-corresponding to the start time in ``yyyy-MM-dd-HH-mm`` format.

--- a/core-plugins/docs/Script-transform.md
+++ b/core-plugins/docs/Script-transform.md
@@ -1,3 +1,5 @@
+# Script Transform
+
 Description
 -----------
 
@@ -20,7 +22,7 @@ Properties
 implement a function called ``'transform'``, which takes as input a JSON object (representing
 the input record) and a context object (which encapsulates CDAP metrics and logger),
 and returns a JSON object that represents the transformed input.
-For example::
+For example:
 
     function transform(input, context) {
         if(input.count < 0) {
@@ -43,6 +45,10 @@ Currently supports ``KeyValueTable``.
 
 Example
 -------
+
+The transform takes records that have a ``'subtotal'`` field, calculates ``'tax'`` and
+``'total'`` fields based on the subtotal, and then returns a record containing those three
+fields:
 
     {
         "name": "Script",
@@ -82,9 +88,7 @@ Example
         }
     }
 
-The transform takes records that have a ``'subtotal'`` field, calculates ``'tax'`` and
-``'total'`` fields based on the subtotal, and then returns a record containing those three
-fields. For example, if it receives as an input record:
+For example, if it receives as an input record:
 
     +=========================================================+
     | field name | type                | value                |

--- a/core-plugins/docs/ScriptFilter-transform.md
+++ b/core-plugins/docs/ScriptFilter-transform.md
@@ -1,3 +1,5 @@
+# Script Filter Transform
+
 Description
 -----------
 
@@ -24,6 +26,8 @@ Currently supports ``KeyValueTable``.
 Example
 -------
 
+This example filters out any records whose ``'count'`` field contains a value greater than 100:
+
     {
         "name": "ScriptFilter",
         "properties": {
@@ -45,7 +49,5 @@ Example
             }"
         }
     }
-
-This example filters out any records whose ``'count'`` field contains a value greater than 100.
 
 **Note:** This transform will emit a metric named ``filtered`` that records how many records it filtered out.

--- a/core-plugins/docs/SnapshotAvro-batchsink.md
+++ b/core-plugins/docs/SnapshotAvro-batchsink.md
@@ -10,10 +10,10 @@ can be used to read only the most recently written snapshot.
 Use Case
 --------
 
-This sink is used whenever you want access to a PartitionedFileSet containing exactly the most
-recent run's data in Avro format. For example,
-you might want to create daily snapshots of a database by reading the entire contents of
-a table, writing to this sink, and then other programs can analyze the contents of the specified file.
+This sink is used whenever you want access to a PartitionedFileSet containing exactly the
+most recent run's data in Avro format. For example, you might want to create daily
+snapshots of a database by reading the entire contents of a table, writing to this sink,
+and then other programs can analyze the contents of the specified file.
 
 Properties
 ----------

--- a/core-plugins/docs/SnapshotAvro-batchsink.md
+++ b/core-plugins/docs/SnapshotAvro-batchsink.md
@@ -1,3 +1,5 @@
+# SnapshotAvro Batch Sink
+
 Description
 -----------
 
@@ -30,6 +32,10 @@ The properties are also passed to the dataset at runtime as arguments.
 Example
 -------
 
+This example will write to a PartitionedFileSet named 'users'. It will write data in Avro format
+using the given schema. Every time the pipeline runs, the most recent run will be stored in
+a new partition in the PartitionedFileSet:
+
     {
         "name": "SnapshotAvro",
         "properties": {
@@ -46,6 +52,3 @@ Example
         }
     }
 
-This example will write to a PartitionedFileSet named 'users'. It will write data in Avro format
-using the given schema. Every time the pipeline runs, the most recent run will be stored in
-a new partition in the PartitionedFileSet.

--- a/core-plugins/docs/SnapshotAvro-batchsource.md
+++ b/core-plugins/docs/SnapshotAvro-batchsource.md
@@ -10,10 +10,10 @@ Use Case
 --------
 
 This source is used whenever you want to read data written to the corresponding
-SnapshotAvro sink. It will read only the last snapshot written to that sink.
-For example, you might want to create daily snapshots of a database by reading the entire contents of
-a table and writing it to a SnapshotAvro sink. You might then want to use this source to read the most
-recent snapshot and run some data analysis on it.
+SnapshotAvro sink. It will read only the last snapshot written to that sink. For example,
+you might want to create daily snapshots of a database by reading the entire contents of a
+table and writing it to a SnapshotAvro sink. You might then want to use this source to
+read the most recent snapshot and run some data analysis on it.
 
 Properties
 ----------

--- a/core-plugins/docs/SnapshotAvro-batchsource.md
+++ b/core-plugins/docs/SnapshotAvro-batchsource.md
@@ -1,3 +1,5 @@
+# SnapshotAvro Batch Source
+
 Description
 -----------
 
@@ -30,6 +32,10 @@ The properties are also passed to the dataset at runtime as arguments.
 Example
 -------
 
+This example will read from a SnapshotFileSet named 'users'. It will read data in Avro format
+using the given schema. Every time the pipeline runs, only the most recently added snapshot will
+be read:
+
     {
         "name": "SnapshotAvro",
         "properties": {
@@ -45,7 +51,3 @@ Example
             }"
         }
     }
-
-This example will read from a SnapshotFileSet named 'users'. It will read data in Avro format
-using the given schema. Every time the pipeline runs, only the most recently added snapshot will
-be read.

--- a/core-plugins/docs/SnapshotParquet-batchsink.md
+++ b/core-plugins/docs/SnapshotParquet-batchsink.md
@@ -10,10 +10,10 @@ can be used to read only the most recently written snapshot.
 Use Case
 --------
 
-This sink is used whenever you want access to a PartitionedFileSet containing exactly the most
-recent run's data in Parquet format. For example,
-you might want to create daily snapshots of a database by reading the entire contents of
-a table, writing to this sink, and then other programs can analyze the contents of the specified file.
+This sink is used whenever you want access to a PartitionedFileSet containing exactly the
+most recent run's data in Parquet format. For example, you might want to create daily
+snapshots of a database by reading the entire contents of a table, writing to this sink,
+and then other programs can analyze the contents of the specified file.
 
 Properties
 ----------

--- a/core-plugins/docs/SnapshotParquet-batchsink.md
+++ b/core-plugins/docs/SnapshotParquet-batchsink.md
@@ -1,3 +1,5 @@
+# SnapshotParquet Batch Sink
+
 Description
 -----------
 
@@ -30,6 +32,10 @@ The properties are also passed to the dataset at runtime as arguments.
 Example
 -------
 
+This example will write to a PartitionedFileSet named 'users'. It will write data in Parquet format
+using the given schema. Every time the pipeline runs, the most recent run will be stored in
+a new partition in the PartitionedFileSet:
+
     {
         "name": "SnapshotParquet",
         "properties": {
@@ -45,7 +51,3 @@ Example
             }"
         }
     }
-
-This example will write to a PartitionedFileSet named 'users'. It will write data in Parquet format
-using the given schema. Every time the pipeline runs, the most recent run will be stored in
-a new partition in the PartitionedFileSet.

--- a/core-plugins/docs/SnapshotParquet-batchsource.md
+++ b/core-plugins/docs/SnapshotParquet-batchsource.md
@@ -10,10 +10,10 @@ Use Case
 --------
 
 This source is used whenever you want to read data written to the corresponding
-SnapshotParquet sink. It will read only the last snapshot written to that sink.
-For example, you might want to create daily snapshots of a database by reading the entire contents of
-a table and writing it to a SnapshotParquet sink. You might then want to use this source to read the most
-recent snapshot and run a data analysis on it.
+SnapshotParquet sink. It will read only the last snapshot written to that sink. For
+example, you might want to create daily snapshots of a database by reading the entire
+contents of a table and writing it to a SnapshotParquet sink. You might then want to use
+this source to read the most recent snapshot and run a data analysis on it.
 
 Properties
 ----------

--- a/core-plugins/docs/SnapshotParquet-batchsource.md
+++ b/core-plugins/docs/SnapshotParquet-batchsource.md
@@ -1,3 +1,5 @@
+# SnapshotParquet Batch Source
+
 Description
 -----------
 
@@ -30,6 +32,10 @@ The properties are also passed to the dataset at runtime as arguments.
 Example
 -------
 
+This example will read from a SnapshotFileSet named 'users'. It will read data in Parquet format
+using the given schema. Every time the pipeline runs, only the most recently added snapshot will
+be read:
+
     {
         "name": "SnapshotParquet",
         "properties": {
@@ -45,7 +51,3 @@ Example
             }"
         }
     }
-
-This example will read from a SnapshotFileSet named 'users'. It will read data in Parquet format
-using the given schema. Every time the pipeline runs, only the most recently added snapshot will
-be read.

--- a/core-plugins/docs/Stream-batchsource.md
+++ b/core-plugins/docs/Stream-batchsource.md
@@ -1,3 +1,5 @@
+# Stream Batch Source
+
 Description
 -----------
 
@@ -48,6 +50,8 @@ the schema.
 Example
 -------
 
+This example reads from a stream named 'accesslogs':
+
     {
         "name": "Stream",
         "properties": {
@@ -58,14 +62,16 @@ Example
         }
     }
 
-This example reads from a stream named 'accesslogs'. With the 'duration' property set to
-'10m', the source will read ten minutes-worth of data. As the 'delay' property is set to
-'5m', the source will read data up to five minutes before the logical start time of the
-run. The 'end time' of the data will then be five minutes before that logical start time. 
-Combining the duration and the delay, the 'start time' of the data will be 15 minutes
-before the logical start time of the run. For example, if the pipeline was scheduled to
-run at 10:00am, the source will read data from 9:45am to 9:55am. The stream contents will
-be parsed as 'clf' (Combined Log Format), which will output records with this schema:
+With the 'duration' property set to '10m', the source will read ten minutes-worth of data.
+As the 'delay' property is set to '5m', the source will read data up to five minutes
+before the logical start time of the run. The 'end time' of the data will then be five
+minutes before that logical start time. Combining the duration and the delay, the 'start
+time' of the data will be 15 minutes before the logical start time of the run. For
+example, if the pipeline was scheduled to run at 10:00am, the source will read data from
+9:45am to 9:55am. 
+
+The stream contents will be parsed as 'clf' (Combined Log Format), which will output
+records with this schema:
 
     +======================================+
     | field name     | type                |

--- a/core-plugins/docs/Stream-realtimesink.md
+++ b/core-plugins/docs/Stream-realtimesink.md
@@ -1,7 +1,9 @@
+# Stream Real-time Sink
+
 Description
 -----------
 
-Real-time sink that outputs to a specified CDAP Stream
+Real-time sink that outputs to a specified CDAP Stream.
 
 Use Case
 --------
@@ -25,6 +27,11 @@ presumed to be a map of string to string.
 Example
 -------
 
+This example will write to a stream named 'purchases'. Each record it receives will be written
+as a single stream event. The stream event body will be equal to the value of the 'message' field
+from the input record. No headers will be written in this example because the 'headers.field'
+property is not set:
+
     {
         "name": "Stream",
         "properties": {
@@ -32,8 +39,3 @@ Example
             "body.field": "message"
         }
     }
-
-This example will write to a stream named 'purchases'. Each record it receives will be written
-as a single stream event. The stream event body will be equal to the value of the 'message' field
-from the input record. No headers will be written in this example because the 'headers.field'
-property is not set.

--- a/core-plugins/docs/StructuredRecordToGenericRecord-transform.md
+++ b/core-plugins/docs/StructuredRecordToGenericRecord-transform.md
@@ -1,3 +1,5 @@
+# StructuredRecord To GenericRecord Transform
+
 Description
 -----------
 

--- a/core-plugins/docs/TPFSAvro-batchsink.md
+++ b/core-plugins/docs/TPFSAvro-batchsink.md
@@ -1,3 +1,5 @@
+# TimePartitionedFileSet Avro Batch Sink
+
 Description
 -----------
 
@@ -32,6 +34,8 @@ This setting is only used if ``filePathFormat`` is not null.
 Example
 -------
 
+This example will write to a ``TimePartitionedFileSet`` named ``'users'``:
+
     {
         "name": "TPFSAvro",
         "properties": {
@@ -50,11 +54,11 @@ Example
         }
     }
 
-This example will write to a ``TimePartitionedFileSet`` named ``'users'``. It will write data in
-Avro format using the given schema. Every time the pipeline runs, a new partition in the
-``TimePartitionedFileSet`` will be created based on the logical start time of the run with the
-output directory ending with the date formatted as specified. All data for the run will be
-written to that partition. For example, if the pipeline was scheduled to run at 10:00am on
-January 1, 2015 in Los Angeles, a new partition will be created with year 2015, month 1,
-day 1, hour 10, and minute 0, and the output directory for that partition would end with
-``2015-01-01/10-00``.
+It will write data in Avro format using the given schema. Every time the pipeline runs, a
+new partition in the ``TimePartitionedFileSet`` will be created based on the logical start
+time of the run with the output directory ending with the date formatted as specified. All
+data for the run will be written to that partition.
+
+For example, if the pipeline was scheduled to run at 10:00am on January 1, 2015 in Los
+Angeles, a new partition will be created with year 2015, month 1, day 1, hour 10, and
+minute 0, and the output directory for that partition would end with ``2015-01-01/10-00``.

--- a/core-plugins/docs/TPFSAvro-batchsource.md
+++ b/core-plugins/docs/TPFSAvro-batchsource.md
@@ -1,3 +1,5 @@
+# TimePartitionedFileSet Avro Batch Source
+
 Description
 -----------
 
@@ -34,6 +36,9 @@ start time to 10 minutes before its logical start time. The default value is 0.
 Example
 -------
 
+This example reads from a TimePartitionedFileSet named 'webactivity', assuming the underlying
+files are in Avro format:
+
     {
         "name": "TPFSAvro",
         "properties": {
@@ -53,15 +58,16 @@ Example
         }
     }
 
-This example reads from a TimePartitionedFileSet named 'webactivity', assuming the underlying
-files are in Avro format. TimePartitionedFileSets are partitioned by year, month, day, hour,
-and minute. Suppose the current run was scheduled to start at 10:00am on January 1, 2015.
-Since the 'delay' property is set to one minute, only data before 9:59am January 1, 2015 will
-be read. This excludes the partition for year 2015, month 1, day 1, hour 9, and minute 59.
-Since the 'duration' property is set to five minutes, a total of five partitions will be read.
-This means partitions for year 2015, month 1, day 1, hour 9, and minutes 54, 55, 56, 57, and 58
-will be read. The source will read the actual data using the given schema. This means it will output
-records with this schema:
+TimePartitionedFileSets are partitioned by year, month, day, hour, and minute. Suppose the
+current run was scheduled to start at 10:00am on January 1, 2015. Since the 'delay'
+property is set to one minute, only data before 9:59am January 1, 2015 will be read. This
+excludes the partition for year 2015, month 1, day 1, hour 9, and minute 59. Since the
+'duration' property is set to five minutes, a total of five partitions will be read. This
+means partitions for year 2015, month 1, day 1, hour 9, and minutes 54, 55, 56, 57, and 58
+will be read. 
+
+The source will read the actual data using the given schema and will output records with
+this schema:
 
     +=======================+
     | field name  | type    |
@@ -71,4 +77,3 @@ records with this schema:
     | action      | string  |
     | item        | string  |
     +=======================+
-

--- a/core-plugins/docs/TPFSParquet-batchsink.md
+++ b/core-plugins/docs/TPFSParquet-batchsink.md
@@ -1,3 +1,5 @@
+# TimePartitionedFileSet Parquet Batch Sink
+
 Description
 -----------
 
@@ -32,6 +34,8 @@ This setting is only used if ``filePathFormat`` is not null.
 Example
 -------
 
+This example will write to a ``TimePartitionedFileSet`` named ``'users'``:
+
     {
         "name": "TPFSParquet",
         "properties": {
@@ -50,11 +54,11 @@ Example
         }
     }
 
-This example will write to a ``TimePartitionedFileSet`` named ``'users'``. It will write data in
-Avro format using the given schema. Every time the pipeline runs, a new partition in the
-``TimePartitionedFileSet`` will be created based on the logical start time of the run with the
-output directory ending with the date formatted as specified. All data for the run will be
-written to that partition. For example, if the pipeline was scheduled to run at 10:00am on
-January 1, 2015 in Los Angeles, a new partition will be created with year 2015, month 1,
-day 1, hour 10, and minute 0, and the output directory for that partition would end with
-``2015-01-01/10-00``.
+It will write data in Avro format using the given schema. Every time the pipeline runs, a
+new partition in the ``TimePartitionedFileSet`` will be created based on the logical start
+time of the run with the output directory ending with the date formatted as specified. All
+data for the run will be written to that partition.
+
+For example, if the pipeline was scheduled to run at 10:00am on January 1, 2015 in Los
+Angeles, a new partition will be created with year 2015, month 1, day 1, hour 10, and
+minute 0, and the output directory for that partition would end with ``2015-01-01/10-00``.

--- a/core-plugins/docs/TPFSParquet-batchsource.md
+++ b/core-plugins/docs/TPFSParquet-batchsource.md
@@ -1,3 +1,5 @@
+# TimePartitionedFileSet Parquet Batch Source
+
 Description
 -----------
 
@@ -34,6 +36,9 @@ start time to 10 minutes before its logical start time. The default value is 0.
 Example
 -------
 
+This example reads from a TimePartitionedFileSet named 'webactivity', assuming the underlying
+files are in Parquet format:
+
     {
         "name": "TPFSParquet",
         "properties": {
@@ -53,15 +58,16 @@ Example
         }
     }
 
-This example reads from a TimePartitionedFileSet named 'webactivity', assuming the underlying
-files are in Parquet format. TimePartitionedFileSets are partitioned by year, month, day, hour,
-and minute. Suppose the current run was scheduled to start at 10:00am on January 1, 2015.
-Since the 'delay' property is set to one minute, only data before 9:59am January 1, 2015 will
-be read. This excludes the partition for year 2015, month 1, day 1, hour 9, and minute 59.
-Since the 'duration' property is set to five minutes, a total of five partitions will be read.
-This means partitions for year 2015, month 1, day 1, hour 9, and minutes 54, 55, 56, 57, and 58
-will be read. The source will read the actual data using the given schema. This means it will output
-records with this schema:
+TimePartitionedFileSets are partitioned by year, month, day, hour, and minute. Suppose the
+current run was scheduled to start at 10:00am on January 1, 2015. Since the 'delay'
+property is set to one minute, only data before 9:59am January 1, 2015 will be read. This
+excludes the partition for year 2015, month 1, day 1, hour 9, and minute 59. Since the
+'duration' property is set to five minutes, a total of five partitions will be read. This
+means partitions for year 2015, month 1, day 1, hour 9, and minutes 54, 55, 56, 57, and 58
+will be read. 
+
+The source will read the actual data using the given schema and will output records with
+this schema:
 
     +=======================+
     | field name  | type    |

--- a/core-plugins/docs/Table-batchsink.md
+++ b/core-plugins/docs/Table-batchsink.md
@@ -1,7 +1,9 @@
+# Table Batch Sink
+
 Description
 -----------
 
-Writes records to a Table with one record field mapping
+Writes records to a CDAP Table with one record field mapping
 to the Table rowkey, and all other record fields mapping to Table columns.
 
 Use Case
@@ -27,6 +29,8 @@ key when writing to the table.
 Example
 -------
 
+This example writes to a Table named 'users':
+
     {
         "name": "Table",
         "properties": {
@@ -44,7 +48,7 @@ Example
         }
     }
 
-This example writes to a Table named 'users'. It takes records with the following schema as input
+It takes records with this schema as input:
 
     +======================================+
     | field name     | type                |

--- a/core-plugins/docs/Table-batchsource.md
+++ b/core-plugins/docs/Table-batchsource.md
@@ -1,3 +1,5 @@
+# Table Batch Source
+
 Description
 -----------
 
@@ -27,6 +29,8 @@ the schema, and must not be nullable.
 Example
 -------
 
+This example reads from a Table named 'users':
+
     {
         "name": "Table",
         "properties": {
@@ -44,7 +48,7 @@ Example
         }
     }
 
-This example reads from a Table named 'users'. It outputs records with this schema:
+It outputs records with this schema:
 
     +======================================+
     | field name     | type                |

--- a/core-plugins/docs/Table-realtimesink.md
+++ b/core-plugins/docs/Table-realtimesink.md
@@ -1,7 +1,11 @@
+# Table Real-time Sink
+
 Description
 -----------
 
-Writes records to a Table with one record field mapping
+Writes records to a CDAP # Amazon SQS Real-time Source
+
+Table with one record field mapping
 to the Table rowkey, and all other record fields mapping to Table columns.
 
 Use Case
@@ -27,6 +31,8 @@ key when writing to the table.
 Example
 -------
 
+The example writes to a Table named 'users':
+
     {
         "name": "Table",
         "properties": {
@@ -44,7 +50,7 @@ Example
         }
     }
 
-The example writes to a Table named 'users'. It takes records with the following schema as input:
+It takes records with this schema as input:
 
     +======================================+
     | field name     | type                |

--- a/core-plugins/docs/Twitter-realtimesource.md
+++ b/core-plugins/docs/Twitter-realtimesource.md
@@ -1,3 +1,5 @@
+# Twitter Real-time Source
+
 Description
 -----------
 
@@ -36,13 +38,13 @@ the relevant app to find the consumer key and secret.
   [Twitter OAuth documentation]: https://dev.twitter.com/oauth/overview
   [your apps]: https://apps.twitter.com/
 
-**ConsumerKey:** Consumer Key
+**ConsumerKey:** Twitter Consumer Key.
 
-**ConsumerSecret:** Consumer Secret
+**ConsumerSecret:** Twitter Consumer Secret.
 
-**AccessToken:** Access Token
+**AccessToken:** Twitter Access Token.
 
-**AccessTokenSecret:** Access Token Secret
+**AccessTokenSecret:** Twitter Access Token Secret.
 
 Example
 -------

--- a/core-plugins/docs/Validator-transform.md
+++ b/core-plugins/docs/Validator-transform.md
@@ -1,3 +1,5 @@
+# Validator Transform
+
 Description
 -----------
 
@@ -62,12 +64,12 @@ Properties
 ----------
 
 **validators** Comma-separated list of validators that are used by the validationScript.
-Example: ``"validators": "core| 
+Example: ``"validators": "core"``
 
 **validationScript:** Javascript that must implement a function ``isValid`` that takes a JSON object
 (representing the input record) and a context object (encapsulating CDAP metrics, logger, and validators)
 and returns a result JSON with validity, error code, and error message.
-Example response::
+Example response:
 
     {
         "isValid" : true [or] false,
@@ -82,6 +84,12 @@ Currently supports ``KeyValueTable``.
 
 Examples
 --------
+
+This example sends an error code ``'10'`` for any records whose ``'body'`` field contains
+a value whose length is greater than 10. It has been "pretty-printed" for readability. It
+uses the :ref:`CoreValidator <cdap-apps-etl-plugins-shared-core-validator>` (included
+using ``"validators": "core"`` ) and references a function using its Javascript name
+(``coreValidator.maxLength``):
 
       {
         "name": "Validator",
@@ -99,11 +107,9 @@ Examples
         }
       }
 
-This example sends an error code ``'10'`` for any records whose ``'body'`` field contains
-a value whose length is greater than 10. It has been "pretty-printed" for readability. It
-uses the :ref:`CoreValidator <cdap-apps-etl-plugins-shared-core-validator>` (included
-using ``"validators": "core| ) and references a function using its Javascript name
-(``coreValidator.maxLength``).
+This example uses the key-value dataset ``'blacklist'`` as a lookup table,
+and sends an error code ``'10'`` for any records whose ``'body'`` field exists in the ``'blacklist'`` dataset.
+It has been "pretty-printed" for readability:
 
     {
         "name": "Validator",
@@ -124,9 +130,13 @@ using ``"validators": "core| ) and references a function using its Javascript na
         }
     }
 
-This example uses the key-value dataset ``'blacklist'`` as a lookup table,
-and sends an error code ``'10'`` for any records whose ``'body'`` field exists in the ``'blacklist'`` dataset.
-It has been "pretty-printed" for readability.
+This example sends an error code ``'5'`` for any records whose ``'date'`` field is an
+invalid date, sends an error code ``'7'`` for any records whose ``'url'`` field is an
+invalid URL, and sends an error code ``'10'`` for any records whose ``'content_length'``
+field is greater than 1MB.
+
+It has been "pretty-printed" for readability. It uses the CoreValidator and references functions 
+using their Javascript names (such as ``coreValidator.isDate``):
 
     {
         "name": "Validator",
@@ -157,12 +167,4 @@ It has been "pretty-printed" for readability.
         }
     }
 
-This example sends an error code ``'5'`` for any records whose ``'date'`` field is an
-invalid date, sends an error code ``'7'`` for any records whose ``'url'`` field is an
-invalid URL, and sends an error code ``'10'`` for any records whose ``'content_length'``
-field is greater than 1MB.
-
-It has been "pretty-printed" for readability. It uses the CoreValidator and references functions using their Javascript names (such as
-``coreValidator.isDate``).
-
-**Note:** This plugin emits a metric called 'invalid' that tracks how many invalid records were found
+**Note:** This plugin emits a metric called 'invalid' that tracks how many invalid records were found.

--- a/core-plugins/docs/Validator-transform.md
+++ b/core-plugins/docs/Validator-transform.md
@@ -87,9 +87,8 @@ Examples
 
 This example sends an error code ``'10'`` for any records whose ``'body'`` field contains
 a value whose length is greater than 10. It has been "pretty-printed" for readability. It
-uses the :ref:`CoreValidator <cdap-apps-etl-plugins-shared-core-validator>` (included
-using ``"validators": "core"`` ) and references a function using its Javascript name
-(``coreValidator.maxLength``):
+uses the ``CoreValidator`` (included using ``"validators": "core"`` ) and references a
+function using its Javascript name (``coreValidator.maxLength``):
 
       {
         "name": "Validator",
@@ -107,9 +106,9 @@ using ``"validators": "core"`` ) and references a function using its Javascript 
         }
       }
 
-This example uses the key-value dataset ``'blacklist'`` as a lookup table,
-and sends an error code ``'10'`` for any records whose ``'body'`` field exists in the ``'blacklist'`` dataset.
-It has been "pretty-printed" for readability:
+This example uses the key-value dataset ``'blacklist'`` as a lookup table, and sends an
+error code ``'10'`` for any records whose ``'body'`` field exists in the ``'blacklist'``
+dataset. It has been "pretty-printed" for readability:
 
     {
         "name": "Validator",

--- a/elasticsearch-plugins/docs/Elasticsearch-batchsink.md
+++ b/elasticsearch-plugins/docs/Elasticsearch-batchsink.md
@@ -1,3 +1,5 @@
+# Elasticsearch Batch Sink
+
 Description
 -----------
 Takes the Structured Record from the input source and converts it to a JSON string, then indexes it in
@@ -10,22 +12,22 @@ with a stream batch source and Elasticsearch as a sink.
 
 Configuration
 -------------
-**es.host:** The hostname and port for the Elasticsearch instance
+**es.host:** The hostname and port for the Elasticsearch instance.
 
 **es.index:** The name of the index where the data will be stored; if the index does not
-already exist, it will be created using Elasticsearch's default properties
+already exist, it will be created using Elasticsearch's default properties.
 
 **es.type:** The name of the type where the data will be stored; if it does not already
-exist, it will be created
+exist, it will be created.
 
 **es.idField:** The field that will determine the id for the document; it should match a fieldname
-in the Structured Record of the input
+in the Structured Record of the input.
 
 Example
 -------
 This example connects to Elasticsearch, which is running locally, and writes the data to
 the specified index (megacorp) and type (employee). The data is indexed using the id field
-in the record. Each run, the documents will be updated if they are still present in the source::
+in the record. Each run, the documents will be updated if they are still present in the source:
 
     {
         "name": "Elasticsearch",

--- a/elasticsearch-plugins/docs/Elasticsearch-batchsource.md
+++ b/elasticsearch-plugins/docs/Elasticsearch-batchsource.md
@@ -1,3 +1,5 @@
+# Elasticsearch Batch Source
+
 Description
 -----------
 
@@ -11,22 +13,23 @@ in an index and type from Elasticsearch and store the data in an HBase table.
 Configuration
 -------------
 
-**es.host:** The hostname and port for the Elasticsearch instance
+**es.host:** The hostname and port for the Elasticsearch instance.
 
-**es.index:** The name of the index to query
+**es.index:** The name of the index to query.
 
-**es.type:** The name of the type where the data is stored
+**es.type:** The name of the type where the data is stored.
 
 **query:** The query to use to import data from the specified index and type;
-see Elasticsearch for additional query examples
+see Elasticsearch for additional query examples.
 
-**schema:** The schema or mapping of the data in Elasticsearch
+**schema:** The schema or mapping of the data in Elasticsearch.
 
 Example
 -------
-    This example connects to Elasticsearch, which is running locally, and reads in records in the
-    specified index (*megacorp*) and type (*employee*) which match the query to (in this case) select all records.
-    All data from the index will be read on each run:
+
+This example connects to Elasticsearch, which is running locally, and reads in records in the
+specified index (*megacorp*) and type (*employee*) which match the query to (in this case) select all records.
+All data from the index will be read on each run:
 
     {
         "name": "Elasticsearch",

--- a/elasticsearch-plugins/docs/Elasticsearch-realtimesink.md
+++ b/elasticsearch-plugins/docs/Elasticsearch-realtimesink.md
@@ -1,3 +1,5 @@
+# Elasticsearch Real-time Sink
+
 Description
 -----------
 Takes the Structured Record from the input source and converts it to a JSON string, then indexes it in
@@ -10,24 +12,25 @@ to be able to search on them.
 
 Configuration
 -------------
-**es.cluster:** The name of the cluster to connect to; defaults to *elasticsearch*
+**es.cluster:** The name of the cluster to connect to; defaults to ``'elasticsearch'``.
 
 **es.transportAddresses:** The addresses for nodes; specify the address for at least one node,
-and separate others by commas; other nodes will be sniffed out
+and separate others by commas; other nodes will be sniffed out.
 
 **es.index:** The name of the index where the data will be stored; if the index does not already exist,
-it will be created using Elasticsearch's default properties
+it will be created using Elasticsearch's default properties.
 
-**es.type:** The name of the type where the data will be stored; if it does not already exist, it will be created
+**es.type:** The name of the type where the data will be stored; if it does not already exist, it will be created.
 
 **es.idField:** The field that will determine the id for the document; it should match a fieldname in the
-Structured Record of the input; if left blank, Elasticsearch will create a unique id for each document
+Structured Record of the input; if left blank, Elasticsearch will create a unique id for each document.
 
 Example
 --------
+
 This example connects to Elasticsearch, which is running locally, and writes the data to
 the specified index (*logs*) and type (*cdap*). The data is indexed using the timestamp (*ts*) field
-in the record.
+in the record:
 
     {
         "name": "Elasticsearch",

--- a/hive-plugins/docs/Hive-batchsink.md
+++ b/hive-plugins/docs/Hive-batchsink.md
@@ -1,3 +1,5 @@
+# Hive Batch Sink
+
 Description
 -----------
 Converts a StructuredRecord to a HCatRecord and then writes it to an existing Hive table.
@@ -5,7 +7,7 @@ Converts a StructuredRecord to a HCatRecord and then writes it to an existing Hi
 Configuration
 -------------
 **metastoreURI:** The URI of Hive metastore in the format ``thrift://<hostname>:<port>``.
-Example: thrift://somehost.net:9083
+Example: ``thrift://somehost.net:9083``.
 
 **tableName:** The name of the Hive table. This table must exist.
 

--- a/hive-plugins/docs/Hive-batchsource.md
+++ b/hive-plugins/docs/Hive-batchsource.md
@@ -1,3 +1,5 @@
+# Hive Batch Source
+
 Description
 -----------
 Reads records from a Hive table and converts each record into a StructuredRecord with the help
@@ -6,7 +8,7 @@ of the specified schema (if provided) or the table's schema.
 Configuration
 -------------
 **metastoreURI:** The URI of Hive metastore in the format of ``thrift://<hostname>:<port>``.
-Example: thrift://somehost.net:9083
+Example: ``thrift://somehost.net:9083``.
 
 **tableName:** The name of the Hive table. This table must exist.
 

--- a/kafka-plugins/docs/KafkaProducer-realtimesink.md
+++ b/kafka-plugins/docs/KafkaProducer-realtimesink.md
@@ -1,3 +1,5 @@
+# Kafka Producer Real-time Sink
+
 Description
 -----------
 Kafka producer plugin that allows you to convert a Structured Record into CSV or JSON.
@@ -7,14 +9,15 @@ can also be configured to operate in either sync or async mode.
 
 Configuration
 -------------
-**brokers:** Specifies a list of brokers to connect to
+**brokers:** Specifies a list of brokers to connect to.
 
-**async:** Specifies whether writing the events to broker is *Asynchronous* or *Synchronous*
+**async:** Specifies whether writing the events to broker is *Asynchronous* or *Synchronous*.
 
-**partitionfield:** Specifies the input fields that need to be used to determine the partition id; the field type should be int or long
+**partitionfield:** Specifies the input fields that need to be used to determine the partition id; 
+the field type should be int or long.
 
-**key:** Specifies the input field that should be used as the key for the event published into Kafka
+**key:** Specifies the input field that should be used as the key for the event published into Kafka.
 
-**topics:** Specifies a list of topics to which the event should be published to
+**topics:** Specifies a list of topics to which the event should be published to.
 
-**format:** Specifies the format of the event published to Kafka
+**format:** Specifies the format of the event published to Kafka.

--- a/mongodb-plugins/docs/MongoDB-batchsink.md
+++ b/mongodb-plugins/docs/MongoDB-batchsink.md
@@ -1,7 +1,9 @@
+# MongoDB Batch Sink
+
 Description
 -----------
 Converts a StructuredRecord into a BSONWritable and then writes it to a MongoDB collection.
 
 Configuration
 -------------
-**connectionString:** MongoDB connection string
+**connectionString:** MongoDB connection string.

--- a/mongodb-plugins/docs/MongoDB-batchsource.md
+++ b/mongodb-plugins/docs/MongoDB-batchsource.md
@@ -1,3 +1,5 @@
+# MongoDB Batch Source
+
 Description
 -----------
 Reads documents from a MongoDB collection and converts each document into a StructuredRecord with the help
@@ -5,14 +7,14 @@ of the specified schema. The user can optionally provide input query, input fiel
 
 Configuration
 -------------
-**connectionString:** MongoDB connection string
+**connectionString:** MongoDB connection string.
 
-**schema:** Specifies the schema of document
+**schema:** Specifies the schema of document.
 
-**authConnectionString:** Auxiliary MongoDB connection string
+**authConnectionString:** Auxiliary MongoDB connection string.
 
-**inputQuery:** Filter the input collection with a query
+**inputQuery:** Filter the input collection with a query.
 
-**inputFields:** Projection document that can limit the fields that appear in each document
+**inputFields:** Projection document that can limit the fields that appear in each document.
 
-**splitterClass:** Name of the splitter class to use
+**splitterClass:** Name of the splitter class to use.

--- a/mongodb-plugins/docs/MongoDB-realtimesink.md
+++ b/mongodb-plugins/docs/MongoDB-realtimesink.md
@@ -1,11 +1,13 @@
+# MongoDB Real-time Sink
+
 Description
 -----------
 Takes a StructuredRecord from a previous node, converts it into a BSONDocument and writes it to a MongoDB collection.
 
 Configuration
 -------------
-**connectionString:** MongoDB connection string
+**connectionString:** MongoDB connection string.
 
-**dbName:** MongoDB database name
+**dbName:** MongoDB database name.
 
-**collectionName:** MongoDB collection name
+**collectionName:** MongoDB collection name.

--- a/python-evaluator-transform/docs/PythonEvaluator-transform.md
+++ b/python-evaluator-transform/docs/PythonEvaluator-transform.md
@@ -1,3 +1,5 @@
+# Python Evaluator Transform
+
 Description
 -----------
 Executes user-provided Python code that transforms one record into another.
@@ -20,6 +22,10 @@ schema is the same as the input schema.
 
 Example
 -------
+
+The transform takes records that have a ``'subtotal'`` field, calculates ``'tax'`` and
+``'total'`` fields based on the subtotal, and then returns a record, as a Python dictionary,
+containing those three fields:
 
     {
         "name": "PythonEvaluator",
@@ -47,10 +53,6 @@ Example
             }"
         }
     }
-
-The transform takes records that have a ``'subtotal'`` field, calculates ``'tax'`` and
-``'total'`` fields based on the subtotal, and then returns a record, as a Python dictionary,
-containing those three fields.
 
 Known Issues
 ------------

--- a/transform-plugins/docs/CSVFormatter-transform.md
+++ b/transform-plugins/docs/CSVFormatter-transform.md
@@ -1,11 +1,16 @@
+# CSV Formatter Transform
+
 Description
 -----------
-Formats a Structured Record as a CSV Record. Supported CSV Record formats are DELIMITED, EXCEL, MYSQL, RFC4180, and TDF. When the format is DELIMITED, one can specify different delimiters that a CSV Record should use for separating fields.
+Formats a Structured Record as a CSV Record. Supported CSV Record formats are DELIMITED,
+EXCEL, MYSQL, RFC4180, and TDF. When the format is DELIMITED, one can specify different
+delimiters that a CSV Record should use for separating fields.
 
 Configuration
 -------------
-**format:** Specifies the format of the CSV Record to be generated
+**format:** Specifies the format of the CSV Record to be generated.
 
-**delimiter:** Specifies the delimiter to be used to generate a CSV Record; this option is available when the format is specified as ``DELIMITED``
+**delimiter:** Specifies the delimiter to be used to generate a CSV Record; 
+this option is available when the format is specified as ``DELIMITED``.
 
-**schema:** Specifies the output schema. Output schema should only have fields of type String
+**schema:** Specifies the output schema. Output schema should only have fields of type String.

--- a/transform-plugins/docs/CSVParser-transform.md
+++ b/transform-plugins/docs/CSVParser-transform.md
@@ -1,3 +1,5 @@
+# CSV Parser Transform
+
 Description
 -----------
 Parses an input field as a CSV Record into a Structured Record. Supports multi-line CSV Record parsing
@@ -6,8 +8,8 @@ Supports these CSV Record types: DEFAULT, EXCEL, MYSQL, RFC4180, and TDF.
 
 Configuration
 -------------
-**format:** Specifies the format of CSV Record the input should be parsed as
+**format:** Specifies the format of the CSV Record the input should be parsed as.
 
-**field:** Specifies the input field that should be parsed as CSV Record
+**field:** Specifies the input field that should be parsed as a CSV Record.
 
-**schema:** Specifies the output schema of CSV Record
+**schema:** Specifies the output schema of the CSV Record.

--- a/transform-plugins/docs/CloneRecord-transform.md
+++ b/transform-plugins/docs/CloneRecord-transform.md
@@ -1,7 +1,10 @@
+# Clone Record Transform
+
 Description
 -----------
-Makes a copy of every input record received for a configured number of times on the output. This transform does not change any record fields or types. It's an identity transform.
+Makes a copy of every input record received for a configured number of times on the output. 
+This transform does not change any record fields or types. It's an identity transform.
 
 Configuration
 -------------
-**copies:** Specifies the numbers of copies of the input record that are to be emitted
+**copies:** Specifies the numbers of copies of the input record that are to be emitted.

--- a/transform-plugins/docs/Compressor-transform.md
+++ b/transform-plugins/docs/Compressor-transform.md
@@ -1,3 +1,5 @@
+# Compressor Transform
+
 Description
 -----------
 Compresses configured fields. Multiple fields can be specified to be compressed using different compression algorithms.
@@ -5,6 +7,8 @@ Plugin supports SNAPPY, ZIP, and GZIP types of compression of fields.
 
 Configuration
 -------------
-**compressor:** Specifies the configuration for compressing fields; in JSON configuration, this is specified as ``<field>:<compressor>[,<field>:<compressor>]*``
+**compressor:** Specifies the configuration for compressing fields; in JSON configuration, 
+this is specified as ``<field>:<compressor>[,<field>:<compressor>]*``.
 
- **schema:** Specifies the output schema; the fields that are compressed will have the same field name but they will be of type ``BYTES``
+ **schema:** Specifies the output schema; the fields that are compressed will have the same field name 
+ but they will be of type ``BYTES``.

--- a/transform-plugins/docs/Decoder-transform.md
+++ b/transform-plugins/docs/Decoder-transform.md
@@ -1,3 +1,5 @@
+# Decoder Transform
+
 Description
 -----------
 Decodes configured fields. Multiple fields can be specified to be decoded using different decoding methods.
@@ -5,6 +7,8 @@ Available decoding methods are STRING_BASE64, BASE64, BASE32, STRING_BASE32, and
 
 Configuration
 -------------
-**decode:** Specifies the configuration for decode fields; in JSON configuration, this is specified as ``<field>:<decoder>[,<field>:<decoder>]*``
+**decode:** Specifies the configuration for decode fields; in JSON configuration, 
+this is specified as ``<field>:<decoder>[,<field>:<decoder>]*``.
 
-**schema:** Specifies the output schema; the fields that are decoded will have the same field name but they will be of type ``BYTES`` or STRING``
+**schema:** Specifies the output schema; the fields that are decoded will have the same field 
+name but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Decompressor-transform.md
+++ b/transform-plugins/docs/Decompressor-transform.md
@@ -2,9 +2,9 @@
 
 Description
 -----------
-Decompresses configured fields. Multiple fields can be specified to be decompressed using 
-different decompression algorithms.
-Plugin supports SNAPPY, ZIP, and GZIP types of decompression of fields.
+Decompresses configured fields. Multiple fields can be specified to be decompressed using
+different decompression algorithms. Plugin supports SNAPPY, ZIP, and GZIP types of
+decompression of fields.
 
 Configuration
 -------------

--- a/transform-plugins/docs/Decompressor-transform.md
+++ b/transform-plugins/docs/Decompressor-transform.md
@@ -1,10 +1,15 @@
+# Decompressor Transform
+
 Description
 -----------
-Decompresses configured fields. Multiple fields can be specified to be decompressed using different decompression algorithms.
+Decompresses configured fields. Multiple fields can be specified to be decompressed using 
+different decompression algorithms.
 Plugin supports SNAPPY, ZIP, and GZIP types of decompression of fields.
 
 Configuration
 -------------
-**decompressor:** Specifies the configuration for decompressing fields; in JSON configuration, this is specified as ``<field>:<decompressor>[,<field>:<decompressor>]*``
+**decompressor:** Specifies the configuration for decompressing fields; in JSON configuration, 
+this is specified as ``<field>:<decompressor>[,<field>:<decompressor>]*``.
 
-**schema:** Specifies the output schema; the fields that are decompressed will have the same field name but they will be of type ``BYTES`` or ``STRING``
+**schema:** Specifies the output schema; the fields that are decompressed will have the same field 
+name but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Encoder-transform.md
+++ b/transform-plugins/docs/Encoder-transform.md
@@ -1,3 +1,5 @@
+# Encoder Transform
+
 Description
 -----------
 Encodes configured fields. Multiple fields can be specified to be encoded using different encoding methods.
@@ -5,6 +7,8 @@ Available encoding methods are STRING_BASE64, BASE64, BASE32, STRING_BASE32, and
 
 Configuration
 -------------
-**encode:** Specifies the configuration for encode fields; in JSON configuration, this is specified as ``<field>:<encoder>[,<field>:<encoder>]*``
+**encode:** Specifies the configuration for encode fields; in JSON configuration, 
+this is specified as ``<field>:<encoder>[,<field>:<encoder>]*``.
 
-**schema:** Specifies the output schema; the fields that are encoded will have the same field name but they will be of type ``BYTES`` or ``STRING``
+**schema:** Specifies the output schema; the fields that are encoded will have the same field name 
+but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Hasher-transform.md
+++ b/transform-plugins/docs/Hasher-transform.md
@@ -1,9 +1,11 @@
+# Hasher Transform
+
 Description
 -----------
 Hashes fields using a digest algorithm such as MD2, MD5, SHA1, SHA256, SHA384, or SHA512.
 
 Configuration
 -------------
-**fields:** Specifies the fields to be hashed
+**fields:** Specifies the fields to be hashed.
 
-**hash:** Specifies the hashing algorithm
+**hash:** Specifies the hashing algorithm.

--- a/transform-plugins/docs/JSONFormatter-transform.md
+++ b/transform-plugins/docs/JSONFormatter-transform.md
@@ -1,7 +1,10 @@
+# JSON Formatter Transform
+
 Description
 -----------
-Formats a Structured Record as JSON Object. Plugin will convert the Structured Record to a JSON object and write to the output record. The output record schema is a single field, either type STRING or type BYTE array.
+Formats a Structured Record as JSON Object. Plugin will convert the Structured Record to a JSON object 
+and write to the output record. The output record schema is a single field, either type STRING or type BYTE array.
 
 Configuration
 -------------
-**schema:** Specifies the output schema, a single field either type ``STRING`` or type ``BYTES``
+**schema:** Specifies the output schema, a single field either type ``STRING`` or type ``BYTES``.

--- a/transform-plugins/docs/JSONParser-transform.md
+++ b/transform-plugins/docs/JSONParser-transform.md
@@ -1,9 +1,13 @@
+# JSON Parser Transform
+
 Description
 -----------
-Parses an input field value as a JSON Object. Each record in the input is parsed as a JSON Object and converted into a Structured Record. The Structured Record can specify particular fields that it's interested in, making projections possible.
+Parses an input field value as a JSON Object. Each record in the input is parsed as a JSON Object 
+and converted into a Structured Record. The Structured Record can specify particular fields that 
+it's interested in, making projections possible.
 
 Configuration
 -------------
-**field:** Specifies the input field that should be parsed as a CSV Record
+**field:** Specifies the input field that should be parsed as a CSV Record.
 
-**schema:** Specifies the output schema for the JSON Record
+**schema:** Specifies the output schema for the JSON Record.

--- a/transform-plugins/docs/StreamFormatter-transform.md
+++ b/transform-plugins/docs/StreamFormatter-transform.md
@@ -1,3 +1,5 @@
+# Stream Formatter Transform
+
 Description
 -----------
 Formats a Structured Record as Stream format. Plugin will convert the Structured Record to Stream format.
@@ -5,10 +7,11 @@ It will include a header and body configurations. The body of the Stream event c
 
 Configuration
 -------------
-**body:** Specifies the input Structured Record fields that should be included in the body of the Stream event
+**body:** Specifies the input Structured Record fields that should be included in the body of the Stream event.
 
-**header:** Specifies the input Structured Record fields that should be included in the header of the Stream event
+**header:** Specifies the input Structured Record fields that should be included in the header of the Stream event.
 
-**format:** Specifies the format of the body. Currently supported formats are JSON, CSV, TSV, and PSV
+**format:** Specifies the format of the body. Currently supported formats are JSON, CSV, TSV, and PSV.
 
-**schema:** Specifies the output schema; the output schema can have only two fields: one of type ``STRING`` and the other of type ``MAP<STRING, STRING>``
+**schema:** Specifies the output schema; the output schema can have only two fields: one of type ``STRING`` 
+and the other of type ``MAP<STRING, STRING>``.


### PR DESCRIPTION
When the doc files were converted to Markdown, the titles were stripped off. This causes problems when the documents are imported in Sphinx, as they have numerous levels that appear rather than a title with a set of lower level titles.
- Added titles to all files
- Changed all examples so that descriptive text precedes the example code rather than following it
- Removed reST formatting included in error
- Fixed formatting issues where noticed
