### PR TITLE
Bump develop pom to 3.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <cassandraunit.version>2.0.2.2</cassandraunit.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
-    <cdap.version>3.4.0-SNAPSHOT</cdap.version>
+    <cdap.version>3.5.0-SNAPSHOT</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <es.version>1.6.0</es.version>
     <es-hadoop.version>2.1.0</es-hadoop.version>


### PR DESCRIPTION
Cut release/1.3 branch for 3.4.0 and bumping develop to 3.5.0-SNAPSHOT

Reference: https://github.com/caskdata/hydrator-plugins/pull/120
