### PR TITLE
Remove project-version property from copybook

### DIFF
--- a/copybookreader-plugins/pom.xml
+++ b/copybookreader-plugins/pom.xml
@@ -31,7 +31,6 @@
     <jrecord.version>0.80.8</jrecord.version>
     <cb2xml.version>0.80.8-jrecord</cb2xml.version>
     <main.basedir>${project.basedir}</main.basedir>
-    <project-version>3.5.0-SNAPSHOT</project-version>
   </properties>
 
   <repositories>
@@ -46,7 +45,6 @@
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>
-      <version>${project-version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -98,7 +96,6 @@
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-proto</artifactId>
-      <version>${project-version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,18 @@
       </dependency>
       <dependency>
         <groupId>co.cask.cdap</groupId>
+        <artifactId>cdap-api</artifactId>
+        <version>${cdap.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>co.cask.cdap</groupId>
+        <artifactId>cdap-etl-proto</artifactId>
+        <version>${cdap.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-etl-api</artifactId>
         <version>${cdap.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
- Specify dependency in parent pom for cdap project. Then project-version property can be removed
