### PR TITLE
[CDAP-6744][HYDRA-341]: Email Action Test Case uses deprecated macros function. Hydrator Maven Build doesn't run test.

### DIFF
--- a/core-plugins/docs/Email-postaction.md
+++ b/core-plugins/docs/Email-postaction.md
@@ -50,7 +50,7 @@ This example sends an email from 'team-ops@example.com' to 'team-alerts@example.
         "properties": {
             "recipientEmailAddress": "team-alerts@example.com",
             "senderEmailAddress": "team-ops@example.com",
-            "subject": "Pipeline Failure ${runtime(yyyy-MM-dd)}",
+            "subject": "Pipeline Failure ${logicalStartTime(yyyy-MM-dd)}",
             "message": "The pipeline run failed.",
             "includeWorkflowToken": "true",
             "host": "smtp-server.com",

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/BatchPluginsTestSuite.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/BatchPluginsTestSuite.java
@@ -16,6 +16,7 @@
 
 package co.cask.hydrator.plugin.batch;
 
+import co.cask.hydrator.plugin.batch.action.EmailActionTestRun;
 import co.cask.hydrator.plugin.batch.aggregator.DedupTestRun;
 import co.cask.hydrator.plugin.batch.aggregator.GroupByTestRun;
 import org.junit.runner.RunWith;
@@ -33,7 +34,8 @@ import org.junit.runners.Suite;
   ETLMapReduceTestRun.class,
   GroupByTestRun.class,
   DedupTestRun.class,
-  ETLFTPTestRun.class
+  ETLFTPTestRun.class,
+  EmailActionTestRun.class
 })
 public class BatchPluginsTestSuite extends ETLBatchTestBase {
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
@@ -60,7 +60,7 @@ public class EmailActionTestRun extends ETLBatchTestBase {
       new ETLPlugin("Email", PostAction.PLUGIN_TYPE,
                     ImmutableMap.of("recipients", "to@test.com",
                                     "sender", "from@test.com",
-                                    "message", "Run for ${runtime(yyyy-MM-dd,0m,UTC)} completed.",
+                                    "message", "Run for ${logicalStartTime(yyyy-MM-dd,0m,UTC)} completed.",
                                     "subject", "Test",
                                     "port", Integer.toString(port)),
                     null));


### PR DESCRIPTION
Email Action Test uses deprecated `runtime` macro function. Changed it to `logicalStartTime`
