### PR TITLE
[CDAP-6177] XMLParser transform plugin

### DIFF
--- a/transform-plugins/docs/XMLParser-transform.md
+++ b/transform-plugins/docs/XMLParser-transform.md
@@ -1,0 +1,93 @@
+# XML Parser Transform
+
+Description
+-----------
+The XML Parser Transform uses XPath to extract fields from a complex XML event. This plugin should generally be used
+in conjunction with the XML Reader Batch Source. The XML Reader will provide individual events to the XML Parser,
+which will be responsible for extracting fields from the events and mapping them to the output schema.
+
+
+Use Case
+--------
+The transform takes an input record that contain XML events or records, parses it using the specified XPaths and returns
+a structured record according to the specified schema. For example, this plugin can be used in conjunction with the XML
+Reader Batch Source to extract values from XMLNews documents and create structured records which are easier to query.
+
+
+Properties
+----------
+
+**input:** The field in the input record that is the source of the XML event or record.
+
+**encoding:** The source XML character set encoding (default UTF-8).
+
+**xPathMappings:** Mapping of the field names to the XPaths of the XML record. A comma-separated list, each element of
+which is a field name, followed by a colon, followed by an XPath expression. XPath location paths can include predicates
+and supports XPath 1.0.
+Example : ``<field-name>:<XPath expression>``
+
+**fieldTypeMapping:** Mapping of field names in the output schema to data types. Consists of a comma-separated list,
+each element of which is a field name followed by a colon and a type, where the field names are the same as used in the
+xPathMappings, and the type is one of: boolean, int, long, float, double, bytes, or string.
+Example : ``<field-name>:<data-type>``
+
+**processOnError:** The action to take in case of an error.
+                     - "Ignore error and continue"
+                     - "Exit on error" : Stops processing upon encountering an error
+                     - "Write to error dataset" :  Writes the error record to an error dataset and continues
+
+Example
+-------
+
+This example parses an XML record received in the "body" field of the input record following the *xPathMappings* for
+each field name. The output structured record will be created  using the type specified for each field in the
+"fieldTypeMapping". Only years and prices will be passed on for books with a price over 35.00:
+
+       {
+            "name": "XMLParser",
+            "plugin": {
+                "name": "XMLParser",
+                "type": "transform",
+                "label": "XMLParser",
+                "properties": {
+                    "input": "body",
+                    "encoding": "UTF-8",
+                    "xPathMappings": "category://book/@category,
+                                      title://book/title,
+                                      year:/bookstore/book[price>35.00]/year,
+                                      price:/bookstore/book[price>35.00]/price,
+                                      subcategory://book/subcategory",
+                    "fieldTypeMapping": "category:string,title:string,year:int,price:double,subcategory:string",
+                    "processOnError": "Ignore error and continue"
+                }
+            }
+       }
+
+For example, suppose the transform receives these input records:
+
+    +=========================================================================================================+
+    | offset   | body                                                                                         |
+    +=========================================================================================================+
+    | 1        | <bookstore><book category="cooking"><subcategory><type>Continental</type><genre>European     |
+    |          | cuisines</genre></subcategory><title lang="en">Everyday Italian</title><author>Giada De      |
+    |          | Laurentiis</author><year>2005</year><price>30.00</price></book></bookstore>                  |
+    | 2        | <bookstore><book category="children"><subcategory><type>Series</type><genre>fantasy          |
+    |          | literature</genre></subcategory><title lang="en">Harry Potter</title><author>J. K. Rowling   |
+    |          | </author><year>2005</year><price>49.99</price></book></bookstore>                            |
+    +=========================================================================================================+
+
+The output records will contain:
+
+    +=========================================================================================================+
+    | category  | title              | year   |  price  | subcategory                                         |
+    +=========================================================================================================+
+    | cooking   | Everyday Italian   | null   |  null   | <subcategory><type>Continental</type><genre>European|
+    |           |                    |        |         | cuisines</genre></subcategory>                      |
+    | children  | Harry Potter       | 2005   | 49.99   | <subcategory><type>Series</type><genre>fantasy      |
+    |           |                    |        |         | literature</genre></subcategory>                    |
+    +=========================================================================================================+
+
+Here, since the subcategory contains child nodes, the plugin will retrun the complete subcategory node (along with its
+child elements) as string as ``<subcategory><type>Continental</type><genre>European cuisines</genre></subcategory>`` .
+This is to ensure that the plugin returns a sigle XML event for a structured record intead of the two child events:
+ ``<type>Continental</type>`` and ``<genre>European cuisines</genre>``.

