### PR TITLE
Revert "compile python script during configurePipeline stage"

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
@@ -159,8 +159,6 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
     } else {
       pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
     }
-    // try evaluating the script to fail application creation if the script is invalid
-    init();
   }
 
   @Override

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/PythonEvaluatorTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/PythonEvaluatorTest.java
@@ -132,31 +132,6 @@ public class PythonEvaluatorTest {
     Assert.assertEquals(expectedListField, output.get("arrayField"));
   }
 
-  @Test(expected = Exception.class)
-  public void testScriptCompilationValidation() throws Exception {
-    Schema outputSchema = Schema.recordOf(
-      "smallerSchema",
-      Schema.Field.of("intField", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("longField", Schema.of(Schema.Type.LONG)));
-
-    PythonEvaluator.Config config = new PythonEvaluator.Config(
-      "def transform(x, emitter, context):\n" +
-        " y = {}\n" +
-        "y['intField'] *= 1024\n" +
-        "  y['longField'] *= 1024\n" +
-        "  emitter.emit(y)",
-      outputSchema.toString());
-
-    Schema inputSchema = Schema.recordOf(
-      "biggerSchema",
-      Schema.Field.of("intField", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("longField", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("doubleField", Schema.of(Schema.Type.DOUBLE)));
-
-    MockPipelineConfigurer configurer = new MockPipelineConfigurer(inputSchema);
-    new PythonEvaluator(config).configurePipeline(configurer);
-  }
-
   @Test
   public void testSchemaValidation() throws Exception {
     Schema outputSchema = Schema.recordOf(
@@ -167,9 +142,9 @@ public class PythonEvaluatorTest {
     PythonEvaluator.Config config = new PythonEvaluator.Config(
       "def transform(x, emitter, context):\n" +
         " y = {}\n" +
-        " y['intField'] *= 1024\n" +
-        " y['longField'] *= 1024\n" +
-        " emitter.emit(y)",
+        "  y['intField'] *= 1024\n" +
+        "  y['longField'] *= 1024\n" +
+        "  emitter.emit(y)",
       outputSchema.toString());
 
     Schema inputSchema = Schema.recordOf(
@@ -185,7 +160,7 @@ public class PythonEvaluatorTest {
     // check if schema is null, input schema is used.
     config = new PythonEvaluator.Config(
       "def transform(x, emitter, context):\n" +
-        "  y = {}\n" +
+        " y = {}\n" +
         "  y['intField'] *= 1024\n" +
         "  y['longField'] *= 1024\n" +
         "  emitter.emit(y)",


### PR DESCRIPTION
This reverts commit 7d4eb4d9cb445133b3277227a3d9abf896ce63b1.

This reverts https://github.com/caskdata/hydrator-plugins/pull/144
because calling init() leaks memory in the current implementation of PythonEvaluator,
so this avoids calling it in master.
Otherwise, you can only deploy a pipeline with this plugin a limited amount of times because master goes out of permgen space.
This revert will work around that issue.
