### PR TITLE
Set PluginClassLoader to be the context classloader when creating the Configuration object

### DIFF
--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/HBaseSink.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/HBaseSink.java
@@ -69,10 +69,23 @@ public class HBaseSink extends ReferenceBatchSink<StructuredRecord, NullWritable
 
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
-    Job job = JobUtils.createInstance();
-    Configuration conf = job.getConfiguration();
+    Job job;
+    ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+    // Switch the context classloader to plugin class' classloader (PluginClassLoader) so that
+    // when Job/Configuration is created, it uses PluginClassLoader to load resources (hbase-default.xml)
+    // which is present in the plugin jar and is not visible in the CombineClassLoader (which is what oldClassLoader
+    // points to).
+    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+    try {
+      job = JobUtils.createInstance();
+    } finally {
+      // Switch back to the original
+      Thread.currentThread().setContextClassLoader(oldClassLoader);
+    }
 
+    Configuration conf = job.getConfiguration();
     HBaseConfiguration.addHbaseResources(conf);
+
     context.addOutput(Output.of(config.referenceName, new HBaseOutputFormatProvider(config, conf))
                         .alias(config.columnFamily));
   }


### PR DESCRIPTION
When HBaseConfiguration tries to load resources (hbase-default.xml), it uses the context classloader which was initially set to CombineClassLoader which doesn't have access to hbase-default.xml. So switching the context class loader to PluginClassLoader and switching it back solved the problem.

Verified on SDK, Multinode clusters.

TODO: Add an integration test to catch this issue early on.
