### PR TITLE
allow each module to specify their own parents

### DIFF
--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -23,6 +23,11 @@
     <version>1.3.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <app.parents>system:cdap-etl-batch[3.3.0,3.5.0-SNAPSHOT),system:cdap-etl-data-pipeline[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT)</app.parents>
+  </properties>
+
   <name>Database Plugins</name>
   <artifactId>database-plugins</artifactId>
   <modelVersion>4.0.0</modelVersion>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -22,6 +22,11 @@
     <groupId>co.cask.hydrator</groupId>
     <version>1.3.0-SNAPSHOT</version>
   </parent>
+  
+  <properties>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <app.parents>system:cdap-etl-batch[3.3.0,3.5.0-SNAPSHOT),system:cdap-etl-data-pipeline[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT)</app.parents>
+  </properties>
 
   <name>HBase Plugins</name>
   <artifactId>hbase-plugins</artifactId>

--- a/hdfs-plugins/pom.xml
+++ b/hdfs-plugins/pom.xml
@@ -25,7 +25,12 @@
 
   <name>HDFS Plugins</name>
   <artifactId>hdfs-plugins</artifactId>
-  <modelVersion>4.0.0</modelVersion>  
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <app.parents>system:cdap-etl-batch[3.3.0,3.5.0-SNAPSHOT),system:cdap-etl-data-pipeline[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT)</app.parents>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/hive-plugins/pom.xml
+++ b/hive-plugins/pom.xml
@@ -27,6 +27,11 @@
   <artifactId>hive-plugins</artifactId>
   <modelVersion>4.0.0</modelVersion>
 
+  <properties>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <app.parents>system:cdap-etl-batch[3.3.0,3.5.0-SNAPSHOT),system:cdap-etl-data-pipeline[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT)</app.parents>
+  </properties>
+
   <repositories>
     <repository>
       <id>cloudera</id>

--- a/kafka-plugins/pom.xml
+++ b/kafka-plugins/pom.xml
@@ -22,6 +22,11 @@
     <version>1.3.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <!-- properties for script build step that creates the config files for the artifacts -->
+    <app.parents>system:cdap-etl-realtime[3.3.0,3.5.0-SNAPSHOT)</app.parents>
+  </properties>
+
   <name>Kafka Hydrator Plugins</name>
   <artifactId>kafka-plugins</artifactId>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
-    <etl.versionRange>[3.3.0-SNAPSHOT,3.5.0-SNAPSHOT)</etl.versionRange>
+    <app.parents>system:cdap-etl-batch[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT),system:cdap-etl-realtime[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT),system:cdap-etl-data-pipeline[3.4.0-SNAPSHOT,3.5.0-SNAPSHOT)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
@@ -701,10 +701,15 @@
                     cfgFile.createNewFile();
                   }
 
-                  var etlRange = project.getProperty("etl.versionRange");
+                  var parents = project.getProperty("app.parents").split(",");
                   var config = {
-                    "parents": [ "system:cdap-etl-batch" + etlRange, "system:cdap-etl-realtime" + etlRange, "system:cdap-etl-data-pipeline" + etlRange ],
+                    "parents": [ ],
                     "properties": {}
+                  }
+                  for (i = 0; i < parents.length; i+=2) {
+                    // because name1[lo,hi],name2[lo,hi] gets split into "name1[lo", "hi]", "name2[lo", "hi]"
+                    // so we have to combine them again
+                    config.parents.push(parents[i] + "," + parents[i+1]);
                   }
 
                   // look in widgets directory for widget config for each plugin


### PR DESCRIPTION
Since the data-pipeline app supports some plugin types that
the etl-batch app does not, we need a way for certain modules to
limit which apps they extend.
