### PR TITLE
Added errorDataset property to XMLParser json

### DIFF
--- a/transform-plugins/widgets/XMLParser-transform.json
+++ b/transform-plugins/widgets/XMLParser-transform.json
@@ -67,5 +67,8 @@
       ]
     }
   ],
+  "errorDataset": {
+    "errorDatasetTooltip": "Dataset that collects error messages from emitter."
+  },
   "outputs": []
 }


### PR DESCRIPTION
Fix for - https://issues.cask.co/browse/CDAP-6813
Added errorDataset name to allow user to set the error data-set that is to be used.
