### PR TITLE
CDAP-4143 handle semicolons at the end of a query.

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
@@ -65,6 +65,17 @@ public class DBConfig extends PluginConfig {
 
   protected String cleanQuery(String query) {
     query = query.trim();
-    return query.endsWith(";") ? query.substring(0, query.length() - 1) : query;
+    // find the last character that is not whitespace or a semicolon
+    int idx = query.length() - 1;
+    char currChar = query.charAt(idx);
+    while (idx > 0 && currChar == ';' || Character.isWhitespace(currChar)) {
+      idx--;
+      currChar = query.charAt(idx);
+    }
+    // why would somebody do this?
+    if (idx == 0) {
+      return "";
+    }
+    return query.substring(0, idx + 1);
   }
 }

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
@@ -62,4 +62,9 @@ public class DBConfig extends PluginConfig {
   public DBConfig() {
     jdbcPluginType = "jdbc";
   }
+
+  protected String cleanQuery(String query) {
+    query = query.trim();
+    return query.endsWith(";") ? query.substring(0, query.length() - 1) : query;
+  }
 }

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/teradata/batch/source/TeradataSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/teradata/batch/source/TeradataSource.java
@@ -54,14 +54,6 @@ import java.sql.Driver;
 public class TeradataSource extends BatchSource<LongWritable, DBRecord, StructuredRecord> {
   private static final Logger LOG = LoggerFactory.getLogger(TeradataSource.class);
 
-  private static final String IMPORT_QUERY_DESCRIPTION = "The SELECT query to use to import data from the specified " +
-    "table. You can specify an arbitrary number of columns to import, or import all columns using *. The Query should" +
-    "contain the '$CONDITIONS' string. For example, 'SELECT * FROM table WHERE $CONDITIONS'. The '$CONDITIONS' string" +
-    "will be replaced by 'splitBy' field limits specified by the bounding query.";
-  private static final String BOUNDING_QUERY_DESCRIPTION = "Bounding Query should return the min and max of the " +
-    "values of the 'splitBy' field. For example, 'SELECT MIN(id),MAX(id) FROM table'";
-  private static final String SPLIT_FIELD_DESCRIPTION = "Field Name which will be used to generate splits.";
-
   private final TeradataSourceConfig sourceConfig;
   private final DBManager dbManager;
   private Class<? extends Driver> driverClass;
@@ -74,8 +66,9 @@ public class TeradataSource extends BatchSource<LongWritable, DBRecord, Structur
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     dbManager.validateJDBCPluginPipeline(pipelineConfigurer, getJDBCPluginId());
-    Preconditions.checkArgument(sourceConfig.importQuery.contains("$CONDITIONS"), "Import Query %s must contain the " +
-      "string '$CONDITIONS'.", sourceConfig.importQuery);
+    Preconditions.checkArgument(sourceConfig.getImportQuery().contains("$CONDITIONS"),
+                                "Import Query %s must contain the string '$CONDITIONS'.",
+                                sourceConfig.importQuery);
   }
 
   @Override
@@ -83,7 +76,7 @@ public class TeradataSource extends BatchSource<LongWritable, DBRecord, Structur
     LOG.debug("pluginType = {}; pluginName = {}; connectionString = {}; importQuery = {}; " +
                 "boundingQuery = {}",
               sourceConfig.jdbcPluginType, sourceConfig.jdbcPluginName,
-              sourceConfig.connectionString, sourceConfig.importQuery, sourceConfig.boundingQuery);
+              sourceConfig.connectionString, sourceConfig.getImportQuery(), sourceConfig.getBoundingQuery());
 
     Job job = Job.getInstance();
     Configuration hConf = job.getConfiguration();
@@ -106,7 +99,8 @@ public class TeradataSource extends BatchSource<LongWritable, DBRecord, Structur
       DBConfiguration.configureDB(hConf, driverClass.getName(), sourceConfig.connectionString,
                                   sourceConfig.user, sourceConfig.password);
     }
