### PR TITLE
Do not add partition to the underlying PFS through SnapshotFileSet

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/dataset/SnapshotFileSet.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/dataset/SnapshotFileSet.java
@@ -96,10 +96,6 @@ public class SnapshotFileSet {
   public void onSuccess(long snapshotTime) throws IOException, InterruptedException {
     Location lock = lock();
     try {
-      // add partition
-      PartitionKey partitionKey = PartitionKey.builder().addLongField("snapshot", snapshotTime).build();
-      files.addPartition(partitionKey, String.valueOf(snapshotTime));
-
       // update state file that contains the latest snapshot
       Long latestSnapshot = getLatestSnapshot();
       if (latestSnapshot == null || snapshotTime > latestSnapshot) {


### PR DESCRIPTION
`SnapshotFileSet` embeds the `PartitionFileSet`.
1. When MapReduce job finishes `MapReduceRuntimeService.destroy` gets called.
2. `destroy` method in turn calls the `commitOutput` which adds a partition to the embedded PFS through `PartitionFileSet.onSuccess` method. 
3. `destroy` method then calls the `MapReduce.destroy` method of the user's MR program.
4. When pipeline is using `SnapshotFileSet` (through `SnapshotFileBatchSink`), `destroy` method from step 3 results into `SnapshotFileSet.onSuccess` method which again tries to create the partition already created in the step 2 above.

This is causing `ETLSnapshotTestRun.testMultiSnapshotOutput` (unit test case) and `BatchAggregatorTest` (ITN) failures.

Fix is to not to create partition in the `SnapshotFileSet`.
