### PR TITLE
CDAP-5037 setting to cleanup old partitions after successful runs

### DIFF
--- a/core-plugins/docs/TPFSAvro-batchsink.md
+++ b/core-plugins/docs/TPFSAvro-batchsink.md
@@ -31,6 +31,17 @@ Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``.
 **timeZone:** The string ID for the time zone to format the date in. Defaults to using UTC.
 This setting is only used if ``filePathFormat`` is not null.
 
+**partitionOffset:** Amount of time to subtract from the pipeline runtime to get the output partition. Defaults to 0m.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit,
+with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
+For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015."
+
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete old partitions older after successful runs.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any partitions older than that.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
+'m' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
 
 Example
 -------

--- a/core-plugins/docs/TPFSAvro-batchsink.md
+++ b/core-plugins/docs/TPFSAvro-batchsink.md
@@ -31,14 +31,14 @@ Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``.
 **timeZone:** The string ID for the time zone to format the date in. Defaults to using UTC.
 This setting is only used if ``filePathFormat`` is not null.
 
-**partitionOffset:** Amount of time to subtract from the pipeline runtime to get the output partition. Defaults to 0m.
+**partitionOffset:** Amount of time to subtract from the pipeline runtime to determine the output partition. Defaults to 0m.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit,
 with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
 For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
 and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015."
 
-**cleanPartitionsOlderThan:** Optional property that configures the sink to delete old partitions older after successful runs.
-If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any partitions older than that.
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
 and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.

--- a/core-plugins/docs/TPFSParquet-batchsink.md
+++ b/core-plugins/docs/TPFSParquet-batchsink.md
@@ -31,6 +31,18 @@ Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``.
 **timeZone:** The string ID for the time zone to format the date in. Defaults to using UTC.
 This setting is only used if ``filePathFormat`` is not null.
 
+**partitionOffset:** Amount of time to subtract from the pipeline runtime to get the output partition. Defaults to 0m.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit,
+with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
+For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015."
+
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete old partitions older after successful runs.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any partitions older than that.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
+'m' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+
 
 Example
 -------

--- a/core-plugins/docs/TPFSParquet-batchsink.md
+++ b/core-plugins/docs/TPFSParquet-batchsink.md
@@ -31,14 +31,14 @@ Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``.
 **timeZone:** The string ID for the time zone to format the date in. Defaults to using UTC.
 This setting is only used if ``filePathFormat`` is not null.
 
-**partitionOffset:** Amount of time to subtract from the pipeline runtime to get the output partition. Defaults to 0m.
+**partitionOffset:** Amount of time to subtract from the pipeline runtime to determine the output partition. Defaults to 0m.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit,
 with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
 For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
 and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015."
 
-**cleanPartitionsOlderThan:** Optional property that configures the sink to delete old partitions older after successful runs.
-If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any partitions older than that.
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any partitions for time partitions older than that.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
 and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TPFSSinkConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TPFSSinkConfig.java
