### PR TITLE
Make hydrator 1.3.2 use cdap 3.4.1 temporarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <cassandraunit.version>2.0.2.2</cassandraunit.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
-    <cdap.version>3.4.2</cdap.version>
+    <cdap.version>3.4.1</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
     <es.version>1.6.0</es.version>


### PR DESCRIPTION
Should use cdap 3.4.1 until 3.4.2  is out.
