### PR TITLE
CDAP-6255 Handle the case where a field is null in HDFSSink by writing an empty string in its place

### DIFF
--- a/hdfs-plugins/src/main/java/co/cask/hydrator/plugin/HDFSSink.java
+++ b/hdfs-plugins/src/main/java/co/cask/hydrator/plugin/HDFSSink.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
 @Name("HDFS")
 @Description("Batch HDFS Sink")
 public class HDFSSink extends ReferenceBatchSink<StructuredRecord, Text, NullWritable> {
+  public static final String NULL_STRING = "\0";
   private HDFSSinkConfig config;
 
   public HDFSSink(HDFSSinkConfig config) {
@@ -76,7 +77,9 @@ public class HDFSSink extends ReferenceBatchSink<StructuredRecord, Text, NullWri
   public void transform(StructuredRecord input, Emitter<KeyValue<Text, NullWritable>> emitter) throws Exception {
     List<String> dataArray = new ArrayList<>();
     for (Schema.Field field : input.getSchema().getFields()) {
-      dataArray.add(input.get(field.getName()).toString());
+      Object fieldValue = input.get(field.getName());
+      String data = (fieldValue != null) ? fieldValue.toString() : NULL_STRING;
+      dataArray.add(data);
     }
     emitter.emit(new KeyValue<>(new Text(Joiner.on(",").join(dataArray)), NullWritable.get()));
   }

--- a/hdfs-plugins/src/test/java/co/cask/hydrator/plugin/HDFSSinkTest.java
+++ b/hdfs-plugins/src/test/java/co/cask/hydrator/plugin/HDFSSinkTest.java
@@ -72,7 +72,7 @@ public class HDFSSinkTest extends HydratorTestBase {
 
   private static final Schema SCHEMA = Schema.recordOf(
     "event",
-    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("ticker", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
     Schema.Field.of("num", Schema.of(Schema.Type.INT)),
     Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
 
@@ -149,7 +149,7 @@ public class HDFSSinkTest extends HydratorTestBase {
 
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
     List<StructuredRecord> input = ImmutableList.of(
-      StructuredRecord.builder(SCHEMA).set("ticker", "AAPL").set("num", 10).set("price", 400.23).build(),
+      StructuredRecord.builder(SCHEMA).set("ticker", null).set("num", 10).set("price", 400.23).build(),
       StructuredRecord.builder(SCHEMA).set("ticker", "CDAP").set("num", 13).set("price", 123.23).build()
     );
     MockSource.writeInput(inputManager, input);
@@ -170,7 +170,11 @@ public class HDFSSinkTest extends HydratorTestBase {
       String line;
       while ((line = reader.readLine()) != null) {
         lines.add(line);
-        if (line.contains("AAPL") || line.contains("CDAP")) {
+        if (line.contains("CDAP") && line.contains("123.23")) {
+          count++;
+        }
+
+        if (line.contains("400.23") && line.startsWith(HDFSSink.NULL_STRING)) {
           count++;
         }
       }


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-6255

Modified the test case to check for the case where a field is null.
