### PR TITLE
CDAP-6140 binary is a reserved keyword. hence use backticks in explore

### DIFF
--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/realtime/ETLWorkerTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/realtime/ETLWorkerTest.java
@@ -270,7 +270,7 @@ public class ETLWorkerTest extends ETLRealtimeTestBase {
     Assert.assertNotNull(row.getLong("time"));
 
     Connection connection = getQueryClient();
-    ResultSet results = connection.prepareStatement("select binary,name,score from dataset_table1").executeQuery();
+    ResultSet results = connection.prepareStatement("select `binary`,name,score from dataset_table1").executeQuery();
     Assert.assertTrue(results.next());
     Assert.assertArrayEquals("Bob".getBytes(Charsets.UTF_8), results.getBytes(1));
     Assert.assertEquals("Bob", results.getString(2));


### PR DESCRIPTION
Using backticks for binary since it is a keyword

Cherry-picked from the PR merged to develop #278 
