### PR TITLE
Fixing renaming field when alias is not present in config

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/Joiner.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/Joiner.java
@@ -149,6 +149,10 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
   @Path("outputSchema")
   public Schema getOutputSchema(GetSchemaRequest request) {
     try {
+      perStageJoinKeys = request.getPerStageJoinKeys();
+      requiredInputs = request.getInputs();
+      perStageSelectedFields = request.getPerStageSelectedFields();
+      duplicateFields = ArrayListMultimap.create();
       return getOutputSchema(request.inputSchemas);
     } catch (IllegalArgumentException e) {
       if (!duplicateFields.isEmpty()) {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/JoinerConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/JoinerConfig.java
@@ -160,12 +160,18 @@ public class JoinerConfig extends PluginConfig {
                                                          selectedField));
       }
 
+      String stageName = Iterables.get(stageOldNamePair, 0);
+      String oldFieldName = Iterables.get(stageOldNamePair, 1);
+
       // if alias is not present in selected fields, use original field name as alias
-      String alias = (Iterables.size(stageOldNameAliasPair) == 1) ? Iterables.get(stageOldNameAliasPair, 0) :
-        Iterables.get(stageOldNameAliasPair, 1);
-      tableBuilder.put(Iterables.get(stageOldNamePair, 0), Iterables.get(stageOldNamePair, 1), alias);
+      String alias = isAliasPresent(stageOldNameAliasPair) ? oldFieldName : Iterables.get(stageOldNameAliasPair, 1);
+      tableBuilder.put(stageName, oldFieldName, alias);
     }
     return tableBuilder.build();
+  }
+
+  private boolean isAliasPresent(Iterable<String> stageOldNameAliasPair) {
+    return Iterables.size(stageOldNameAliasPair) == 1;
   }
 
   Set<String> getInputs() {

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerConfigTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerConfigTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -151,13 +152,22 @@ public class JoinerConfigTest {
 
   @Test
   public void testJoinerConfigWithoutFieldsToRename() {
-    String selectedFields = "film.film_id film_id, film.film_name as film_name, " +
+    String selectedFields = "film.film_id, film.film_name, " +
       "filmActor.actor_name as renamed_actor, filmCategory.category_name as renamed_category";
 
     JoinerConfig config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            selectedFields, "film,filmActor,filmCategory");
-    config.getPerStageSelectedFields();
+
+    Table<String, String, String> actual = config.getPerStageSelectedFields();
+    ImmutableTable.Builder<String, String, String> tableBuilder = new ImmutableTable.Builder<>();
+    tableBuilder.put("film", "film_id", "film_id");
+    tableBuilder.put("film", "film_name", "film_name");
+    tableBuilder.put("filmActor", "actor_name", "renamed_actor");
+    tableBuilder.put("filmCategory", "category_name", "renamed_category");
+    Table<String, String, String> expected = tableBuilder.build();
+    Assert.assertEquals(expected, actual);
+
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerTestRun.java
@@ -113,8 +113,8 @@ public class JoinerTestRun extends ETLBatchTestBase {
                                    Properties.Table.PROPERTY_SCHEMA, filmCategorySchema.toString()),
                                  null));
 
-    String selectedFields = "film.film_id as film_id, film.film_name as film_name, filmActor.actor_name as " +
-      "renamed_actor, filmCategory.category_name as renamed_category";
+    String selectedFields = "film.film_id, film.film_name, filmActor.actor_name as renamed_actor, " +
+      "filmCategory.category_name as renamed_category";
 
     ETLStage joinStage =
       new ETLStage("joiner",


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6529
Build: http://builds.cask.co/browse/HYP-DBT32-3

Summary:
- Addressing issue when selected field does not get populated correctly when alias is not specified.
- Fixing Rest end point for getOutputSchema to use request instead of config
- Adding test case for selecting fields without specifying alias.
