### PR TITLE
CDAP-3254 Adding unit tests to verify explore works for TPFSAvro/Parquet with map as one of the fields

### DIFF
--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
@@ -71,7 +71,7 @@ import java.util.List;
 public class ETLBatchTestBase extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", true);
 
   protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "etlbatch", "3.2.0");
   protected static final ArtifactSummary ETLBATCH_ARTIFACT = new ArtifactSummary("etlbatch", "3.2.0");


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-3254

This issue doesn't seem to arise in unit tests. Enhanced tests to cover the case mentioned in the JIRA.
Will do testing on cluster to confirm that the issue is not reproducible and then close the JIRA.
