### PR TITLE
Cube widget improvements

### DIFF
--- a/core-plugins/docs/Cube-batchsink.md
+++ b/core-plugins/docs/Cube-batchsink.md
@@ -27,14 +27,15 @@ Properties
 **dataset.cube.resolutions:** Aggregation resolutions to be used if a
 new Cube dataset needs to be created. See [Cube dataset configuration details] for more information.
 
-**dataset.cube.properties:** Provides any dataset properties to be used
-if a new Cube dataset needs to be created; provided as a JSON Map. For
-example, if aggregations are desired on fields ``'abc'`` and ``'xyz'``, the
-property should have the value:
-``{"dataset.cube.aggregation.agg1.dimensions":"abc", "dataset.cube.aggregation.agg2.dimensions":"xyz"}``.
+**dataset.cube.aggregations:** Provides cube aggregation dataset properties to be used
+if a new Cube dataset needs to be created; provided as a collection of aggregation-groups.
+Each aggregation group is identified by a unique name and value is a collection of fields.
+example, if aggregations are desired on fields ``abc`` and ``xyz``, the
+property can have the key ``agg1`` and value ``abc,xyz``:
 See [Cube dataset configuration details] for more information.
+[Cube dataset configuration details]: http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html
 
-  [Cube dataset configuration details]: http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html
+**dataset.cube.properties:** Provides additional cube dataset properties if needed.
 
 **cubeFact.timestamp.field:** Name of the StructuredRecord field that contains the
 timestamp to be used in the CubeFact. If not provided, the current time of the record
@@ -47,10 +48,11 @@ If not provided, the current time of the record processing will be used as a Cub
 ``cubeFact.timestamp.field`` is provided).
 
 **cubeFact.measurements:** Measurements to be extracted from StructuredRecord to be used
