### PR TITLE
[CDAP-6123] TPFS sink and source to configure input and output schema…

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,24 +20,18 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.hydrator.plugin.common.FileSetUtil;
 import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
-import org.apache.avro.mapreduce.AvroKeyInputFormat;
-import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.io.NullWritable;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -59,30 +53,8 @@ public class TimePartitionedFileSetDatasetAvroSink extends
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-    super.configurePipeline(pipelineConfigurer);
-    String tpfsName = tpfsSinkConfig.name;
-    String basePath = tpfsSinkConfig.basePath == null ? tpfsName : tpfsSinkConfig.basePath;
-    // parse it to make sure its valid
-    new Schema.Parser().parse(config.schema);
-    pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), FileSetProperties.builder()
-      .setBasePath(basePath)
-      .setInputFormat(AvroKeyInputFormat.class)
-      .setOutputFormat(AvroKeyOutputFormat.class)
-      .setEnableExploreOnCreate(true)
-      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
-      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
-      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
-      .setTableProperty("avro.schema.literal", config.schema)
-      .add(DatasetProperties.SCHEMA, config.schema)
-      .build());
-  }
-
-  @Override
-  protected Map<String, String> getAdditionalTPFSArguments() {
-    Map<String, String> args = new HashMap<>();
-    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "avro.schema.output.key", config.schema);
-    return args;
+  protected void addFileSetProperties(FileSetProperties.Builder properties) {
+    FileSetUtil.configureAvroFileSet(config.schema, properties);
   }
 
   @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -20,25 +20,16 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
-import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.data.schema.UnsupportedTypeException;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
-import co.cask.hydrator.common.HiveSchemaConverter;
+import co.cask.hydrator.plugin.common.FileSetUtil;
 import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
-import parquet.avro.AvroParquetInputFormat;
-import parquet.avro.AvroParquetOutputFormat;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -61,35 +52,8 @@ public class TimePartitionedFileSetDatasetParquetSink extends
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-    super.configurePipeline(pipelineConfigurer);
-    String tpfsName = tpfsSinkConfig.name;
-    String basePath = tpfsSinkConfig.basePath == null ? tpfsName : tpfsSinkConfig.basePath;
-    String schema = config.schema.toLowerCase();
-    // parse to make sure it's valid
-    new org.apache.avro.Schema.Parser().parse(schema);
-    String hiveSchema;
-    try {
-      hiveSchema = HiveSchemaConverter.toHiveSchema(Schema.parseJson(schema));
-    } catch (UnsupportedTypeException | IOException e) {
-      throw new RuntimeException("Error: Schema is not valid ", e);
-    }
-    pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), FileSetProperties.builder()
-      .setBasePath(basePath)
-      .setInputFormat(AvroParquetInputFormat.class)
-      .setOutputFormat(AvroParquetOutputFormat.class)
-      .setEnableExploreOnCreate(true)
-      .setExploreFormat("parquet")
-      .setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1))
-      .add(DatasetProperties.SCHEMA, schema)
-      .build());
-  }
-
-  @Override
-  protected Map<String, String> getAdditionalTPFSArguments() {
-    Map<String, String> args = new HashMap<>();
-    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "parquet.avro.schema", config.schema.toLowerCase());
-    return args;
+  protected void addFileSetProperties(FileSetProperties.Builder properties) {
+    FileSetUtil.configureParquetFileSet(config.schema, properties);
   }
 
   @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,6 @@ package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.data.batch.Input;
-import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
@@ -93,7 +92,6 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
       properties.setBasePath(config.basePath);
     }
     addFileSetProperties(properties);
-
     pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), properties.build());
   }
 
@@ -106,7 +104,6 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
     Map<String, String> sourceArgs = Maps.newHashMap();
     TimePartitionedFileSetArguments.setInputStartTime(sourceArgs, startTime);
     TimePartitionedFileSetArguments.setInputEndTime(sourceArgs, endTime);
-    addInputFormatConfiguration(sourceArgs);
     context.setInput(Input.ofDataset(config.name, sourceArgs));
   }
 
@@ -114,9 +111,4 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
    * Set file set specific properties, such as input/output format and explore properties.
    */
   protected abstract void addFileSetProperties(FileSetProperties.Builder properties);
