### PR TITLE
getSchema and listTables plugin endpoint implementations in DBSource

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBUtils.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBUtils.java
@@ -16,6 +16,10 @@
 
 package co.cask.hydrator.plugin;
 
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,8 +28,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.sql.Driver;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.Hashtable;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MBeanRegistrationException;
@@ -55,6 +64,122 @@ public final class DBUtils {
     }
     shutDownMySQLAbandonedConnectionCleanupThread(pluginClassLoader);
     unregisterOracleMBean(pluginClassLoader);
+  }
+
+  /**
+   * Ensures that the JDBC Driver specified in configuration is available and can be loaded. Also registers it with
+   * {@link DriverManager} if it is not already registered.
+   */
+  public static DriverCleanup ensureJDBCDriverIsAvailable(Class<? extends Driver> jdbcDriverClass,
+                                                          String connectionString,
+                                                          String jdbcPluginType, String jdbcPluginName)
+    throws IllegalAccessException, InstantiationException, SQLException {
+
+    try {
+      DriverManager.getDriver(connectionString);
+      return new DriverCleanup(null);
+    } catch (SQLException e) {
+      // Driver not found. We will try to register it with the DriverManager.
+      LOG.debug("Plugin Type: {} and Plugin Name: {}; Driver Class: {} not found. Registering JDBC driver via shim {} ",
+                jdbcPluginType, jdbcPluginName, jdbcDriverClass.getName(),
+                JDBCDriverShim.class.getName());
+      final JDBCDriverShim driverShim = new JDBCDriverShim(jdbcDriverClass.newInstance());
+      try {
+        DBUtils.deregisterAllDrivers(jdbcDriverClass);
+      } catch (NoSuchFieldException | ClassNotFoundException e1) {
+        LOG.error("Unable to deregister JDBC Driver class {}", jdbcDriverClass);
+      }
+      DriverManager.registerDriver(driverShim);
+      return new DriverCleanup(driverShim);
+    }
+  }
+
+  /**
+   * Given the result set, get the metadata of the result set and return
+   * list of {@link co.cask.cdap.api.data.schema.Schema.Field},
+   * where name of the field is same as column name and type of the field is obtained using {@link DBUtils#getType(int)}
+   * @param resultSet result set of executed query
+   * @return list of schema fields
+   * @throws SQLException
+   */
+  public static List<Schema.Field> getSchemaFields(ResultSet resultSet) throws SQLException {
+    List<Schema.Field> schemaFields = Lists.newArrayList();
+    ResultSetMetaData metadata = resultSet.getMetaData();
+    // ResultSetMetadata columns are numbered starting with 1
+    for (int i = 1; i <= metadata.getColumnCount(); i++) {
+      String columnName = metadata.getColumnName(i);
+      int columnSqlType = metadata.getColumnType(i);
+      Schema columnSchema = Schema.of(getType(columnSqlType));
+      if (ResultSetMetaData.columnNullable == metadata.isNullable(i)) {
+        columnSchema = Schema.nullableOf(columnSchema);
+      }
+      Schema.Field field = Schema.Field.of(columnName, columnSchema);
+      schemaFields.add(field);
+    }
+    return schemaFields;
+  }
+
+  // given a sql type return schema type
+  private static Schema.Type getType(int sqlType) throws SQLException {
+    // Type.STRING covers sql types - VARCHAR,CHAR,CLOB,LONGNVARCHAR,LONGVARCHAR,NCHAR,NCLOB,NVARCHAR
+    Schema.Type type = Schema.Type.STRING;
+    switch (sqlType) {
+      case Types.NULL:
+        type = Schema.Type.NULL;
+        break;
+
+      case Types.BOOLEAN:
+      case Types.BIT:
+        type = Schema.Type.BOOLEAN;
+        break;
+
+      case Types.TINYINT:
+      case Types.SMALLINT:
+      case Types.INTEGER:
+        type = Schema.Type.INT;
+        break;
+
+      case Types.BIGINT:
+        type = Schema.Type.LONG;
+        break;
+
+      case Types.REAL:
+      case Types.FLOAT:
+        type = Schema.Type.FLOAT;
+        break;
+
+      case Types.NUMERIC:
+      case Types.DECIMAL:
+      case Types.DOUBLE:
+        type = Schema.Type.DOUBLE;
+        break;
+
+      case Types.DATE:
+      case Types.TIME:
+      case Types.TIMESTAMP:
+        type = Schema.Type.LONG;
+        break;
+
+      case Types.BINARY:
+      case Types.VARBINARY:
+      case Types.LONGVARBINARY:
+      case Types.BLOB:
+        type = Schema.Type.BYTES;
+        break;
+
+      case Types.ARRAY:
+      case Types.DATALINK:
+      case Types.DISTINCT:
+      case Types.JAVA_OBJECT:
+      case Types.OTHER:
+      case Types.REF:
+      case Types.ROWID:
+      case Types.SQLXML:
+      case Types.STRUCT:
+        throw new SQLException(new UnsupportedTypeException("Unsupported SQL Type: " + sqlType));
+    }
+
+    return type;
   }
 
   /**

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DriverCleanup.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DriverCleanup.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.etl.api.Destroyable;
+import com.google.common.base.Throwables;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+
+/**
+ * class to de-register driver
+ */
+public class DriverCleanup implements Destroyable {
+  private final JDBCDriverShim driverShim;
+
+  DriverCleanup(@Nullable JDBCDriverShim driverShim) {
+    this.driverShim = driverShim;
+  }
+
+  public void destroy() {
+    if (driverShim != null) {
+      try {
+        DriverManager.deregisterDriver(driverShim);
+      } catch (SQLException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+}

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -20,8 +20,11 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.plugin.EndpointPluginContext;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
@@ -32,6 +35,7 @@ import co.cask.hydrator.plugin.DBConfig;
 import co.cask.hydrator.plugin.DBManager;
 import co.cask.hydrator.plugin.DBRecord;
 import co.cask.hydrator.plugin.DBUtils;
+import co.cask.hydrator.plugin.DriverCleanup;
 import co.cask.hydrator.plugin.FieldCase;
 import co.cask.hydrator.plugin.StructuredRecordUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -41,7 +45,16 @@ import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
 import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
+import java.sql.Statement;
+import javax.annotation.Nullable;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Path;
 
 /**
  * Batch source to read from a Database table
@@ -64,6 +77,72 @@ public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredReco
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     dbManager.validateJDBCPluginPipeline(pipelineConfigurer, getJDBCPluginId());
+  }
+
+  class GetSchemaRequest {
+    public String connectionString;
+    @Nullable
+    public String user;
+    @Nullable
+    public String password;
+    public String jdbcPluginName;
+    @Nullable
+    public String jdbcPluginType = "jdbc";
+    public String query;
+  }
+
+  /**
+   * Endpoint method to get the output schema of a query.
+   *
+   * @param request {@link GetSchemaRequest} containing information required for connection and query to execute.
+   * @param pluginContext context to create plugins
+   * @return schema of fields
+   * @throws SQLException
+   * @throws InstantiationException
+   * @throws IllegalAccessException
+   * @throws BadRequestException If executing the query threw {@link SQLSyntaxErrorException}
+   * we get the message and throw it as BadRequestException
+   */
+  @Path("getSchema")
+  public Schema getSchema(GetSchemaRequest request,
+                          EndpointPluginContext pluginContext)
+    throws SQLException, InstantiationException, IllegalAccessException, BadRequestException {
+    DriverCleanup driverCleanup = loadPluginClassAndGetDriver(request, pluginContext);
+    try {
+      try (Connection connection = getConnection(request.connectionString, request.user, request.password)) {
+        Statement statement = connection.createStatement();
+        statement.setMaxRows(1);
+        ResultSet resultSet = statement.executeQuery(request.query);
+        return Schema.recordOf("outputSchema", DBUtils.getSchemaFields(resultSet));
+      }
+    } catch (SQLSyntaxErrorException e) {
+      throw new BadRequestException(e.getMessage());
+    } finally {
+      driverCleanup.destroy();
+    }
+  }
+
+  private DriverCleanup loadPluginClassAndGetDriver(GetSchemaRequest request, EndpointPluginContext pluginContext)
+    throws IllegalAccessException, InstantiationException, SQLException {
+    Class<? extends Driver> driverClass =
+      pluginContext.loadPluginClass(request.jdbcPluginType, request.jdbcPluginName, PluginProperties.builder().build());
+
+    try {
+      return DBUtils.ensureJDBCDriverIsAvailable(driverClass, request.connectionString,
+                                                 request.jdbcPluginType, request.jdbcPluginName);
+    } catch (IllegalAccessException | InstantiationException | SQLException e) {
+      LOG.error("Unable to load or register driver {}", driverClass, e);
+      throw e;
+    }
+  }
+
+  private Connection getConnection(String connectionString,
+                                   @Nullable String user, @Nullable String password) throws SQLException {
+    if (user == null) {
+      return DriverManager.getConnection(connectionString);
+    } else {
+      return DriverManager.getConnection(connectionString, user, password);
+    }
   }
 
   @Override


### PR DESCRIPTION
Implementing listTables and getSchema endpoints in dbsource. 

REST call for this plugin method would look like,
`curl -v -X POST "<hostname>:10000/v3/namespaces/default/artifacts/database-plugins/versions/1.3.0-SNAPSHOT/plugintypes/batchsource/plugins/Database/methods/listTables?scope=system"  -d @dbconfig.json`

JIRA : https://issues.cask.co/browse/CDAP-5153
Blocked by : https://github.com/caskdata/cdap/pull/5264
