### PR TITLE
Allow signing of JARs in 'release' profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -704,4 +704,31 @@
       </plugin>
     </plugins>
   </build>
+
+  <!-- Profile for release. Includes signing of jars. -->
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <configuration>
+              <passphrase>${gpg.passphrase}</passphrase>
+              <useAgent>${gpg.useagent}</useAgent>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Tested this change by running:
`mvn clean verify -DskipTests -P release -Dgpg.passphrase=****** -Dgpg.useagent=false`
on a bamboo box and found these results:

```
$ find . -name '*.asc'
./transform-plugins/target/transform-plugins-1.2.0-SNAPSHOT.jar.asc
./transform-plugins/target/transform-plugins-1.2.0-SNAPSHOT.pom.asc
./kafka-plugins/target/kafka-plugins-1.2.0-SNAPSHOT.jar.asc
./kafka-plugins/target/kafka-plugins-1.2.0-SNAPSHOT.pom.asc
./core-plugins/target/core-plugins-1.2.0-SNAPSHOT.pom.asc
./core-plugins/target/core-plugins-1.2.0-SNAPSHOT-tests.jar.asc
./core-plugins/target/core-plugins-1.2.0-SNAPSHOT.jar.asc
./hdfs-plugins/target/hdfs-plugins-1.2.0-SNAPSHOT.pom.asc
./hdfs-plugins/target/hdfs-plugins-1.2.0-SNAPSHOT.jar.asc
./python-evaluator-transform/target/python-evaluator-transform-1.2.0-SNAPSHOT.pom.asc
./python-evaluator-transform/target/python-evaluator-transform-1.2.0-SNAPSHOT.jar.asc
./target/hydrator-plugins-1.2.0-SNAPSHOT.pom.asc
./hbase-plugins/target/hbase-plugins-1.2.0-SNAPSHOT.pom.asc
./hbase-plugins/target/hbase-plugins-1.2.0-SNAPSHOT.jar.asc
./hydrator-common/target/hydrator-common-1.2.0-SNAPSHOT.pom.asc
./hydrator-common/target/hydrator-common-1.2.0-SNAPSHOT.jar.asc
./elasticsearch-plugins/target/elasticsearch-plugins-1.2.0-SNAPSHOT.jar.asc
./elasticsearch-plugins/target/elasticsearch-plugins-1.2.0-SNAPSHOT.pom.asc
./cassandra-plugins/target/cassandra-plugins-1.2.0-SNAPSHOT.pom.asc
./cassandra-plugins/target/cassandra-plugins-1.2.0-SNAPSHOT.jar.asc
./database-plugins/target/database-plugins-1.2.0-SNAPSHOT.pom.asc
./database-plugins/target/database-plugins-1.2.0-SNAPSHOT.jar.asc
./mongodb-plugins/target/mongodb-plugins-1.2.0-SNAPSHOT.jar.asc
./mongodb-plugins/target/mongodb-plugins-1.2.0-SNAPSHOT.pom.asc
./hive-plugins/target/hive-plugins-1.2.0-SNAPSHOT.pom.asc
./hive-plugins/target/hive-plugins-1.2.0-SNAPSHOT.jar.asc
```
