### PR TITLE
Add support for nullable input fields in CSVParser

### DIFF
--- a/transform-plugins/docs/CSVParser-transform.md
+++ b/transform-plugins/docs/CSVParser-transform.md
@@ -12,6 +12,8 @@ Configuration
 -------------
 **format:** Specifies the format of the CSV Record the input should be parsed as.
 
-**field:** Specifies the input field that should be parsed as a CSV Record.
+**field:** Specifies the input field that should be parsed as a CSV Record. 
+Input records with a null input field propagate all other fields and set fields that
+would otherwise be parsed by the CSVParser to null.
 
 **schema:** Specifies the output schema of the CSV Record.

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Transformation that parses a field as CSV Record into {@link StructuredRecord}.
@@ -102,24 +103,33 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
     }
 
     Schema inputSchema = configurer.getStageConfigurer().getInputSchema();
+    validateInputSchema(inputSchema);
+    configurer.getStageConfigurer().setOutputSchema(parseAndValidateOutputSchema(inputSchema));
+  }
+
+  void validateInputSchema(Schema inputSchema) {
     if (inputSchema != null) {
+      // Check the existence of field in input schema
       Schema.Field inputSchemaField = inputSchema.getField(config.field);
       if (inputSchemaField == null) {
         throw new IllegalArgumentException(
           "Field " + config.field + " is not present in the input schema");
-      } else {
-        if (!inputSchemaField.getSchema().getType().equals(Schema.Type.STRING)) {
-          throw new IllegalArgumentException(
-            "Type for field  " + config.field + " must be String");
-        }
+      }
+
+      // Check that the field type is String or Nullable String
+      Schema fieldSchema = inputSchemaField.getSchema();
+      Schema.Type fieldType = fieldSchema.isNullable() ? fieldSchema.getNonNullable().getType() : fieldSchema.getType();
+      if (!fieldType.equals(Schema.Type.STRING)) {
+        throw new IllegalArgumentException(
+          "Type for field  " + config.field + " must be String");
       }
     }
+  }
 
-
+  Schema parseAndValidateOutputSchema(Schema inputSchema) {
     // Check if schema specified is a valid schema or no.
     try {
       Schema outputSchema = Schema.parseJson(this.config.schema);
-      configurer.getStageConfigurer().setOutputSchema(outputSchema);
 
       // When a input field is passed through to output, the type and name should be the same.
       // If the type is not the same, then we fail.
@@ -136,6 +146,7 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
           }
         }
       }
+      return outputSchema;
     } catch (IOException e) {
       throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
     }
