### PR TITLE
HYDRA-338 fix parent lower bound versions

### DIFF
--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-etl-batch[3.3.0,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-batch[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
   </properties>
 
   <name>Database Plugins</name>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -25,7 +25,7 @@
   
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-etl-batch[3.3.0,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-batch[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
   </properties>
 
   <name>HBase Plugins</name>

--- a/hdfs-plugins/pom.xml
+++ b/hdfs-plugins/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-etl-batch[3.3.0,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-batch[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
   </properties>
 
   <dependencies>

--- a/hive-plugins/pom.xml
+++ b/hive-plugins/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-etl-batch[3.3.0,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-batch[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
   </properties>
 
   <repositories>

--- a/kafka-plugins/pom.xml
+++ b/kafka-plugins/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-etl-realtime[3.3.0,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-realtime[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
   </properties>
 
   <name>Kafka Hydrator Plugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
-    <app.parents>system:cdap-etl-batch[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-etl-realtime[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-batch[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-etl-realtime[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT),system:cdap-data-pipeline[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
   </properties>

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <properties>
-    <app.parents>system:cdap-data-pipeline[3.4.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-data-pipeline[3.5.0-SNAPSHOT,3.6.0-SNAPSHOT)</app.parents>
     <spark.version>1.3.1</spark.version>
   </properties>
 


### PR DESCRIPTION
These plugins require 3.5.x versions of the Hydrator apps, as they
contain various implementations of the new plugin types, like join.