@@ -18,7 +18,10 @@ package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.hydrator.common.ETLUtils;
+import com.google.common.base.Strings;
 
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -26,20 +29,47 @@ import javax.annotation.Nullable;
  */
 public abstract class TPFSSinkConfig extends PluginConfig {
 
-  @Description(TimePartitionedFileSetSink.TPFS_NAME_DESC)
+  @Description("Name of the Time Partitioned FileSet Dataset to which the records " +
+    "are written to. If it doesn't exist, it will be created.")
   protected String name;
 
-  @Description(TimePartitionedFileSetSink.BASE_PATH_DESC)
+  @Description("The base path for the time partitioned fileset. Defaults to the " +
+    "name of the dataset.")
   @Nullable
   protected String basePath;
 
-  @Description(TimePartitionedFileSetSink.PATH_FORMAT_DESC)
+  @Description("The format for the path; for example: " +
+    "'yyyy-MM-dd/HH-mm' will create a file path ending in the format of 2015-01-01/20-42. " +
+    "The string provided will be provided to SimpleDataFormat. " +
+    "If left blank, then the partitions will be of the form 2015-01-01/20-42.142017372000. " +
+    "Note that each partition must have a unique file path or a runtime exception will be thrown.")
   @Nullable
   protected String filePathFormat;
 
-  @Description(TimePartitionedFileSetSink.TIME_ZONE_DESC)
+  @Description("The time zone to format the partition. " +
+    "This option is only used if pathFormat is set. If blank or an invalid TimeZone ID, defaults to UTC. " +
+    "Note that the time zone provided must be recognized by TimeZone.getTimeZone(String); " +
+    "for example: \"America/Los_Angeles\"")
   @Nullable
   protected String timeZone;
+
+  @Description("Amount of time to subtract from the pipeline runtime to get the output partition. Defaults to 0m. " +
+    "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
+    "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to " +
+    "run at midnight of January 1, 2016, and the offset is set to '1d', data will be written to the partition for " +
+    "midnight Dec 31, 2015.")
+  @Nullable
+  protected String partitionOffset;
+
+  @Description("Optional property that configures the sink to delete old partitions after successful runs. " +
+    "If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and " +
+    "delete any partitions older than that time. " +
+    "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
+    "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to " +
+    "run at midnight of January 1, 2016, and this property is set to 7d, the sink will delete any partitions " +
+    "for time partitions older than midnight Dec 25, 2015.")
+  @Nullable
+  protected String cleanPartitionsOlderThan;
 
   public TPFSSinkConfig(String name, @Nullable String basePath,
                         @Nullable String filePathFormat, @Nullable String timeZone) {
@@ -47,5 +77,20 @@ public abstract class TPFSSinkConfig extends PluginConfig {
     this.basePath = basePath;
     this.filePathFormat = filePathFormat;
     this.timeZone = timeZone;
+  }
+
+  public void validate() {
+    if (!Strings.isNullOrEmpty(timeZone) && Strings.isNullOrEmpty(filePathFormat)) {
+      throw new IllegalArgumentException("The filePathFormat setting must be set in order to set timeZone.");
+    }
+    if (partitionOffset != null) {
+      ETLUtils.parseDuration(partitionOffset);
+    }
+    if (cleanPartitionsOlderThan != null) {
+      long oldTime = ETLUtils.parseDuration(cleanPartitionsOlderThan);
+      if (oldTime < TimeUnit.MINUTES.toMillis(1)) {
+        throw new IllegalArgumentException("Cannot clean partitions from less than 1 minute ago.");
+      }
+    }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TPFSSinkConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TPFSSinkConfig.java
@@ -33,31 +33,31 @@ public abstract class TPFSSinkConfig extends PluginConfig {
     "are written to. If it doesn't exist, it will be created.")
   protected String name;
 
-  @Description("The base path for the time partitioned fileset. Defaults to the " +
+  @Description("The base path for the Time Partitioned FileSet. Defaults to the " +
     "name of the dataset.")
   @Nullable
   protected String basePath;
 
   @Description("The format for the path; for example: " +
-    "'yyyy-MM-dd/HH-mm' will create a file path ending in the format of 2015-01-01/20-42. " +
-    "The string provided will be provided to SimpleDataFormat. " +
-    "If left blank, then the partitions will be of the form 2015-01-01/20-42.142017372000. " +
+    "'yyyy-MM-dd/HH-mm' will create a file path ending such as '2015-01-01/20-42'. " +
+    "The string provided will be passed to SimpleDataFormat. " +
+    "If left blank, the partitions will be of the form '2015-01-01/20-42.142017372000'. " +
     "Note that each partition must have a unique file path or a runtime exception will be thrown.")
   @Nullable
   protected String filePathFormat;
 
   @Description("The time zone to format the partition. " +
-    "This option is only used if pathFormat is set. If blank or an invalid TimeZone ID, defaults to UTC. " +
+    "This option is only used if filePathFormat is set. If blank or an invalid TimeZone ID, defaults to UTC. " +
     "Note that the time zone provided must be recognized by TimeZone.getTimeZone(String); " +
     "for example: \"America/Los_Angeles\"")
   @Nullable
   protected String timeZone;
 
-  @Description("Amount of time to subtract from the pipeline runtime to get the output partition. Defaults to 0m. " +
-    "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
-    "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to " +
-    "run at midnight of January 1, 2016, and the offset is set to '1d', data will be written to the partition for " +
-    "midnight Dec 31, 2015.")
+  @Description("Amount of time to subtract from the pipeline runtime to determine the output partition. " +
+    "Defaults to 0m. The format is expected to be a number followed by an 's', 'm', 'h', or 'd' " +
+    "specifying the time unit, with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. " +
+    "For example, if the pipeline is scheduled to run at midnight of January 1, 2016, and the offset is set to '1d', " +
+    "data will be written to the partition for midnight Dec 31, 2015.")
   @Nullable
   protected String partitionOffset;
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetSink.java
@@ -17,12 +17,16 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
-import com.google.common.base.Preconditions;
+import co.cask.hydrator.common.ETLUtils;
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,20 +38,7 @@ import java.util.Map;
  */
 public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
   extends BatchSink<StructuredRecord, KEY_OUT, VAL_OUT> {
-
-  protected static final String TPFS_NAME_DESC = "Name of the Time Partitioned FileSet Dataset to which the records " +
-    "are written to. If it doesn't exist, it will be created.";
-  protected static final String BASE_PATH_DESC = "The base path for the time partitioned fileset. Defaults to the " +
-    "name of the dataset.";
-  protected static final String PATH_FORMAT_DESC = "The format for the path; for example: " +
-    "'yyyy-MM-dd/HH-mm' will create a file path ending in the format of 2015-01-01/20-42. " +
-    "The string provided will be provided to SimpleDataFormat. " +
-    "If left blank, then the partitions will be of the form 2015-01-01/20-42.142017372000. " +
-    "Note that each partition must have a unique file path or a runtime exception will be thrown.";
-  protected static final String TIME_ZONE_DESC = "The time zone to format the partition. " +
-    "This option is only used if pathFormat is set. If blank or an invalid TimeZone ID, defaults to UTC. " +
-    "Note that the time zone provided must be recognized by TimeZone.getTimeZone(String); " +
-    "for example: \"America/Los_Angeles\"";
+  private static final Logger LOG = LoggerFactory.getLogger(TimePartitionedFileSetSink.class);
 
   protected final TPFSSinkConfig tpfsSinkConfig;
 
@@ -57,15 +48,18 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tpfsSinkConfig.filePathFormat)
-                                  || Strings.isNullOrEmpty(tpfsSinkConfig.timeZone),
-                                "Set the filePathFormat to set the timezone");
+    tpfsSinkConfig.validate();
   }
 
   @Override
   public void prepareRun(BatchSinkContext context) {
     Map<String, String> sinkArgs = getAdditionalTPFSArguments();
-    TimePartitionedFileSetArguments.setOutputPartitionTime(sinkArgs, context.getLogicalStartTime());
+    long outputPartitionTime = getRuntime(context);
+    if (tpfsSinkConfig.partitionOffset != null) {
+      outputPartitionTime -= ETLUtils.parseDuration(tpfsSinkConfig.partitionOffset);
+    }
+    LOG.info("Writing to output partition of time {}.", outputPartitionTime);
+    TimePartitionedFileSetArguments.setOutputPartitionTime(sinkArgs, outputPartitionTime);
     if (!Strings.isNullOrEmpty(tpfsSinkConfig.filePathFormat)) {
       TimePartitionedFileSetArguments.setOutputPathFormat(sinkArgs, tpfsSinkConfig.filePathFormat,
                                                           tpfsSinkConfig.timeZone);
@@ -79,5 +73,25 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
    */
   protected Map<String, String> getAdditionalTPFSArguments() {
     return new HashMap<>();
+  }
+
+  private long getRuntime(BatchSinkContext context) {
+    String runtimeStr = context.getRuntimeArguments().get("runtime");
+    if (runtimeStr != null) {
+      return Long.parseLong(runtimeStr);
+    }
+    return context.getLogicalStartTime();
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, BatchSinkContext context) {
+    if (succeeded && tpfsSinkConfig.cleanPartitionsOlderThan != null) {
+      long cutoffTime = getRuntime(context) - ETLUtils.parseDuration(tpfsSinkConfig.cleanPartitionsOlderThan);
+      TimePartitionedFileSet tpfs = context.getDataset(tpfsSinkConfig.name);
+      for (TimePartitionDetail timePartitionDetail : tpfs.getPartitionsByTime(0, cutoffTime)) {
+        LOG.info("Cleaning up old partition for timestamp {}", timePartitionDetail.getTime());
+        tpfs.dropPartition(timePartitionDetail.getTime());
+      }
+    }
   }
 }

--- a/core-plugins/widgets/TPFSAvro-batchsink.json
+++ b/core-plugins/widgets/TPFSAvro-batchsink.json
@@ -25,6 +25,16 @@
           "widget-type": "textbox",
           "label": "Time Zone",
           "name": "timeZone"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Partition Offset",
+          "name": "partitionOffset"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Clean Partitions Older Than",
+          "name": "cleanPartitionsOlderThan"
         }
       ]
     }

--- a/core-plugins/widgets/TPFSParquet-batchsink.json
+++ b/core-plugins/widgets/TPFSParquet-batchsink.json
@@ -25,6 +25,16 @@
           "widget-type": "textbox",
           "label": "Time Zone",
           "name": "timeZone"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Partition Offset",
+          "name": "partitionOffset"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Clean Partitions Older Than",
+          "name": "cleanPartitionsOlderThan"
         }
       ]
     }


### PR DESCRIPTION
Adding a setting to TPFS sinks to clean up old partitions after
successful runs. This allows users to limit the size of their
dataset instead of letting it grow infinitely.
