### PR TITLE
fixing build by adding test dependency on hadoop-common:tests.

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -175,6 +175,13 @@
       <version>2.3.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <classifier>tests</classifier>
+      <version>${hadoop.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
For some reason, ony some machines, this dependency wasn't getting
pulled in, so just declaring it explicitly.