@@ -191,48 +202,55 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
 
     // Parse the text as CSV and emit it as structured record.
     try {
-      org.apache.commons.csv.CSVParser parser = org.apache.commons.csv.CSVParser.parse(body, csvFormat);
-      List<CSVRecord> records = parser.getRecords();
-      for (CSVRecord record : records) {
-        emitter.emit(createStructuredRecord(record, in));
+      if (body == null) {
+        emitter.emit(createStructuredRecord(null, in));
+      } else {
+        org.apache.commons.csv.CSVParser parser = org.apache.commons.csv.CSVParser.parse(body, csvFormat);
+        List<CSVRecord> records = parser.getRecords();
+        for (CSVRecord record : records) {
+          emitter.emit(createStructuredRecord(record, in));
+        }
       }
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
   }
 
-  private StructuredRecord createStructuredRecord(CSVRecord record, StructuredRecord in) {
+  private StructuredRecord createStructuredRecord(@Nullable CSVRecord record, StructuredRecord in) {
     StructuredRecord.Builder builder = StructuredRecord.builder(outSchema);
     int i = 0;
     for (Field field : fields) {
       String name = field.getName();
       // If the field specified in the output field is present in the input, then
       // it's directly copied into the output, else field is parsed in from the CSV parser.
+      // If the input record is null, propagate all supplied input fields and null other fields
+      // assumed to be CSV-parsed fields
       if (in.get(name) != null) {
         builder.set(name, in.get(name));
-        continue;
-      }
-
-      String val = record.get(i);
-      Schema fieldSchema = field.getSchema();
-
-      if (val.isEmpty()) {
-        boolean isNullable = fieldSchema.isNullable();
-        Schema.Type fieldType = isNullable ? fieldSchema.getNonNullable().getType() : fieldSchema.getType();
-        // if the field is a string or a nullable string, set the value to the empty string
-        if (fieldType == Schema.Type.STRING) {
-          builder.set(field.getName(), "");
-        } else if (!isNullable) {
-          // otherwise, error out
-          throw new IllegalArgumentException(String.format(
-            "Field #%d (named '%s') is of non-nullable type '%s', " +
-              "but was parsed as an empty string for CSV record '%s'",
-            i, field.getName(), field.getSchema().getType(), record));
-        }
+      } else if (record == null) {
+        builder.set(name, null);
       } else {
-        builder.convertAndSet(field.getName(), val);
+        String val = record.get(i);
+        Schema fieldSchema = field.getSchema();
+
+        if (val.isEmpty()) {
+          boolean isNullable = fieldSchema.isNullable();
+          Schema.Type fieldType = isNullable ? fieldSchema.getNonNullable().getType() : fieldSchema.getType();
+          // if the field is a string or a nullable string, set the value to the empty string
+          if (fieldType == Schema.Type.STRING) {
+            builder.set(field.getName(), "");
+          } else if (!isNullable) {
+            // otherwise, error out
+            throw new IllegalArgumentException(String.format(
+              "Field #%d (named '%s') is of non-nullable type '%s', " +
+                "but was parsed as an empty string for CSV record '%s'",
+              i, field.getName(), field.getSchema().getType(), record));
+          }
+        } else {
+          builder.convertAndSet(field.getName(), val);
+        }
+        ++i;
       }
-      ++i;
     }
     return builder.build();
   }
@@ -248,7 +266,8 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
     private final String format;
 
     @Name("field")
-    @Description("Specify the field that should be used for parsing into CSV.")
+    @Description("Specify the field that should be used for parsing into CSV. Input records with a null input field " +
+      "propagate all other fields and set fields that would otherwise be parsed by the CSVParser to null.")
     private final String field;
 
     @Name("schema")

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVParserTest.java
@@ -70,6 +70,11 @@ public class CSVParserTest {
                                                         Schema.Field.of("e", Schema.of(Schema.Type.BOOLEAN)),
                                                         Schema.Field.of("offset", Schema.of(Schema.Type.INT)));
 
+  // Input schema with nullable field to parse
+  private static final Schema NULLABLE_INPUT = Schema.recordOf("nullableInput",
+                                                               Schema.Field.of("body", Schema.nullableOf(
+                                                                 Schema.of(Schema.Type.STRING))));
+
   @Test
   public void testNullableFields() throws Exception {
     Schema schema = Schema.recordOf("nullables",
@@ -242,11 +247,17 @@ public class CSVParserTest {
   @Test
   public void testSchemaValidation() throws Exception {
     CSVParser.Config config = new CSVParser.Config("DEFAULT", "body", OUTPUT1.toString());
-    Transform<StructuredRecord, StructuredRecord> transform = new CSVParser(config);
+    CSVParser csvParser = new CSVParser(config);
+    csvParser.validateInputSchema(INPUT1);
+    Assert.assertEquals(OUTPUT1, csvParser.parseAndValidateOutputSchema(INPUT1));
+  }
 
-    MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(INPUT1);
-    transform.configurePipeline(mockPipelineConfigurer);
-    Assert.assertEquals(OUTPUT1, mockPipelineConfigurer.getOutputSchema());
+  @Test
+  public void testNullableFieldSchemaValidation() throws Exception {
+    CSVParser.Config config = new CSVParser.Config("DEFAULT", "body", OUTPUT1.toString());
+    CSVParser csvParser = new CSVParser(config);
+    csvParser.validateInputSchema(NULLABLE_INPUT);
+    Assert.assertEquals(OUTPUT1, csvParser.parseAndValidateOutputSchema(NULLABLE_INPUT));
   }
 
   @Test


### PR DESCRIPTION
Added support for the CSVParser transform to accept nullable fields. Null input fields allows all other fields to be propagated and otherwise-parsed fields to be set to null.