-in CubeFact. Provide properties as a JSON Map. For example, to use the 'price' field as a
-measurement of type gauge, and the 'quantity' field as a measurement of type counter, the
-property should have the value: ``{"cubeFact.measurement.price":"GAUGE",
-"cubeFact.measurement.quantity":"COUNTER"}``.
+in CubeFact. Supports collection of measurements and requires at least one measurement to be provided.
+Each measurement has measurement-name and measurement-type. Currently supported measurement types are COUNTER, GAUGE.
+For example, to use the 'price' field as a
+measurement of type gauge, and the 'quantity' field as a measurement of type counter, you would add two measurements
+one measurement with name `price` and type `GAUGE, second measurement with name `quantity` and type `COUNTER`.
 
 
 Example

--- a/core-plugins/docs/Cube-realtimesink.md
+++ b/core-plugins/docs/Cube-realtimesink.md
@@ -26,14 +26,15 @@ Properties
 **dataset.cube.resolutions:** Aggregation resolutions to be used if a
 new Cube dataset needs to be created. See [Cube dataset configuration details] for more information.
 
-**dataset.cube.properties:** Provides any dataset properties to be used
-if a new Cube dataset needs to be created; provided as a JSON Map. For
-example, if aggregations are desired on fields ``'abc'`` and ``'xyz'``, the
-property should have the value:
-``{"dataset.cube.aggregation.agg1.dimensions":"abc", "dataset.cube.aggregation.agg2.dimensions":"xyz"}``.
+**dataset.cube.aggregations:** Provides cube aggregation dataset properties to be used
+if a new Cube dataset needs to be created; provided as a collection of aggregation-groups.
+Each aggregation group is identified by a unique name and value is a collection of fields.
+example, if aggregations are desired on fields ``abc`` and ``xyz``, the
+property can have the key ``agg1`` and value ``abc,xyz``:
 See [Cube dataset configuration details] for more information.
+[Cube dataset configuration details]: http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html
 
-  [Cube dataset configuration details]: http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html
+**dataset.cube.properties:** Provides additional cube dataset properties if needed.
 
 **cubeFact.timestamp.field:** Name of the StructuredRecord field that contains the timestamp to be used in
 the CubeFact. If not provided, the current time of the record processing will be used as the CubeFact timestamp.
@@ -41,10 +42,12 @@ the CubeFact. If not provided, the current time of the record processing will be
 **cubeFact.timestamp.format:** Format of the value of timestamp field; example: "HH:mm:ss" (used if
 ``cubeFact.timestamp.field`` is provided).
 
-**cubeFact.measurements:** Measurements to be extracted from the StructuredRecord to be used in the CubeFact.
-Provide properties as a JSON Map. For example, to use the 'price' field as a measurement of type ``gauge``,
-and the 'quantity' field as a measurement of type ``counter``, the property should have the value
-``{"cubeFact.measurement.price":"GAUGE", "cubeFact.measurement.quantity":"COUNTER"}``.
+**cubeFact.measurements:** Measurements to be extracted from StructuredRecord to be used
+in CubeFact. Supports collection of measurements and requires at least one measurement to be provided.
+Each measurement has measurement-name and measurement-type. Currently supported measurement types are COUNTER, GAUGE.
+For example, to use the 'price' field as a
+measurement of type gauge, and the 'quantity' field as a measurement of type counter, you would add two measurements
+one measurement with name `price` and type `GAUGE, second measurement with name `quantity` and type `COUNTER`.
 
 
 Example

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeSinkConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeSinkConfig.java
@@ -37,14 +37,20 @@ public class CubeSinkConfig extends PluginConfig {
   @Nullable
   String resolutions;
 
+  @Name(Properties.Cube.AGGREGATIONS)
+  @Description("Provided as a collection of aggregation-groups. " +
+    "Each aggregation group is identified by a unique name and value is a collection of fields. " +
+    "Example, if aggregations are desired on fields 'abc' and 'xyz', " +
+    "the property can have aggregation group with one entry, with entry's key 'agg1' and " +
+    "value 'abc,xyz'. the fields are comma separated, key and value are delimited by ':' and " +
+    "the entries are delimited by ';'. See [Cube dataset configuration details] for more information. " +
+    "[Cube dataset configuration details]: " +
+    "http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html")
+  @Nullable
+  String aggregations;
+
   @Name(Properties.Cube.DATASET_OTHER)
-  @Description("Provides any dataset properties to be used if a new Cube dataset needs to be created; " +
-    "provided as a JSON Map. For example, if aggregations are desired on fields 'abc' and 'xyz', " +
-    "the property should have the value: " +
-    "\"{\"dataset.cube.aggregation.agg1.dimensions\":\"abc\", \"dataset.cube.aggregation.agg2.dimensions\":\"xyz\"}. " +
-    "See Cube dataset configuration details available at " +
-    "http://docs.cask.co/cdap/current/en/developers-manual/building-blocks/datasets/cube.html#cube-configuration " +
-    "for more information.")
+  @Description("Extra dataset properties to be included")
   @Nullable
   String datasetOther;
 
@@ -61,18 +67,21 @@ public class CubeSinkConfig extends PluginConfig {
   String tsFormat;
 
   @Name(Properties.Cube.MEASUREMENTS)
-  @Description("Measurements to be extracted from StructuredRecord to be " +
-    "used in CubeFact. Provide properties as a JSON Map. For example, to use the 'price' field as a measurement of " +
-    "type gauge, and the 'count' field as a measurement of type counter, the property should have the value: " +
-    "\"{\"cubeFact.measurement.price\":\"GAUGE\", \"cubeFact.measurement.count\":\"COUNTER\"}.")
-  @Nullable
+  @Description("Measurements to be extracted from StructuredRecord to be used" +
+    "in CubeFact. Supports collection of measurements and requires at least one measurement to be provided." +
+    "Each measurement has measurement-name and measurement-type. " +
+    "Currently supported measurement types are COUNTER, GAUGE." +
+    "For example, to use the 'price' field as a measurement of type gauge, and the '" +
+    "quantity' field as a measurement of type counter, property will have two measurements. " +
+    "one measurement with name 'price' and type 'GAUGE', second measurement with name 'quantity' and type 'COUNTER'. " +
+    "the key and value are delimited by ':' while the entries are delimited by ';'")
   String measurements;
 
-  public CubeSinkConfig(String name, String resolutions, String datasetOther,
+  public CubeSinkConfig(String name, String resolutions, String aggregations,
                         String tsField, String tsFormat, String measurements) {
     this.name = name;
     this.resolutions = resolutions;
-    this.datasetOther = datasetOther;
+    this.aggregations = aggregations;
     this.tsField = tsField;
     this.tsFormat = tsFormat;
     this.measurements = measurements;
@@ -88,8 +97,8 @@ public class CubeSinkConfig extends PluginConfig {
   }
 
   @Nullable
-  public String getDatasetOther() {
-    return datasetOther;
+  public String getAggregations() {
+    return aggregations;
   }
 
   @Nullable

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeUtils.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.hydrator.plugin.common;
+
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for usage by batch and real-time cube sinks.
+ */
+public final class CubeUtils {
+
+  private CubeUtils() {
+    throw new AssertionError("Should not instantiate static utility class.");
+  }
+
+  public static Map<String, String> parseAndGetProperties(String property, String propertyValue, String delimiter,
+                                                          String fieldDelimiter, Function<String, String> keyFunction) {
+    Map<String, String> result = new HashMap<>();
+    List<String> fieldGroups = Arrays.asList(propertyValue.split(delimiter));
+    for (String group : fieldGroups) {
+      String[] split = group.split(fieldDelimiter);
+      if (split.length != 2) {
+        //should not happen
+        throw new IllegalArgumentException(
+          String.format("For Property {} Parameter {} , name or value is empty, please check config", property, group));
+      }
+      if (Strings.isNullOrEmpty(split[0])) {
+        throw new IllegalArgumentException(
+          String.format("Empty key/value is not allowed in {}", property));
+      }
+      if (Strings.isNullOrEmpty(split[1])) {
+        throw new IllegalArgumentException(
+          String.format("Empty key/value is not allowed in {}", property));
+      }
+      result.put(keyFunction.apply(split[0]), split[1]);
+    }
+    return result;
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/Properties.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/Properties.java
@@ -109,6 +109,7 @@ public final class Properties {
     public static final String DATASET_RESOLUTIONS =
       co.cask.cdap.api.dataset.lib.cube.Cube.PROPERTY_RESOLUTIONS;
     public static final String DATASET_OTHER = "dataset.cube.properties";
+    public static final String AGGREGATIONS = "dataset.cube.aggregations";
 
     public static final String FACT_TS_FIELD = "cubeFact.timestamp.field";
     public static final String FACT_TS_FORMAT = "cubeFact.timestamp.format";

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredRecordToCubeFact.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredRecordToCubeFact.java
@@ -25,10 +25,7 @@ import co.cask.cdap.api.dataset.lib.cube.Measurement;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
-import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -66,9 +63,6 @@ import javax.annotation.Nullable;
 </pre>
  */
 public class StructuredRecordToCubeFact {
-  private static final Gson GSON = new Gson();
-  private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
-
   private final CubeFactBuilder factBuilder;
 
   public StructuredRecordToCubeFact(Map<String, String> properties) {
@@ -89,7 +83,6 @@ public class StructuredRecordToCubeFact {
       Map<String, String> props = new HashMap<>(properties);
       this.timestampResolver = new TimestampResolver(props);
       this.measurementResolvers = Lists.newArrayList();
-      addMeasurementsFromProperty(props);
       for (Map.Entry<String, String> property : props.entrySet()) {
         if (property.getKey().startsWith(Properties.Cube.MEASUREMENT_PREFIX)) {
           measurementResolvers.add(new MeasurementResolver(property.getKey(), property.getValue()));
@@ -99,14 +92,6 @@ public class StructuredRecordToCubeFact {
         throw new IllegalArgumentException("At least one measurement must be specified with " +
                                              Properties.Cube.MEASUREMENT_PREFIX +
                                              "<measurement_name>=<measurement_type>");
-      }
-    }
-
-    // todo: workaround for CDAP-2944: allows specifying custom props via JSON map in a property value
-    private void addMeasurementsFromProperty(Map<String, String> props) {
-      if (props.containsKey(Properties.Cube.MEASUREMENTS)) {
-        Map<String, String> measurements = GSON.fromJson(props.get(Properties.Cube.MEASUREMENTS), STRING_MAP_TYPE);
-        props.putAll(measurements);
       }
     }
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/BatchPluginsTestSuite.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/BatchPluginsTestSuite.java
@@ -26,7 +26,6 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-  BatchCubeSinkTestRun.class,
   ETLSnapshotTestRun.class,
   ETLStreamConversionTestRun.class,
   ETLTPFSTestRun.class,

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/realtime/RealtimeCubeSinkTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/realtime/RealtimeCubeSinkTest.java
@@ -61,16 +61,13 @@ public class RealtimeCubeSinkTest extends ETLRealtimeTestBase {
                                ImmutableMap.of(DataGeneratorSource.PROPERTY_TYPE,
                                                DataGeneratorSource.TABLE_TYPE));
     // single aggregation
-    Map<String, String> datasetProps = ImmutableMap.of(
-      CubeDatasetDefinition.PROPERTY_AGGREGATION_PREFIX + "byName.dimensions", "name"
-    );
-    Map<String, String> measurementsProps = ImmutableMap.of(
-      Properties.Cube.MEASUREMENT_PREFIX + "score", "GAUGE"
-    );
+    String aggregationGroup = "byName:name";
+    String measurement = "score:GAUGE";
+
     Plugin sink = new Plugin("Cube",
                              ImmutableMap.of(Properties.Cube.DATASET_NAME, "cube1",
-                                             Properties.Cube.DATASET_OTHER, new Gson().toJson(datasetProps),
-                                             Properties.Cube.MEASUREMENTS, new Gson().toJson(measurementsProps)));
+                                             Properties.Cube.AGGREGATIONS, aggregationGroup,
+                                             Properties.Cube.MEASUREMENTS, measurement));
     ETLRealtimeConfig etlConfig = new ETLRealtimeConfig(new ETLStage("source", source),
                                                         new ETLStage("sink", sink), Lists.<ETLStage>newArrayList());
 

--- a/core-plugins/widgets/Cube-batchsink.json
+++ b/core-plugins/widgets/Cube-batchsink.json
@@ -25,6 +25,16 @@
           }
         },
         {
+          "widget-type": "keyvalue",
+          "label": "Aggregations",
+          "name": "dataset.cube.aggregations",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "kv-delimiter" : ":",
+            "delimiter" : ";"
+          }
+        },
+        {
           "widget-type": "json-editor",
           "label": "Other Dataset Properties",
           "name": "dataset.cube.properties"
@@ -35,6 +45,17 @@
       "label": "CubeFact Mapping",
       "properties": [
         {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Measurements",
+          "name": "cubeFact.measurements",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "kv-delimiter" : ":",
+            "delimiter" : ";",
+            "dropdownOptions": ["COUNTER", "GAUGE"]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Timestamp Field",
           "name": "cubeFact.timestamp.field"
@@ -43,11 +64,6 @@
           "widget-type": "textbox",
           "label": "Timestamp Format",
           "name": "cubeFact.timestamp.format"
-        },
-        {
-          "widget-type": "json-editor",
-          "label": "Measurements",
-          "name": "cubeFact.measurements"
         }
       ]
     }

--- a/core-plugins/widgets/Cube-realtimesink.json
+++ b/core-plugins/widgets/Cube-realtimesink.json
@@ -25,6 +25,16 @@
           }
         },
         {
+          "widget-type": "keyvalue",
+          "label": "Aggregations",
+          "name": "dataset.cube.aggregations",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "kv-delimiter" : ":",
+            "delimiter" : ";"
+          }
+        },
+        {
           "widget-type": "json-editor",
           "label": "Other Dataset Properties",
           "name": "dataset.cube.properties"
@@ -35,6 +45,17 @@
       "label": "CubeFact Mapping",
       "properties": [
         {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Measurements",
+          "name": "cubeFact.measurements",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "kv-delimiter" : ":",
+            "delimiter" : ";",
+            "dropdownOptions": ["COUNTER", "GAUGE"]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Timestamp Field",
           "name": "cubeFact.timestamp.field"
@@ -43,11 +64,6 @@
           "widget-type": "textbox",
           "label": "Timestamp Format",
           "name": "cubeFact.timestamp.format"
-        },
-        {
-          "widget-type": "json-editor",
-          "label": "Measurements",
-          "name": "cubeFact.measurements"
         }
       ]
     }


### PR DESCRIPTION
Added improvements to cube widget, so the user doesn't have to provide JSON of properties, rather can provide the aggregation groups using key,value pairs. 

similarly can use key-value for adding widgets, with fixed measure type. Also made this measurement field as required. 

Added corresponding code changes, docs changes and tests in CubeSink(batch, realtime)

Having JSON and optional fields were causing issues with frequent misconfiguration.

After changes, the widget would look like below,
<img width="658" alt="screen shot 2016-03-25 at 11 58 09 am" src="https://cloud.githubusercontent.com/assets/1328150/14051602/87b7b06e-f281-11e5-8faa-7085f48acfc1.png">
