### PR TITLE
Remove aliasing of batch sinks

### DIFF
--- a/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCassandraSink.java
+++ b/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCassandraSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -65,8 +65,7 @@ public class BatchCassandraSink
 
   @Override
   public void prepareRun(BatchSinkContext context) {
-    context.addOutput(Output.of(config.referenceName, new CassandraOutputFormatProvider(config))
-                        .alias(config.columnFamily));
+    context.addOutput(Output.of(config.referenceName, new CassandraOutputFormatProvider(config)));
   }
 
   @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3AvroBatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3AvroBatchSink.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.hydrator.plugin.common.Properties;
 import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
@@ -41,7 +42,7 @@ import java.util.Map;
 /**
  * {@link S3AvroBatchSink} that stores data in avro format to S3.
  */
-@Plugin(type = "batchsink")
+@Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("S3Avro")
 @Description("Batch sink to write to Amazon S3 in Avro format.")
 public class S3AvroBatchSink extends S3BatchSink<AvroKey<GenericRecord>, NullWritable> {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3BatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3BatchSink.java
@@ -74,7 +74,7 @@ public abstract class S3BatchSink<KEY_OUT, VAL_OUT> extends ReferenceBatchSink<S
       outputConfig.putAll(properties);
     }
     context.addOutput(Output.of(config.referenceName, new SinkOutputFormatProvider(
-      outputFormatProvider.getOutputFormatClassName(), outputConfig)).alias(config.basePath));
+      outputFormatProvider.getOutputFormatClassName(), outputConfig)));
   }
 
   /**

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.hydrator.common.ReferenceBatchSink;
 import co.cask.hydrator.common.ReferencePluginConfig;
@@ -61,7 +62,7 @@ import java.util.TreeMap;
 /**
  * Sink that can be configured to export data to a database table.
  */
-@Plugin(type = "batchsink")
+@Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("Database")
 @Description("Writes records to a database table. Each record will be written to a row in the table.")
 public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullWritable> {
@@ -109,8 +110,7 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
     } finally {
       DBUtils.cleanup(driverClass);
     }
-    context.addOutput(Output.of(dbSinkConfig.referenceName, new DBOutputFormatProvider(dbSinkConfig, driverClass))
-                        .alias(dbSinkConfig.tableName));
+    context.addOutput(Output.of(dbSinkConfig.referenceName, new DBOutputFormatProvider(dbSinkConfig, driverClass)));
   }
 
   @Override

--- a/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchElasticsearchSink.java
+++ b/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchElasticsearchSink.java
@@ -51,7 +51,7 @@ import java.io.IOException;
  * https://www.elastic.co/guide/en/elasticsearch/guide/current/_index_settings.html.
  * <p/>
  */
-@Plugin(type = "batchsink")
+@Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("Elasticsearch")
 @Description("Elasticsearch Batch Sink takes the structured record from the input source and converts it " +
   "to a JSON string, then indexes it in Elasticsearch using the index, type, and id specified by the user.")
@@ -83,8 +83,7 @@ public class BatchElasticsearchSink extends ReferenceBatchSink<StructuredRecord,
     conf.set("es.input.json", "yes");
     conf.set("es.mapping.id", config.idField);
 
-    context.addOutput(Output.of(config.referenceName, new SinkOutputFormatProvider(EsOutputFormat.class, conf))
-                        .alias(config.index));
+    context.addOutput(Output.of(config.referenceName, new SinkOutputFormatProvider(EsOutputFormat.class, conf)));
   }
 
   @Override

--- a/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/ElasticsearchSource.java
+++ b/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/ElasticsearchSource.java
@@ -101,8 +101,7 @@ public class ElasticsearchSource extends ReferenceBatchSource<Text, MapWritable,
     conf.set("es.query", config.query);
     job.setMapOutputKeyClass(Text.class);
     job.setMapOutputValueClass(MapWritable.class);
-    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(EsInputFormat.class, conf))
-                       .alias(config.index));
+    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(EsInputFormat.class, conf)));
   }
 
   @Override

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/HBaseSink.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/HBaseSink.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.format.RecordPutTransformer;
 import co.cask.hydrator.common.ReferenceBatchSink;
