### PR TITLE
moving timezone into the runtime macro

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/EmailAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/EmailAction.java
@@ -139,6 +139,7 @@ public class EmailAction extends PostAction {
     if (!config.shouldRun(context)) {
       return;
     }
+    config.substituteMacros(context);
 
     Authenticator authenticator = null;
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/HttpCallbackAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/HttpCallbackAction.java
@@ -19,10 +19,10 @@ package co.cask.hydrator.plugin.batch.action;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
-import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchActionContext;
 import co.cask.cdap.etl.api.batch.PostAction;
+import co.cask.hydrator.common.batch.action.ConditionConfig;
 import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -63,6 +63,11 @@ public class HttpCallbackAction extends PostAction {
   @SuppressWarnings("ConstantConditions")
   @Override
   public void run(BatchActionContext batchActionContext) throws Exception {
+    if (!conf.shouldRun(batchActionContext)) {
+      return;
+    }
+    conf.substituteMacros(batchActionContext);
+
     int retries = 0;
     Exception exception = null;
     do {
@@ -109,7 +114,7 @@ public class HttpCallbackAction extends PostAction {
   /**
    * Config for the http callback action.
    */
-  public static final class HttpRequestConf extends PluginConfig {
+  public static final class HttpRequestConf extends ConditionConfig {
     private static final Gson GSON = new Gson();
     private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
@@ -60,7 +60,7 @@ public class EmailActionTestRun extends ETLBatchTestBase {
       new ETLPlugin("Email", PostAction.PLUGIN_TYPE,
                     ImmutableMap.of("recipients", "to@test.com",
                                     "sender", "from@test.com",
-                                    "message", "testing body",
+                                    "message", "Run for ${runtime(yyyy-MM-dd,0m,UTC)} completed.",
                                     "subject", "Test",
                                     "port", Integer.toString(port)),
                     null));
@@ -83,7 +83,7 @@ public class EmailActionTestRun extends ETLBatchTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     WorkflowManager manager = appManager.getWorkflowManager("ETLWorkflow");
-    manager.start();
+    manager.start(ImmutableMap.of("logical.start.time", "0"));
     manager.waitForFinish(5, TimeUnit.MINUTES);
 
     server.stop();
@@ -92,7 +92,7 @@ public class EmailActionTestRun extends ETLBatchTestBase {
     Iterator emailIter = server.getReceivedEmail();
     SmtpMessage email = (SmtpMessage) emailIter.next();
     Assert.assertEquals("Test", email.getHeaderValue("Subject"));
-    Assert.assertTrue(email.getBody().startsWith("testing body"));
+    Assert.assertTrue(email.getBody().startsWith("Run for 1970-01-01 completed."));
     Assert.assertFalse(emailIter.hasNext());
   }
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/HttpCallbackActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/HttpCallbackActionTestRun.java
@@ -80,15 +80,14 @@ public class HttpCallbackActionTestRun extends ETLBatchTestBase {
   }
 
   @Test
-  public void testEmailAction() throws Exception {
-
+  public void testHttpCallbackAction() throws Exception {
     String body = "samuel jackson, dwayne johnson, christopher walken";
     ETLStage action = new ETLStage(
       "http",
       new ETLPlugin("HttpCallback", PostAction.PLUGIN_TYPE,
                     ImmutableMap.of("url", baseURL + "/feeds/users",
                                     "method", "PUT",
-                                    "body", body),
+                                    "body", "${runtime(yyyy-MM-dd,0s,UTC)}: " + body),
                     null));
 
     ETLStage source = new ETLStage("source",
@@ -109,7 +108,7 @@ public class HttpCallbackActionTestRun extends ETLBatchTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     WorkflowManager manager = appManager.getWorkflowManager("ETLWorkflow");
-    manager.start();
+    manager.start(ImmutableMap.of("logical.start.time", "0"));
     manager.waitForFinish(5, TimeUnit.MINUTES);
 
     URL url = new URL(baseURL + "/feeds/users");
@@ -117,7 +116,7 @@ public class HttpCallbackActionTestRun extends ETLBatchTestBase {
     conn.setRequestMethod(HttpMethod.GET);
     Assert.assertEquals(200, conn.getResponseCode());
     try (Reader responseReader = new InputStreamReader(conn.getInputStream(), Charsets.UTF_8)) {
-      Assert.assertEquals(body, CharStreams.toString(responseReader));
+      Assert.assertEquals("1970-01-01: " + body, CharStreams.toString(responseReader));
     }
   }
 

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/action/QueryAction.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/action/QueryAction.java
@@ -53,6 +53,7 @@ public class QueryAction extends PostAction {
     if (!config.shouldRun(batchContext)) {
       return;
     }
+    config.substituteMacros(batchContext);
 
     Class<? extends Driver> driverClass = batchContext.loadPluginClass(JDBC_PLUGIN_ID);
     DBManager dbManager = new DBManager(config);

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/macro/DefaultMacroContext.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/macro/DefaultMacroContext.java
@@ -19,36 +19,26 @@ package co.cask.hydrator.common.macro;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TimeZone;
-import javax.annotation.Nullable;
 
 /**
  * Default implementation of MacroContext.
  */
 public class DefaultMacroContext implements MacroContext {
   private final long logicalStartTime;
-  private final TimeZone timeZone;
   private final Map<String, String> runtimeArguments;
 
-  public DefaultMacroContext(long logicalStartTime, TimeZone timeZone) {
-    this(logicalStartTime, timeZone, new HashMap<String, String>());
+  public DefaultMacroContext(long logicalStartTime) {
+    this(logicalStartTime, new HashMap<String, String>());
   }
 
-  public DefaultMacroContext(long logicalStartTime, TimeZone timeZone, Map<String, String> runtimeArguments) {
+  public DefaultMacroContext(long logicalStartTime, Map<String, String> runtimeArguments) {
     this.logicalStartTime = logicalStartTime;
-    this.timeZone = timeZone;
     this.runtimeArguments = Collections.unmodifiableMap(runtimeArguments);
   }
 
   @Override
   public long getLogicalStartTime() {
     return logicalStartTime;
-  }
-
-  @Nullable
-  @Override
-  public TimeZone getTimeZone() {
-    return timeZone;
   }
 
   @Override

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/macro/MacroContext.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/macro/MacroContext.java
@@ -17,8 +17,6 @@
 package co.cask.hydrator.common.macro;
 
 import java.util.Map;
-import java.util.TimeZone;
-import javax.annotation.Nullable;
 
 /**
  * Context for macro substitution.
@@ -29,12 +27,6 @@ public interface MacroContext {
    * @return the logical start time of the pipeline run.
    */
   long getLogicalStartTime();
-
-  /**
-   * @return the user specified timezone for time based macros. Null if none was specified.
-   */
-  @Nullable
-  TimeZone getTimeZone();
 
   /**
    * @return runtime arguments of the pipeline run.

--- a/hydrator-common/src/test/java/co/cask/hydrator/common/macro/MacroConfigTest.java
+++ b/hydrator-common/src/test/java/co/cask/hydrator/common/macro/MacroConfigTest.java
@@ -19,8 +19,6 @@ package co.cask.hydrator.common.macro;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.TimeZone;
-
 /**
  */
 public class MacroConfigTest {
@@ -28,7 +26,7 @@ public class MacroConfigTest {
 
   @Test
   public void testNoOp() throws InvalidMacroException {
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
     String value = "abc123";
     TestConfig testConfig = new TestConfig(value);
     testConfig.substituteMacros(macroContext);
@@ -39,7 +37,7 @@ public class MacroConfigTest {
 
   @Test
   public void testSubstitution() throws InvalidMacroException {
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
 
     TestConfig testConfig = new TestConfig("${runtime(yyyy-MM-dd'T'HH:mm:ss)}");
     testConfig.substituteMacros(macroContext);
@@ -60,7 +58,7 @@ public class MacroConfigTest {
 
   @Test
   public void testUnenclosedMacro() throws InvalidMacroException {
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
 
     TestConfig testConfig = new TestConfig("${runtime(yyyy-MM-dd'T'HH:mm:ss)");
     testConfig.substituteMacros(macroContext);
@@ -69,7 +67,7 @@ public class MacroConfigTest {
 
   @Test(expected = InvalidMacroException.class)
   public void testInvalidPattern() throws InvalidMacroException {
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
 
     TestConfig testConfig = new TestConfig("${runtime(asdf)}");
     testConfig.substituteMacros(macroContext);
@@ -77,7 +75,7 @@ public class MacroConfigTest {
 
   @Test
   public void testNullValueOK() throws InvalidMacroException {
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
 
     TestConfig testConfig = new TestConfig(null);
     testConfig.substituteMacros(macroContext);
@@ -86,7 +84,7 @@ public class MacroConfigTest {
 
   @Test
   public void testFieldSelection() throws InvalidMacroException {
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
 
     TestConfig testConfig = new TestConfig("${runtime(yyyy-MM-dd'T'HH:mm:ss)}");
     testConfig.substituteMacros(macroContext, "nonexistant");

--- a/hydrator-common/src/test/java/co/cask/hydrator/common/macro/RuntimeMacroTest.java
+++ b/hydrator-common/src/test/java/co/cask/hydrator/common/macro/RuntimeMacroTest.java
@@ -29,14 +29,14 @@ public class RuntimeMacroTest {
   @Test
   public void testSubstitution() {
     RuntimeMacro runtimeMacro = new RuntimeMacro();
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("UTC"));
+    MacroContext macroContext = new DefaultMacroContext(0);
 
     Assert.assertEquals("1970-01-01", runtimeMacro.getValue("yyyy-MM-dd", macroContext));
     Assert.assertEquals("1969-12-31", runtimeMacro.getValue("yyyy-MM-dd,1d", macroContext));
     Assert.assertEquals("1969-12-31", runtimeMacro.getValue("yyyy-MM-dd,+1d", macroContext));
     Assert.assertEquals("1970-01-02", runtimeMacro.getValue("yyyy-MM-dd,-1d", macroContext));
 
-    macroContext = new DefaultMacroContext(1451606400000L, TimeZone.getTimeZone("UTC"));
+    macroContext = new DefaultMacroContext(1451606400000L);
     Assert.assertEquals("2016-01-01", runtimeMacro.getValue("yyyy-MM-dd", macroContext));
     Assert.assertEquals("2015-12-31", runtimeMacro.getValue("yyyy-MM-dd,1d", macroContext));
     Assert.assertEquals("2015-12-31T00:00:00", runtimeMacro.getValue("yyyy-MM-dd'T'HH:mm:ss,1d", macroContext));
@@ -48,7 +48,8 @@ public class RuntimeMacroTest {
   @Test
   public void testTimeZone() {
     RuntimeMacro runtimeMacro = new RuntimeMacro();
-    MacroContext macroContext = new DefaultMacroContext(0, TimeZone.getTimeZone("PST"));
-    Assert.assertEquals("1969-12-31T16:00:00", runtimeMacro.getValue("yyyy-MM-dd'T'HH:mm:ss", macroContext));
+    MacroContext macroContext = new DefaultMacroContext(0);
+    Assert.assertEquals("1969-12-31,15:30:00", runtimeMacro.getValue("yyyy-MM-dd','HH:mm:ss ,30m, PST ", macroContext));
   }
+
 }


### PR DESCRIPTION
addressing an earlier comment how the timezone is specific to
runtime macro. Moving it as an argument for that macro type rather
than having it across macro types. Also fixing post actions so that
they actually perform macro substitution.
