### PR TITLE
Fix compilations errors

### DIFF
--- a/hydrator-common/src/main/java/co/cask/hydrator/common/test/MockRealtimeContext.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/test/MockRealtimeContext.java
@@ -16,6 +16,8 @@
 
 package co.cask.hydrator.common.test;
 
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.StageMetrics;
@@ -75,6 +77,12 @@ public class MockRealtimeContext implements RealtimeContext {
 
   @Override
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String s,
+                                 MacroEvaluator macroEvaluator) throws InstantiationException, InvalidMacroException {
     return null;
   }
 

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/test/MockTransformContext.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/test/MockTransformContext.java
@@ -16,6 +16,8 @@
 
 package co.cask.hydrator.common.test;
 
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
@@ -79,6 +81,12 @@ public class MockTransformContext implements TransformContext {
 
   @Override
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String s,
+                                 MacroEvaluator macroEvaluator) throws InstantiationException, InvalidMacroException {
     return null;
   }
 


### PR DESCRIPTION
Implement newPluginInstance(String,MacroEvaluator) in MockRealtimeContext and MockTransformContext, to match new APIs in cdap.

`mvn clean package -DskipTests` passed locally.