-
-  /**
-   * Adds additional configuration for the {@link InputFormatProvider}.
-   */
-  protected abstract void addInputFormatConfiguration(Map<String, String> config);
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.hydrator.common.HiveSchemaConverter;
+import co.cask.hydrator.common.batch.JobUtils;
+import com.google.common.base.Throwables;
+import org.apache.avro.Schema;
+import org.apache.avro.mapreduce.AvroJob;
+import org.apache.avro.mapreduce.AvroKeyInputFormat;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import parquet.avro.AvroParquetInputFormat;
+import parquet.avro.AvroParquetOutputFormat;
+
+import java.io.IOException;
+import java.util.Map;
+
+
+/**
+ * Utilities for configuring file sets during pipeline configuration.
+ * TODO (CDAP-6211): Why do we lower-case the schema for Parquet but not for Avro?
+ */
+public class FileSetUtil {
+
+  /**
+   * Configure a file set to use Parquet file format with a given schema. The schema is lower-cased, parsed
+   * as an Avro schema, validated and converted into a Hive schema. The file set is configured to use
+   * Parquet input and output format, and also configured for Explore to use Parquet. The schema is added
+   * to the file set properties in all the different required ways:
+   * <ul>
+   *   <li>As a top-level dataset property;</li>
+   *   <li>As the schema for the input and output format;</li>
+   *   <li>As the schema of the Hive table.</li>
+   * </ul>
+   * @param configuredSchema the original schema configured for the table
+   * @param properties a builder for the file set properties
+   */
+  public static void configureParquetFileSet(String configuredSchema, FileSetProperties.Builder properties) {
+
+    // validate and parse schema as Avro, and attempt to convert it into a Hive schema
+    String lowerCaseSchema = configuredSchema.toLowerCase();
+    Schema avroSchema = parseAvroSchema(lowerCaseSchema, configuredSchema);
+    String hiveSchema = parseHiveSchema(lowerCaseSchema, configuredSchema);
+
+    properties
+      .setInputFormat(AvroParquetInputFormat.class)
+      .setOutputFormat(AvroParquetOutputFormat.class)
+      .setEnableExploreOnCreate(true)
+      .setExploreFormat("parquet")
+      .setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1))
+      .add(DatasetProperties.SCHEMA, lowerCaseSchema);
+
+    Job job = createJobForConfiguration();
+    Configuration hConf = job.getConfiguration();
+    AvroParquetInputFormat.setAvroReadSchema(job, avroSchema);
+    for (Map.Entry<String, String> entry : hConf) {
+      properties.setInputProperty(entry.getKey(), entry.getValue());
+    }
+    hConf.clear();
+    AvroParquetOutputFormat.setSchema(job, avroSchema);
+    for (Map.Entry<String, String> entry : hConf) {
+      properties.setOutputProperty(entry.getKey(), entry.getValue());
+    }
+  }
+
+  /**
+   * Configure a file set to use Avro file format with a given schema. The schema is parsed
+   * as an Avro schema, validated and converted into a Hive schema. The file set is configured to use
+   * Avro key input and output format, and also configured for Explore to use Avro. The schema is added
+   * to the file set properties in all the different required ways:
+   * <ul>
+   *   <li>As a top-level dataset property;</li>
+   *   <li>As the schema for the input and output format;</li>
+   *   <li>As the schema of the Hive table;</li>
+   *   <li>As the schema to be used by the Avro serde (which is used by Hive).</li>
+   * </ul>
+   * @param configuredSchema the original schema configured for the table
+   * @param properties a builder for the file set properties
+   */
+  public static void configureAvroFileSet(String configuredSchema, FileSetProperties.Builder properties) {
+    // validate and parse schema as Avro, and attempt to convert it into a Hive schema
+    Schema avroSchema = parseAvroSchema(configuredSchema, configuredSchema);
+    String hiveSchema = parseHiveSchema(configuredSchema, configuredSchema);
+
+    properties
+      .setInputFormat(AvroKeyInputFormat.class)
+      .setOutputFormat(AvroKeyOutputFormat.class)
+      .setEnableExploreOnCreate(true)
+      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+      .setTableProperty("avro.schema.literal", configuredSchema)
+      .setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1))
+      .add(DatasetProperties.SCHEMA, configuredSchema);
+
+    Job job = createJobForConfiguration();
+    Configuration hConf = job.getConfiguration();
+    AvroJob.setInputKeySchema(job, avroSchema);
+    for (Map.Entry<String, String> entry : hConf) {
+      properties.setInputProperty(entry.getKey(), entry.getValue());
+    }
+    hConf.clear();
+    AvroJob.setOutputKeySchema(job, avroSchema);
+    for (Map.Entry<String, String> entry : hConf) {
+      properties.setOutputProperty(entry.getKey(), entry.getValue());
+    }
+  }
+
+  /*----- private helpers ----*/
+
+  private static Schema parseAvroSchema(String schemaString, String configuredSchema) {
+    try {
+      return new Schema.Parser().parse(schemaString);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Schema " + configuredSchema + " is invalid.", e);
+    }
+  }
+
+  private static String parseHiveSchema(String schemaString, String configuredSchema) {
+    try {
+      return HiveSchemaConverter.toHiveSchema(co.cask.cdap.api.data.schema.Schema.parseJson(schemaString));
+    } catch (UnsupportedTypeException e) {
+      throw new IllegalArgumentException("Schema " + configuredSchema + " is not supported as a Hive schema.", e);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Schema " + configuredSchema + " is invalid.", e);
+    }
+  }
+
+  private static Job createJobForConfiguration() {
+    try {
+      return JobUtils.createInstance();
+    } catch (IOException e) {
+      // Shouldn't happen
+      throw Throwables.propagate(e);
+    }
+  }
+
+}

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/batch/JobUtils.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/batch/JobUtils.java
@@ -37,12 +37,10 @@ public final class JobUtils {
     Configuration conf = job.getConfiguration();
     conf.clear();
 
+    // some input formats require the credentials to be present in the job. We don't know for
+    // sure which ones (HCatalog is one of them), so we simply always add them. This has no other
+    // effect, because this method is only used at configure time and will be ignored later on.
     if (UserGroupInformation.isSecurityEnabled()) {
-      // If runs in secure cluster, this program runner is running in a yarn container, hence not able
-      // to get authenticated with the history.
-      conf.unset("mapreduce.jobhistory.address");
-      conf.setBoolean(Job.JOB_AM_ACCESS_DISABLED, false);
-
       Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
       job.getCredentials().addAll(credentials);
     }


### PR DESCRIPTION
… as dataset properties, to allow MapReduce and Spark to use these datasets (Previously, we set only the explore schema but not the schema properties expected by the input/output formats for parquet and avro). Also some refactoring to remove code duplication between avro/parquet and source/sink.
