### PR TITLE
CDAP-3749 db user does not require a password

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBManager.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBManager.java
@@ -47,9 +47,6 @@ public class DBManager implements Destroyable {
     Preconditions.checkArgument(!(dbConfig.user == null && dbConfig.password != null),
                                 "user is null. Please provide both user name and password if database requires " +
                                   "authentication. If not, please remove password and retry.");
-    Preconditions.checkArgument(!(dbConfig.user != null && dbConfig.password == null),
-                                "password is null. Please provide both user name and password if database requires" +
-                                  "authentication. If not, please remove dbUser and retry.");
     Class<? extends Driver> jdbcDriverClass = pipelineConfigurer.usePluginClass(dbConfig.jdbcPluginType,
                                                                                 dbConfig.jdbcPluginName,
                                                                                 jdbcPluginId,

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/BatchETLDBTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/BatchETLDBTestRun.java
@@ -356,7 +356,18 @@ public class BatchETLDBTestRun extends DatabasePluginTestBase {
       .addConnection(database.getName(), table.getName())
       .build();
     appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    TestBase.deployApplication(appId, appRequest);
+    deployApplication(appId, appRequest);
+    // as sink
+    nullPassword = new HashMap<>(baseSinkProps);
+    nullPassword.put(Properties.DB.USER, "emptyPwdUser");
+    database = new ETLStage("databaseSink", new Plugin("Database", nullPassword));
+    etlConfig = ETLBatchConfig.builder("* * * * *")
+      .setSource(table)
+      .addSink(database)
+      .addConnection(table.getName(), database.getName())
+      .build();
+    appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    deployApplication(appId, appRequest);
   }
 
   @Test

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/teradata/test/TeradataPluginTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/teradata/test/TeradataPluginTestRun.java
@@ -304,15 +304,6 @@ public class TeradataPluginTestRun extends DatabasePluginTestBase {
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
     deployApplication(appId, appRequest);
 
-    // non null user name, null password. Should fail.
-    // as source
-    Map<String, String> noPassword = new HashMap<>(baseSourceProps);
-    noPassword.put(Properties.DB.USER, "emptyPwdUser");
-    database = new ETLStage("databaseSource", new Plugin("Teradata", noPassword));
-    etlConfig = new ETLBatchConfig("* * * * *", database, table, transforms);
-    assertDeploymentFailure(
-      appId, etlConfig, "Deploying DB Source with non-null username but null password should have failed.");
-
     // null user name, non-null password. Should fail.
     // as source
     Map<String, String> noUser = new HashMap<>(baseSourceProps);


### PR DESCRIPTION
Fix the database plugins so that specifying a user does not
require also specifying a password. It is completely valid,
though perhaps a bad idea, for a user to have no password.
