### PR TITLE
Use _exportcontents instead of Export-Package

### DIFF
--- a/cassandra-plugins/pom.xml
+++ b/cassandra-plugins/pom.xml
@@ -109,8 +109,8 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>co.cask.hydrator.plugin.batch.*;org.apache.cassandra.hadoop.*;
-              org.apache.commons.lang;co.cask.hydrator.plugin.realtime.*</Export-Package>
+            <_exportcontents>co.cask.hydrator.plugin.batch.*;org.apache.cassandra.hadoop.*;
+              org.apache.commons.lang;co.cask.hydrator.plugin.realtime.*</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -96,12 +96,12 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>
+            <_exportcontents>
               co.cask.hydrator.plugin.*;
               org.apache.commons.lang;
               org.apache.commons.logging.*;
               org.codehaus.jackson.*
-            </Export-Package>
+            </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/elasticsearch-plugins/pom.xml
+++ b/elasticsearch-plugins/pom.xml
@@ -119,9 +119,9 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>co.cask.hydrator.plugin.batch.*;org.elasticsearch.hadoop.mr.*;
+            <_exportcontents>co.cask.hydrator.plugin.batch.*;org.elasticsearch.hadoop.mr.*;
               org.apache.commons.lang;org.apache.commons.logging.*;
-              org.codehaus.jackson.*;co.cask.hydrator.plugin.realtime.*</Export-Package>
+              org.codehaus.jackson.*;co.cask.hydrator.plugin.realtime.*</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -169,13 +169,13 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>
+            <_exportcontents>
               co.cask.hydrator.plugin.*;
               org.apache.commons.lang;
               org.apache.hadoop.hbase.mapreduce.*;
               org.apache.hadoop.hbase.client.*;
               org.apache.hadoop.hbase.io.*;
-            </Export-Package>
+            </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/hdfs-plugins/pom.xml
+++ b/hdfs-plugins/pom.xml
@@ -101,9 +101,9 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>co.cask.hydrator.plugin.*;
+            <_exportcontents>co.cask.hydrator.plugin.*;
               org.apache.commons.lang;org.apache.commons.logging.*;
-              org.codehaus.jackson.*</Export-Package>
+              org.codehaus.jackson.*</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/kafka-plugins/pom.xml
+++ b/kafka-plugins/pom.xml
@@ -148,7 +148,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>co.cask.hydrator.plugin.realtime.*</Export-Package>
+            <_exportcontents>co.cask.hydrator.plugin.realtime.*</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/mongodb-plugins/pom.xml
+++ b/mongodb-plugins/pom.xml
@@ -117,10 +117,10 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>
+            <_exportcontents>
               co.cask.hydrator.plugin.*;
               com.mongodb.hadoop.*;
-            </Export-Package>
+            </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -84,7 +84,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>co.cask.hydrator.plugin.*;org.apache.commons.lang</Export-Package>
+            <_exportcontents>co.cask.hydrator.plugin.*;org.apache.commons.lang</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>


### PR DESCRIPTION
- _exportcontents won’t inspect the jar, hence is faster and works
  with all kinds of JAR.