--- a/transform-plugins/docs/XMLParser-transform.md
+++ b/transform-plugins/docs/XMLParser-transform.md
@@ -40,7 +40,7 @@ Example
 -------
 
 This example parses an XML record received in the "body" field of the input record following the *xPathMappings* for
-each field name. The output structured record will be created  using the type specified for each field in the
+each field name. The output structured record will be created using the type specified for each field in the
 "fieldTypeMapping". Only years and prices will be passed on for books with a price over 35.00:
 
        {
@@ -87,7 +87,7 @@ The output records will contain:
     |           |                    |        |         | literature</genre></subcategory>                    |
     +=========================================================================================================+
 
-Here, since the subcategory contains child nodes, the plugin will retrun the complete subcategory node (along with its
+Here, since the subcategory contains child nodes, the plugin will return the complete subcategory node (along with its
 child elements) as string as ``<subcategory><type>Continental</type><genre>European cuisines</genre></subcategory>`` .
-This is to ensure that the plugin returns a sigle XML event for a structured record intead of the two child events:
+This is to ensure that the plugin returns a single XML event for a structured record intead of the two child events:
  ``<type>Continental</type>`` and ``<genre>European cuisines</genre>``.

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLParser.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.TransformContext;
+import com.google.common.base.Strings;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+/**
+ * Parses XML Event using XPath.
+ * This should generally be used in conjunction with the XML Reader Batch Source.
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name("XMLParser")
+@Description("Parse XML events based on XPath")
+public class XMLParser extends Transform<StructuredRecord, StructuredRecord> {
+
+  private static final String EXIT_ON_ERROR = "Exit on error";
+  private static final String WRITE_ERROR_DATASET = "Write to error dataset";
+  private final Config config;
+  private Schema outSchema;
+  private Map<String, String> xPathMapping = new HashMap<>();
+
+  // Required only for testing.
+  public XMLParser(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    super.configurePipeline(pipelineConfigurer);
+    outSchema = config.getOutputSchema();
+    validateXpathAndSchema();
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(outSchema);
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    super.initialize(context);
+    outSchema = config.getOutputSchema();
+    xPathMapping = getXPathMapping();
+  }
+
+  /**
+   * Valid if xpathMappings and schema contain the same field names.
+   */
+  private void validateXpathAndSchema() {
+    xPathMapping = getXPathMapping();
+    List<Schema.Field> outFields = outSchema.getFields();
+    // Checks if all the fields in the XPath mapping are present in the output schema.
+    // If they are not a list of fields that are not present is included in the error message.
+    StringBuilder notOutput = new StringBuilder();
+    for (Schema.Field field : outFields) {
+      String fieldName = field.getName();
+      if (!xPathMapping.keySet().contains(field.getName())) {
+        notOutput.append(fieldName + ";");
+      }
+    }
+    if (notOutput.length() > 0) {
+      throw new IllegalArgumentException("Following fields are not present in output schema :" +
+                                           notOutput.toString());
+    }
+  }
+
+  private Map<String, String> getXPathMapping() {
+    Map<String, String> map = new HashMap<>();
+    String[] xpaths = config.xPathFieldMapping.split(",");
+    for (String xpath : xpaths) {
+      String[] xpathmap = xpath.split(":"); //name:xpath[,name:xpath]*
+      String fieldName = xpathmap[0].trim();
+      if (Strings.isNullOrEmpty(fieldName)) {
+        throw new IllegalArgumentException("Field name cannot be null or empty.");
+      } else if (xpathmap.length < 2 || Strings.isNullOrEmpty(xpathmap[1])) {
+        throw new IllegalArgumentException(String.format("XPath for field name %s cannot be null or empty.",
+                                                         fieldName));
+      }
+      map.put(fieldName, xpathmap[1].trim());
+    }
+    return map;
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) {
+    try {
+      InputSource source = new InputSource(new StringReader((String) input.get(config.inputField)));
+      source.setEncoding(config.encoding);
+      DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+      DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
+      Document document = documentBuilder.parse(source);
+      XPathFactory xpathFactory = XPathFactory.newInstance();
+      XPath xpath = xpathFactory.newXPath();
+      StructuredRecord.Builder builder = StructuredRecord.builder(outSchema);
+      for (Schema.Field field : outSchema.getFields()) {
+        String fieldName = field.getName();
+        //To evaluate a node, the type(Nodelist or Node) should be known before hand.
+        //Since, the type is not specified from user inputs, taking everything as NodeList and then evaluating.
+        NodeList nodeList = (NodeList) xpath.compile(xPathMapping.get(fieldName)).evaluate(document,
+                                                                                           XPathConstants.NODESET);
+        if (nodeList.getLength() > 1) {
+          throw new IllegalArgumentException("Cannot specify an XPath that is an array");
+        }
+        Node node = nodeList.item(0);
+        //Since all columns have nullable schema extracting not nullable type.
+        Schema.Type type = field.getSchema().getNonNullable().getType();
+        String value = getValue(node, type, fieldName);
+        if (value == null) {
+          builder.set(fieldName, null);
+        } else {
+          builder.set(fieldName, TypeConvertor.get(value, type));
+        }
+      }
+      emitter.emit(builder.build());
+    } catch (Exception e) {
+      switch (config.processOnError) {
+        case EXIT_ON_ERROR:
+          throw new IllegalStateException("Terminating process on error: " + e.getMessage());
+        case WRITE_ERROR_DATASET:
+          emitter.emitError(new InvalidEntry<>(31, e.getStackTrace()[0].toString() + " : " + e.getMessage(), input));
+          break;
+        default:
+          //ignore on error(case "Ignore error and continue")
+          break;
+      }
+    }
+  }
+
+  /**
+   * Get the node value to be parsed into the required format by parseValues().
+   *
+   * @param node      Node from which the text has to be extracted
+   * @param type      schema type to check if it is a nullable string, in case the xpath evaluates to node with children
+   * @param fieldName field name for which the type is to be evaluated
+   * @return node value as string
+   */
+  private String getValue(Node node, Schema.Type type, String fieldName) {
+    if (node != null) {
+      Node firstChild = node.getFirstChild();
+      //If the xpath evaluates to node which contains child element, the output will be an xml record
+      if (firstChild != null && (firstChild.getNodeType() == Node.ELEMENT_NODE || (firstChild.getNextSibling()
+        != null && (firstChild.getNextSibling().getNodeType() == Node.ELEMENT_NODE)))) {
+        if (!type.equals(Schema.Type.STRING)) {
+          throw new IllegalArgumentException(String.format("The xpath returned node which contains child nodes. " +
+                                                             "Cannot convert %s  to type %s", fieldName, type));
+        } else {
+          return nodeToString(node.cloneNode(true));
+        }
+      } else {
+        return node.getTextContent();
+      }
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Convert node to string to be returned in the output, for cases which contains child elements.
+   *
+   * @param node node to be converted to string
+   * @return converted node as string
+   */
+  private String nodeToString(Node node) {
+    StringWriter stringWriter = new StringWriter();
+    try {
+      Transformer transformer = TransformerFactory.newInstance().newTransformer();
+      transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+      transformer.setOutputProperty(OutputKeys.INDENT, "no");
+      transformer.transform(new DOMSource(node), new StreamResult(stringWriter));
+    } catch (TransformerException e) {
+      throw new IllegalArgumentException("Cannot convert node to string. Transformer exception ", e);
+    }
+    return stringWriter.toString();
+  }
+
+  /**
+   * Configuration for the XMLParser transform..
+   */
+  public static class Config extends PluginConfig {
+
+    @Name("input")
+    @Description("The field in the input record that is the source of the XML event or record.")
+    private final String inputField;
+
+    @Description("The source XML character set encoding (default UTF-8).")
+    private final String encoding;
+
+    @Name("xPathMappings")
+    @Description("Mapping of the field names to the XPaths of the XML record. A comma-separated list, each element " +
+      "of which is a field name, followed by a colon, followed by an XPath expression. XPath location paths can " +
+      "include predicates and supports XPath 1.0. Example : <field-name>:<XPath expression>")
+    private final String xPathFieldMapping;
+
+    @Description("Mapping of field names in the output schema to data types. Consists of a comma-separated list, " +
+      "each element of which is a field name followed by a colon and a type, where the field names are the same as " +
+      "used in the xPathMappings, and the type is one of: boolean, int, long, float, double, bytes, or string. " +
+      "Example : <field-name>:<data-type>")
+    private final String fieldTypeMapping;
+
+    @Description("The action to take in case of an error.\n" +
+      "                     - \"Ignore error and continue\"\n" +
+      "                     - \"Exit on error\" : Stops processing upon encountering an error\n" +
+      "                     - \"Write to error dataset\" :  Writes the error record to an error dataset and continues")
+    private final String processOnError;
+
+    public Config(String inputField, String encoding, String xPathFieldMapping, String fieldTypeMapping,
+                  String processOnError) {
+      this.inputField = inputField;
+      this.encoding = encoding;
+      this.xPathFieldMapping = xPathFieldMapping;
+      this.fieldTypeMapping = fieldTypeMapping;
+      this.processOnError = processOnError;
+    }
+
+    /**
+     * Create output schema from the field name and type value coming from keyvalue-dropdown widget.
+     * Since the xpath can evaluate to null(when no node is selected), creating nullable schema for all columns.
+     *
+     * @return output schema
+     */
+    private Schema getOutputSchema() {
+      List<Schema.Field> fields = new ArrayList<>();
+      String[] mappings = fieldTypeMapping.split(",");
+      for (String mapping : mappings) {
+        String[] params = mapping.split(":");
+        String fieldName = params[0].trim();
+        if (Strings.isNullOrEmpty(fieldName)) {
+          throw new IllegalArgumentException("Field name cannot be null or empty.");
+        } else if (params.length < 2 || Strings.isNullOrEmpty(params[1])) {
+          throw new IllegalArgumentException("Type cannot be null. Please specify type for " + fieldName);
+        }
+        Schema.Field field = Schema.Field.of(fieldName, Schema.nullableOf(Schema.of(Schema.Type.valueOf(
+          params[1].trim().toUpperCase()))));
+        if (fields.contains(field)) {
+          throw new IllegalArgumentException(String.format("Field %s already has type specified. Duplicate field %s",
+                                                           fieldName, fieldName));
+        } else {
+          fields.add(field);
+        }
+      }
+      return Schema.recordOf("record", fields);
+    }
+  }
+}

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLParser.java
@@ -158,7 +158,7 @@ public class XMLParser extends Transform<StructuredRecord, StructuredRecord> {
     } catch (Exception e) {
       switch (config.processOnError) {
         case EXIT_ON_ERROR:
-          throw new IllegalStateException("Terminating process on error: " + e.getMessage());
+          throw new IllegalStateException("Terminating process on error: " + e.getMessage(), e);
         case WRITE_ERROR_DATASET:
           emitter.emitError(new InvalidEntry<>(31, e.getStackTrace()[0].toString() + " : " + e.getMessage(), input));
           break;

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/XMLParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/XMLParserTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
+import co.cask.cdap.etl.mock.batch.MockSink;
+import co.cask.cdap.etl.mock.batch.MockSource;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.hydrator.common.MockPipelineConfigurer;
+import co.cask.hydrator.common.test.MockEmitter;
+import co.cask.hydrator.common.test.MockTransformContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class XMLParserTest extends TransformPluginsTestBase {
+  private static final Schema INPUT = Schema.recordOf("input", Schema.Field.of("offset", Schema.of(Schema.Type.INT)),
+                                                      Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
+
+  private static final Logger LOG = LoggerFactory.getLogger(XMLParserTest.class);
+
+  @Test
+  public void testInvalidConfig() throws Exception {
+    XMLParser.Config config = new XMLParser.Config("body", "UTF-8", "category://book/@category,title://book/title," +
+      "year:/bookstore/book[price>35.00]/year,price:/bookstore/book[price>35.00]/price,subcategory://book/subcategory",
+                                                   "category:,title:string,price:double,year:int,subcategory:string",
+                                                   "Exit on error");
+
+    MockPipelineConfigurer configurer = new MockPipelineConfigurer(INPUT);
+    try {
+      new XMLParser(config).configurePipeline(configurer);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Type cannot be null. Please specify type for category", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testXMLParserWithSimpleXPath() throws Exception {
+    String inputTable = "input-simple-xpath";
+    ETLStage source = new ETLStage("source", MockSource.getPlugin(inputTable));
+
+    Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
+      .put("input", "body")
+      .put("encoding", "UTF-8")
+      .put("xPathMappings", "title:/book/title,author:/book/author,year:/book/year")
+      .put("fieldTypeMapping", "title:string,author:string,year:string")
+      .put("processOnError", "Write to error dataset")
+      .build();
+
+    ETLStage transform = new ETLStage("transform",
+                                      new ETLPlugin("XMLParser", Transform.PLUGIN_TYPE, sourceProperties, null));
+    String sinkTable = "output-simple-xpath";
+
+    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(sinkTable));
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(source)
+      .addStage(transform)
+      .addStage(sink)
+      .addConnection(source.getName(), transform.getName())
+      .addConnection(transform.getName(), sink.getName())
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
+    ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
+
+    DataSetManager<Table> inputManager = getDataset(inputTable);
+    List<StructuredRecord> input = ImmutableList.of(
+      StructuredRecord.builder(INPUT)
+        .set("offset", 1)
+        .set("body", "<book category=\"COOKING\"><title lang=\"en\">Everyday Italian</title>" +
+          "<author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>").build()
+    );
+    MockSource.writeInput(inputManager, input);
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(sinkTable);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+    Assert.assertEquals("OutputRecords", 1, outputRecords.size());
+    StructuredRecord record = outputRecords.get(0);
+    Assert.assertEquals("Everyday Italian", record.get("title"));
+    Assert.assertEquals("Giada De Laurentiis", record.get("author"));
+  }
+
+  @Test
+  public void testXpathWithMultipleElements() throws Exception {
+    String inputTable = "input-xpath-with-multiple-elements";
+    ETLStage source = new ETLStage("source", MockSource.getPlugin(inputTable));
+    Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
+      .put("input", "body")
+      .put("encoding", "UTF-16 (Unicode with byte-order mark)")
+      .put("xPathMappings", "category://book/@category,title://book/title,year:/bookstore/book[price>35.00]/year," +
+        "price:/bookstore/book[price>35.00]/price,subcategory://book/subcategory")
+      .put("fieldTypeMapping", "category:string,title:string,price:double,year:int,subcategory:string")
+      .put("processOnError", "Ignore error and continue")
+      .build();
+
+    ETLStage transform = new ETLStage("transform",
+                                      new ETLPlugin("XMLParser", Transform.PLUGIN_TYPE, sourceProperties, null));
+    String sinkTable = "output-xpath-with-multiple-elements";
+
+    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(sinkTable));
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(source)
+      .addStage(transform)
+      .addStage(sink)
+      .addConnection(source.getName(), transform.getName())
+      .addConnection(transform.getName(), sink.getName())
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
+    ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
+
+    DataSetManager<Table> inputManager = getDataset(inputTable);
+    List<StructuredRecord> input = ImmutableList.of(
+      StructuredRecord.builder(INPUT)
+        .set("offset", 1)
+        .set("body", "<bookstore><book category=\"cooking\"><subcategory><type>Continental</type></subcategory>" +
+          "<title lang=\"en\">Everyday Italian</title><author>Giada De Laurentiis</author><year>2005</year>" +
+          "<price>30.00</price></book></bookstore>").build(),
+      StructuredRecord.builder(INPUT)
+        .set("offset", 2)
+        .set("body", "<bookstore><book category=\"children\"><subcategory><type>Series</type></subcategory>" +
+          "<title lang=\"en\">Harry Potter</title><author>J K. Rowling</author><year>2005</year><price>49.99</price>" +
+          "</book></bookstore>").build(),
+      StructuredRecord.builder(INPUT)
+        .set("offset", 3)
+        .set("body", "<bookstore><book category=\"web\"><subcategory><type>Basics</type></subcategory>" +
+          "<title lang=\"en\">Learning XML</title><author>Erik T. Ray</author><year>2003</year><price>39.95</price>" +
+          "</book></bookstore>").build()
+    );
+    MockSource.writeInput(inputManager, input);
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(sinkTable);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+    Assert.assertEquals("OutputRecords", 3, outputRecords.size());
+    for (StructuredRecord record : outputRecords) {
+      if (record.get("category").equals("cooking")) {
+        Assert.assertEquals("Everyday Italian", record.get("title"));
+        Assert.assertEquals(null, record.get("price"));
+        Assert.assertEquals(null, record.get("year"));
+        Assert.assertEquals("<subcategory><type>Continental</type></subcategory>", record.get("subcategory"));
+      } else if (record.get("category").equals("children")) {
+        Assert.assertEquals("Harry Potter", record.get("title"));
+        Assert.assertEquals(49.99, (Double) record.get("price"), 0.0);
+        Assert.assertEquals(2005, record.get("year"));
+        Assert.assertEquals("<subcategory><type>Series</type></subcategory>", record.get("subcategory"));
+      } else if (record.get("category").equals("web")) {
+        Assert.assertEquals("Learning XML", record.get("title"));
+        Assert.assertEquals(39.95, (Double) record.get("price"), 0.01);
+        Assert.assertEquals(2003, record.get("year"));
+        Assert.assertEquals("<subcategory><type>Basics</type></subcategory>", record.get("subcategory"));
+      }
+    }
+  }
+
+  @Test
+  public void testEmitErrors() throws Exception {
+    XMLParser.Config config = new XMLParser.Config("body", "UTF-8", "title:/book/title,author:/book/author," +
+      "year:/book/year", "title:string,author:int,year:int", "Write to error dataset");
+    Transform<StructuredRecord, StructuredRecord> transform = new XMLParser(config);
+    transform.initialize(new MockTransformContext());
+
+    StructuredRecord inputRecord = StructuredRecord.builder(INPUT)
+      .set("offset", 1)
+      .set("body", "<book category=\"COOKING\"><title lang=\"en\">Everyday Italian</title>" +
+        "<author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>").build();
+
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+    transform.transform(inputRecord, emitter);
+    Assert.assertEquals(0, emitter.getEmitted().size());
+    Assert.assertEquals(1, emitter.getErrors().size());
+
+    InvalidEntry<StructuredRecord> invalidEntry = emitter.getErrors().get(0);
+    Assert.assertEquals(31, invalidEntry.getErrorCode());
+    Assert.assertEquals("offset", 1, invalidEntry.getInvalidRecord().get("offset"));
+    Assert.assertEquals("body", "<book category=\"COOKING\"><title lang=\"en\">Everyday Italian</title><author>Giada " +
+      "De Laurentiis</author><year>2005</year><price>30.00</price>" +
+      "</book>", invalidEntry.getInvalidRecord().get("body"));
+  }
+
+  @Test
+  public void testIgnoreError() throws Exception {
+    XMLParser.Config config = new XMLParser.Config("body", "ISO-8859-1", "title:/book/title,author:/book/author," +
+      "year:/book/year", "title:string,author:string,year:int", "Ignore error and continue");
+    Transform<StructuredRecord, StructuredRecord> transform = new XMLParser(config);
+    transform.initialize(new MockTransformContext());
+    List<StructuredRecord> input = ImmutableList.of(
+      StructuredRecord.builder(INPUT)
+        .set("offset", 1)
+        .set("body", "<book category=\"COOKING\"><title lang=\"en\">Everyday Italian</title>" +
+          "<author>Giada De Laurentiis</author><year>null</year><price>30.00</price></book>").build(),
+      StructuredRecord.builder(INPUT)
+        .set("offset", 2)
+        .set("body", "<book category=\"children\"><title lang=\"en\">Harry Potter</title>" +
+          "<author>J K. Rowling</author><year>2005</year><price>49.99</price></book>").build());
+
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+    for (StructuredRecord record : input) {
+      transform.transform(record, emitter);
+    }
+    Assert.assertEquals(1, emitter.getEmitted().size());
+    Assert.assertEquals(0, emitter.getErrors().size());
+    StructuredRecord record = emitter.getEmitted().get(0);
+    Assert.assertEquals("Harry Potter", record.get("title"));
+    Assert.assertEquals("J K. Rowling", record.get("author"));
+    Assert.assertEquals(2005, record.get("year"));
+  }
+
+  @Test
+  public void testExitOnError() throws Exception {
+    XMLParser.Config config = new XMLParser.Config("body", "UTF-8", "title:/book/title,author:/book/author," +
+      "year:/book/year", "title:string,author:int,year:int", "Exit on error");
+    try {
+      Transform<StructuredRecord, StructuredRecord> transform = new XMLParser(config);
+      transform.initialize(new MockTransformContext());
+
+      StructuredRecord inputRecord = StructuredRecord.builder(INPUT)
+        .set("offset", 1)
+        .set("body", "<book category=\"COOKING\"><title lang=\"en\">Everyday Italian</title>" +
+          "<author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>").build();
+
+      MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+      transform.transform(inputRecord, emitter);
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      LOG.error("Test passes. Exiting on exception.", e);
+    }
+  }
+
+  @Test
+  public void testXpathArray() throws Exception {
+    String inputTable = "input-xpath-array";
+    ETLStage source = new ETLStage("source", MockSource.getPlugin(inputTable));
+    Map<String, String> sourceProperties = new ImmutableMap.Builder<String, String>()
+      .put("input", "body")
+      .put("encoding", "UTF-8")
+      .put("xPathMappings", "category://book/@category,title://book/title")
+      .put("fieldTypeMapping", "category:string,title:string")
+      .put("processOnError", "Exit on error")
+      .build();
+
+    ETLStage transform = new ETLStage("transform",
+                                      new ETLPlugin("XMLParser", Transform.PLUGIN_TYPE, sourceProperties, null));
+    String sinkTable = "output-xpath-array";
+
+    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(sinkTable));
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(source)
+      .addStage(transform)
+      .addStage(sink)
+      .addConnection(source.getName(), transform.getName())
+      .addConnection(transform.getName(), sink.getName())
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
+    ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
+
+    DataSetManager<Table> inputManager = getDataset(inputTable);
+    List<StructuredRecord> input = ImmutableList.of(
+      StructuredRecord.builder(INPUT)
+        .set("offset", 1)
+        .set("body", "<bookstore><book category=\"cooking\"><title lang=\"en\">Everyday Italian</title>" +
+          "<author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>" +
+          "<book category=\"children\"><title lang=\"en\">Harry Potter</title><author>J K. Rowling</author>" +
+          "<year>2005</year><price>29.99</price></book></bookstore>").build()
+    );
+    MockSource.writeInput(inputManager, input);
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    Assert.assertEquals("FAILED", mrManager.getHistory().get(0).getStatus().name());
+  }
+}

--- a/transform-plugins/widgets/XMLParser-transform.json
+++ b/transform-plugins/widgets/XMLParser-transform.json
@@ -1,0 +1,71 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "XML Parser",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Input field to parse as an XML record",
+          "name": "input"
+        },
+        {
+          "widget-type": "select",
+          "label": "XML encoding",
+          "name": "encoding",
+          "widget-attributes": {
+            "values": [
+              "UTF-8",
+              "ISO-8859-1",
+              "UTF-8 (using character entities)",
+              "UTF-16 (Unicode with byte-order mark)"
+            ],
+            "default": "UTF-8"
+          }
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "XPath Mappings",
+          "name": "xPathMappings",
+          "widget-attributes": {
+            "showDelimiter": "false"
+          }
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Field Name Schema Type Mapping",
+          "name": "fieldTypeMapping",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "dropdownOptions": [
+              "boolean",
+              "int",
+              "long",
+              "float",
+              "double",
+              "bytes",
+              "string"
+            ],
+            "key-placeholder": "Field Name"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Error handling",
+          "name": "processOnError",
+          "widget-attributes": {
+            "values": [
+              "Ignore error and continue",
+              "Exit on error",
+              "Write to error dataset"
+            ],
+            "default": "Ignore error and continue"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": []
+}


### PR DESCRIPTION
The XMLParser transform plugin receives structured record from XMLReader source plugin and creates structured record based on the xpath specified by the user for each field.
Wiki link for Requirements and Design : https://wiki.cask.co/display/CE/XML+Parser

All review comments from https://github.com/caskdata/hydrator-plugins/pull/293 are addressed in this PR.
