### PR TITLE
Add '-am' to commands in README, to build the dependency modules (for…

### DIFF
--- a/cassandra-plugins/README.rst
+++ b/cassandra-plugins/README.rst
@@ -27,7 +27,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl cassandra-plugins
+  mvn clean package -pl cassandra-plugins -am
 
 After the build completes, you will have a JAR under the
 ``cassandra-plugins/target/`` directory.

--- a/elasticsearch-plugins/README.rst
+++ b/elasticsearch-plugins/README.rst
@@ -25,7 +25,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl elasticsearch-plugins
+  mvn clean package -pl elasticsearch-plugins -am
 
 After the build completes, you will have a JAR under the
 ``elasticsearch-plugins/target/`` directory.

--- a/hive-plugins/README.rst
+++ b/hive-plugins/README.rst
@@ -27,7 +27,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl hive-plugins
+  mvn clean package -pl hive-plugins -am
 
 After the build completes, you will have a jar for each plugin under the
 ``hive-plugins/target/`` directory.

--- a/kafka-plugins/README.rst
+++ b/kafka-plugins/README.rst
@@ -22,7 +22,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl kafka-plugins
+  mvn clean package -pl kafka-plugins -am
 
 After the build completes, you will have a jar for each plugin under the
 ``<plugin-name>/target/`` directory.

--- a/mongodb-plugins/README.rst
+++ b/mongodb-plugins/README.rst
@@ -28,7 +28,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl mongodb-plugins
+  mvn clean package -pl mongodb-plugins -am
 
 After the build completes, you will have a jar for each plugin under the
 ``mongodb-plugins/target/`` directory.

--- a/python-evaluator-transform/README.rst
+++ b/python-evaluator-transform/README.rst
@@ -34,7 +34,7 @@ You can get started with the CDAP-plugin by building directly from the latest so
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl python-evaluator-transform
+  mvn clean package -pl python-evaluator-transform -am
 
 You can build without running tests by using::
 

--- a/transform-plugins/README.rst
+++ b/transform-plugins/README.rst
@@ -31,7 +31,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  mvn clean package -pl transform-plugins
+  mvn clean package -pl transform-plugins -am
 
 After the build completes, you will have a JAR for each plugin under each
 ``<plugin-name>/target/`` directory.


### PR DESCRIPTION
… instance, hydrator-common)

Otherwise, you get issues like this, if you omit the `-am`:

```
[ERROR] Failed to execute goal on project cassandra-plugins: Could not resolve dependencies for project co.cask.hydrator:cassandra-plugins:jar:1.2.0-SNAPSHOT: The following artifacts could not be resolved: co.cask.hydrator:core-plugins:jar:1.2.0-SNAPSHOT, co.cask.hydrator:hydrator-common:jar:1.2.0-SNAPSHOT: Could not find artifact co.cask.hydrator:core-plugins:jar:1.2.0-SNAPSHOT in sonatype (https://oss.sonatype.org/content/groups/public) -> [Help 1]
```
