### PR TITLE
fix warnings in batch sources

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchReadableSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchReadableSource.java
@@ -16,6 +16,7 @@
 
 package co.cask.hydrator.plugin.batch.source;
 
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.PipelineConfigurer;
@@ -58,6 +59,6 @@ public abstract class BatchReadableSource<KEY_IN, VAL_IN, OUT> extends BatchSour
   @Override
   public void prepareRun(BatchSourceContext context) {
     PluginProperties pluginProperties = context.getPluginProperties();
-    context.setInput(pluginProperties.getProperties().get(Properties.BatchReadableWritable.NAME));
+    context.setInput(Input.ofDataset(pluginProperties.getProperties().get(Properties.BatchReadableWritable.NAME)));
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/KVTableSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/KVTableSource.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.plugin.PluginConfig;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchSource.java
@@ -16,6 +16,7 @@
 
 package co.cask.hydrator.plugin.batch.source;
 
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
@@ -68,7 +69,7 @@ public abstract class SnapshotFileBatchSource<KEY, VALUE> extends BatchSource<KE
       arguments = GSON.fromJson(config.getFileProperties(), MAP_TYPE);
     }
 
-    context.setInput(config.getName(), snapshotFileSet.getInputArguments(arguments));
+    context.setInput(Input.ofDataset(config.getName(), snapshotFileSet.getInputArguments(arguments)));
   }
 
   /**

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/StreamBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/StreamBatchSource.java
@@ -19,11 +19,11 @@ package co.cask.hydrator.plugin.batch.source;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.stream.Stream;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.plugin.PluginConfig;
@@ -120,13 +120,9 @@ public class StreamBatchSource extends BatchSource<Object, Object, StructuredRec
 
     FormatSpecification formatSpec = streamBatchConfig.getFormatSpec();
 
-    StreamBatchReadable stream;
-    if (formatSpec == null) {
-      stream = new StreamBatchReadable(streamBatchConfig.name, startTime, endTime);
-    } else {
-      stream = new StreamBatchReadable(streamBatchConfig.name, startTime, endTime, formatSpec);
-    }
-    context.setInput(stream);
+    Input input = formatSpec == null ? Input.ofStream(streamBatchConfig.name, startTime, endTime) :
+      Input.ofStream(streamBatchConfig.name, startTime, endTime, formatSpec);
+    context.setInput(input);
   }
 
   @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
@@ -26,13 +27,11 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
-import co.cask.hydrator.common.SourceInputFormatProvider;
 import co.cask.hydrator.common.TimeParser;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
-import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -49,6 +48,7 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
   /**
    * Config for TimePartitionedFileSetDatasetAvroSource
    */
+  @SuppressWarnings("unused")
   public static class TPFSConfig extends PluginConfig {
     @Description("Name of the TimePartitionedFileSet to read.")
     private String name;
@@ -106,11 +106,8 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
     Map<String, String> sourceArgs = Maps.newHashMap();
     TimePartitionedFileSetArguments.setInputStartTime(sourceArgs, startTime);
     TimePartitionedFileSetArguments.setInputEndTime(sourceArgs, endTime);
-    TimePartitionedFileSet source = context.getDataset(config.name, sourceArgs);
-
-    Map<String, String> config = new HashMap<>(source.getInputFormatConfiguration());
-    addInputFormatConfiguration(config);
-    context.setInput(new SourceInputFormatProvider(source.getInputFormatClassName(), config));
+    addInputFormatConfiguration(sourceArgs);
+    context.setInput(Input.ofDataset(config.name, sourceArgs));
   }
 
   /**

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -269,6 +269,7 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
     String splitBy;
 
     @Nullable
+    @Name(NUM_SPLITS)
     @Description("The number of splits to generate. If set to one, the boundingQuery is not needed, " +
       "and no $CONDITIONS string needs to be specified in the importQuery. If not specified, the " +
       "execution framework will pick a value.")


### PR DESCRIPTION
Move off deprecated methods for setting input of a run. Also fixing
other assorted warnings.