-    DataDrivenETLDBInputFormat.setInput(job, DBRecord.class, sourceConfig.importQuery, sourceConfig.boundingQuery);
+    DataDrivenETLDBInputFormat.setInput(job, DBRecord.class,
+                                        sourceConfig.getImportQuery(), sourceConfig.getBoundingQuery());
     job.getConfiguration().set(DBConfiguration.INPUT_ORDER_BY_PROPERTY, sourceConfig.splitBy);
     context.setInput(new SourceInputFormatProvider(DataDrivenETLDBInputFormat.class, hConf));
   }
@@ -143,15 +137,28 @@ public class TeradataSource extends BatchSource<LongWritable, DBRecord, Structur
     public static final String BOUNDING_QUERY = "boundingQuery";
     public static final String SPLIT_BY = "splitBy";
 
-    @Description(IMPORT_QUERY_DESCRIPTION)
+    @Description("The SELECT query to use to import data from the specified table. " +
+      "You can specify an arbitrary number of columns to import, or import all columns using *. " +
+      "The Query should contain the '$CONDITIONS' string. " +
+      "For example, 'SELECT * FROM table WHERE $CONDITIONS'. The '$CONDITIONS' string" +
+      "will be replaced by 'splitBy' field limits specified by the bounding query.")
     String importQuery;
 
     @Name(BOUNDING_QUERY)
-    @Description(BOUNDING_QUERY_DESCRIPTION)
+    @Description("Bounding Query should return the min and max of the " +
+      "values of the 'splitBy' field. For example, 'SELECT MIN(id),MAX(id) FROM table'")
     String boundingQuery;
 
     @Name(SPLIT_BY)
-    @Description(SPLIT_FIELD_DESCRIPTION)
+    @Description("Field Name which will be used to generate splits.")
     String splitBy;
+
+    private String getImportQuery() {
+      return cleanQuery(importQuery);
+    }
+
+    private String getBoundingQuery() {
+      return cleanQuery(boundingQuery);
+    }
   }
 }

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/DBConfigTest.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/DBConfigTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class DBConfigTest {
+
+  @Test
+  public void testQueryClean() {
+    TestDBConfig config = new TestDBConfig("select * from table; ");
+    Assert.assertEquals("select * from table", config.query);
+  }
+
+  /**
+   * Test config.
+   */
+  private static class TestDBConfig extends DBConfig {
+    private String query;
+
+    public TestDBConfig(String query) {
+      this.query = cleanQuery(query);
+    }
+  }
+}

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/DBConfigTest.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/DBConfigTest.java
@@ -20,13 +20,24 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
+ * Tests for the db config.
  */
 public class DBConfigTest {
 
   @Test
   public void testQueryClean() {
-    TestDBConfig config = new TestDBConfig("select * from table; ");
+    TestDBConfig config = new TestDBConfig("select * from table; ; ;; ;;; ;");
     Assert.assertEquals("select * from table", config.query);
+    config = new TestDBConfig("select * from table;");
+    Assert.assertEquals("select * from table", config.query);
+    config = new TestDBConfig("select * from table");
+    Assert.assertEquals("select * from table", config.query);
+  }
+
+  @Test
+  public void testCleanDumbQuery() {
+    TestDBConfig config = new TestDBConfig("; ; ;; ;;; ;");
+    Assert.assertEquals("", config.query);
   }
 
   /**

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/BatchETLDBTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/BatchETLDBTestRun.java
@@ -64,8 +64,8 @@ public class BatchETLDBTestRun extends DatabasePluginTestBase {
   public void testDBSource() throws Exception {
     String importQuery = "SELECT ID, NAME, SCORE, GRADUATED, TINY, SMALL, BIG, FLOAT_COL, REAL_COL, NUMERIC_COL, " +
       "DECIMAL_COL, BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, BLOB_COL, CLOB_COL FROM \"my_table\"" +
-      "WHERE ID < 3";
-    String countQuery = "SELECT COUNT(ID) from \"my_table\" WHERE id < 3";
+      "WHERE ID < 3;";
+    String countQuery = "SELECT COUNT(ID) from \"my_table\" WHERE id < 3; ";
     Plugin sourceConfig = new Plugin(
       "Database",
       ImmutableMap.<String, String>builder()


### PR DESCRIPTION
We have noticed that many users put a semicolon at the end of the
query. The db input formats don't work in such cases, which is
not very friendly. So check for semicolon and strip it if it exists.
