### PR TITLE
Removing parquet.hadoop export from core-plugins

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -199,7 +199,6 @@
               co.cask.hydrator.plugin.validator.*;
               co.cask.hydrator.plugin.common;
               parquet.avro.*;
-              parquet.hadoop.*
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>


### PR DESCRIPTION
Reopening https://github.com/caskdata/hydrator-plugins/pull/256 against release/1.3 branch

Issue: https://issues.cask.co/browse/CDAP-5768
Build: http://builds.cask.co/browse/HYP-DBT10-1

Removing parquet.hadoop from core-plugins sinces it's not used by the plugin anywhere.

Please see jira details and discussion for more details and related spark issue.