@@ -54,7 +55,7 @@ import javax.annotation.Nullable;
 /**
  * Sink to write to HBase tables.
  */
-@Plugin(type = "batchsink")
+@Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("HBase")
 @Description("HBase Batch Sink")
 public class HBaseSink extends ReferenceBatchSink<StructuredRecord, NullWritable, Mutation> {
@@ -86,8 +87,7 @@ public class HBaseSink extends ReferenceBatchSink<StructuredRecord, NullWritable
     Configuration conf = job.getConfiguration();
     HBaseConfiguration.addHbaseResources(conf);
 
-    context.addOutput(Output.of(config.referenceName, new HBaseOutputFormatProvider(config, conf))
-                        .alias(config.columnFamily));
+    context.addOutput(Output.of(config.referenceName, new HBaseOutputFormatProvider(config, conf)));
   }
 
   @Override

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
@@ -70,8 +70,7 @@ public class HBaseSource extends ReferenceBatchSource<ImmutableBytesWritable, Re
     conf.setStrings(ioSerializations,
                     MutationSerialization.class.getName(), ResultSerialization.class.getName(),
                     KeyValueSerialization.class.getName());
-    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(TableInputFormat.class, conf))
-                       .alias(config.columnFamily));
+    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(TableInputFormat.class, conf)));
   }
 
   @Override

--- a/hdfs-plugins/src/main/java/co/cask/hydrator/plugin/HDFSSink.java
+++ b/hdfs-plugins/src/main/java/co/cask/hydrator/plugin/HDFSSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.hydrator.common.ReferenceBatchSink;
 import co.cask.hydrator.common.ReferencePluginConfig;
@@ -46,7 +47,7 @@ import javax.annotation.Nullable;
 /**
  * HDFS Sink
  */
-@Plugin(type = "batchsink")
+@Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("HDFS")
 @Description("Batch HDFS Sink")
 public class HDFSSink extends ReferenceBatchSink<StructuredRecord, Text, NullWritable> {
@@ -68,8 +69,7 @@ public class HDFSSink extends ReferenceBatchSink<StructuredRecord, Text, NullWri
 
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
-    context.addOutput(Output.of(config.referenceName, new SinkOutputFormatProvider(config, context))
-                        .alias(config.path));
+    context.addOutput(Output.of(config.referenceName, new SinkOutputFormatProvider(config, context)));
   }
 
   @Override

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveBatchSink.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveBatchSink.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.hydrator.common.ReferenceBatchSink;
 import co.cask.hydrator.common.batch.JobUtils;
@@ -65,14 +66,13 @@ import java.util.Map;
 /**
  * Hive Batch Sink
  */
-@Plugin(type = "batchsink")
+@Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("Hive")
 @Description("Batch Sink to write to external Hive tables.")
 public class HiveBatchSink extends ReferenceBatchSink<StructuredRecord, NullWritable, HCatRecord> {
 
   private static final Gson GSON = new Gson();
-  private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() {
-  }.getType();
+  private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
   private HiveSinkConfig config;
   private RecordToHCatRecordTransformer recordToHCatRecordTransformer;
@@ -94,12 +94,11 @@ public class HiveBatchSink extends ReferenceBatchSink<StructuredRecord, NullWrit
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
     Job job = JobUtils.createInstance();
-    Configuration conf = job.getConfiguration();
 
     HiveSinkOutputFormatProvider sinkOutputFormatProvider = new HiveSinkOutputFormatProvider(job, config);
     HCatSchema hiveSchema = sinkOutputFormatProvider.getHiveSchema();
     HiveSchemaStore.storeHiveSchema(context, config.dbName, config.tableName, hiveSchema);
-    context.addOutput(Output.of(config.referenceName, sinkOutputFormatProvider).alias(config.tableName));
+    context.addOutput(Output.of(config.referenceName, sinkOutputFormatProvider));
   }
 
   public void initialize(BatchRuntimeContext context) throws Exception {


### PR DESCRIPTION
We don't need to alias batch sinks with various things (i.e. path, column family, etc).
We can simply use the configured reference name as its name.

https://issues.cask.co/browse/CDAP-6258
