### PR TITLE
fix HYDRA-125 cannot read from TPFS Parquet source

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -162,9 +162,9 @@
     </dependency>
     <!-- End for EMail -->
     <dependency>
-      <groupId>com.twitter</groupId>
+      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>net.sf.uadetector</groupId>
@@ -221,7 +221,8 @@
               co.cask.hydrator.plugin.transform.*;
               co.cask.hydrator.plugin.validator.*;
               org.apache.avro.mapreduce;
-              parquet.avro.*;
+              org.apache.parquet.avro.*;
+              org.apache.parquet.hadoop.*;
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3ParquetBatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3ParquetBatchSink.java
@@ -29,7 +29,7 @@ import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
 import com.google.common.collect.Maps;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import parquet.avro.AvroParquetOutputFormat;
+import org.apache.parquet.avro.AvroParquetOutputFormat;
 
 import java.text.SimpleDateFormat;
 import java.util.Map;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/SnapshotFileBatchParquetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/SnapshotFileBatchParquetSink.java
@@ -31,8 +31,8 @@ import co.cask.hydrator.common.HiveSchemaConverter;
 import co.cask.hydrator.plugin.common.SnapshotFileSetConfig;
 import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
-import parquet.avro.AvroParquetInputFormat;
-import parquet.avro.AvroParquetOutputFormat;
+import org.apache.parquet.avro.AvroParquetInputFormat;
+import org.apache.parquet.avro.AvroParquetOutputFormat;
 
 import java.io.IOException;
 import javax.annotation.Nullable;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchParquetSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchParquetSource.java
@@ -34,8 +34,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.io.NullWritable;
-import parquet.avro.AvroParquetInputFormat;
-import parquet.avro.AvroParquetOutputFormat;
+import org.apache.parquet.avro.AvroParquetInputFormat;
+import org.apache.parquet.avro.AvroParquetOutputFormat;
 
 import javax.annotation.Nullable;
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetDatasetParquetSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetDatasetParquetSource.java
@@ -34,7 +34,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.io.NullWritable;
 
 /**
- * A {@link BatchSource} to read Avro record from {@link TimePartitionedFileSet}
+ * A {@link BatchSource} to read Parquet record from {@link TimePartitionedFileSet}
  */
 @Plugin(type = "batchsource")
 @Name("TPFSParquet")

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
@@ -28,8 +28,8 @@ import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
-import parquet.avro.AvroParquetInputFormat;
-import parquet.avro.AvroParquetOutputFormat;
+import org.apache.parquet.avro.AvroParquetInputFormat;
+import org.apache.parquet.avro.AvroParquetOutputFormat;
 
 import java.io.IOException;
 import java.util.Map;

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
@@ -70,12 +70,12 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetInputFormat;
+import org.apache.parquet.avro.AvroParquetOutputFormat;
+import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.twill.filesystem.Location;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import parquet.avro.AvroParquetInputFormat;
-import parquet.avro.AvroParquetOutputFormat;
-import parquet.avro.AvroParquetReader;
 
 import java.io.IOException;
 import java.util.List;

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLSnapshotTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLSnapshotTestRun.java
@@ -41,10 +41,10 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.Test;
-import parquet.avro.AvroParquetReader;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLTPFSTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLTPFSTestRun.java
@@ -47,11 +47,11 @@ import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.Test;
-import parquet.avro.AvroParquetWriter;
-import parquet.hadoop.ParquetWriter;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRA-125
Build: http://builds.cask.co/browse/HYP-DBT56-1
I cannot reproduce the error described in this JIRA, but get a runtime exception when reading from TPFS parquet source on the cluster:
java.lang.RuntimeException: readObject can't find class
    at co.cask.cdap.internal.app.runtime.batch.dataset.input.TaggedInputSplit.readClass(TaggedInputSplit.java:162)
    at co.cask.cdap.internal.app.runtime.batch.dataset.input.TaggedInputSplit.readFields(TaggedInputSplit.java:146)
    at org.apache.hadoop.io.serializer.WritableSerialization$WritableDeserializer.deserialize(WritableSerialization.java:71)
    at org.apache.hadoop.io.serializer.WritableSerialization$WritableDeserializer.deserialize(WritableSerialization.java:42)
    at org.apache.hadoop.mapred.MapTask.getSplitDetails(MapTask.java:372)
    at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:754)
    at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
    at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:168)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:415)
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
    at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:162)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerLauncher.launch(MapReduceContainerLauncher.java:98)
    at org.apache.hadoop.mapred.YarnChild.main(Unknown Source)
Caused by: java.lang.ClassNotFoundException: Class parquet.hadoop.ParquetInputSplit not found
    at org.apache.hadoop.conf.Configuration.getClassByName(Configuration.java:2101)
    at co.cask.cdap.internal.app.runtime.batch.dataset.input.TaggedInputSplit.readClass(TaggedInputSplit.java:160)

Fix: Export the parquet package and now sink can get data from the TPFS Parquet source in the pipeline.
