### PR TITLE
CDAP-4674 fix Javascript widget name, to get JS editor

### DIFF
--- a/core-plugins/widgets/JavaScript-transform.json
+++ b/core-plugins/widgets/JavaScript-transform.json
@@ -8,7 +8,7 @@
         {
           "widget-type": "javascript-editor",
           "label": "JavaScript",
-          "name": "JavaScript",
+          "name": "script",
           "widget-attributes": {
             "default": "function transform(input, emitter, context) {\n  emitter.emit(input);\n}"
           }


### PR DESCRIPTION
Had incorrect widget name, so we weren't getting JS editor. 
JIRA : https://issues.cask.co/browse/CDAP-4674
