### PR TITLE
[HYDRA-384][HYDRA-385] SSHAction unit test and fix for default port bug

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -203,6 +203,12 @@
       <artifactId>poi-ooxml</artifactId>
       <version>3.11</version>
     </dependency>
+    <dependency>
+      <scope>test</scope>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+      <version>1.2.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/SSHAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/SSHAction.java
@@ -63,7 +63,7 @@ public class SSHAction extends Action {
     // now that macros have been substituted, try validation again
     config.validate();
 
-    Connection connection = new Connection(config.host);
+    Connection connection = new Connection(config.host, config.port);
     try {
       connection.connect();
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/SSHActionTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/SSHActionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.action;
+
+import co.cask.hydrator.plugin.batch.ETLBatchTestBase;
+import co.cask.hydrator.plugin.common.EchoCommandFactory;
+import co.cask.hydrator.plugin.common.MockActionContext;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.server.shell.ProcessShellFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.PublicKey;
+
+/**
+ * Test for {@link SSHAction}
+ */
+public class SSHActionTest extends ETLBatchTestBase {
+  // Test keypair config
+  private static final String PRIVATE_KEY =
+    "-----BEGIN RSA PRIVATE KEY-----\n" +
+    "Proc-Type: 4,ENCRYPTED\n" +
+    "DEK-Info: AES-128-CBC,9CEAA64BCD8E8EF8A953C0282D39FE1B\n" +
+    "\n" +
+    "9wFTqXKQkvtHnzthva5k+vv73DMjeRXckRIiSlJeY61kDbKLCGqQWc3DHqeQZikz\n" +
+    "vAAQFVUqMMX0MHt+mIJZa+7F1kYg6wo9jKr2BIKahwcdCJo5vDx/xBnz33VsGkWf\n" +
+    "gF2lo5X2qQIDrjer6SJLciop9jb91KIkbwE1uR+6/84EWigQQxn1a7rZEQxyZQK+\n" +
+    "wkeYfvWi5Ngav01v4Ui7KJA69+i8634WZrPvpNt1trIAPyW52EtnHA1MrOnKiWmh\n" +
+    "qCmniJ9LoVThnNJekQMCTXi01DZMuWxx6FcZaaJVu7jlxkaWea6l0Nt+gSnkdyxZ\n" +
+    "nb/DB/IC81gvQuUOxQ0gYlaZPkdCygRpFoWl2ssOuP1vBXqSdOeU61TFM45i4mJ9\n" +
+    "/YBB2nsDy6WWstSCLCNQatysVIQwX58Rt19sqHurOS2wOgB4BFhFux/Umd865jmO\n" +
+    "n74LeKM4V93mLpHjet2NF7MRnphOAf0en6cb1rAUFGSCVbVO9ogwxdvfHJcsHlTg\n" +
+    "cWeSMvTl+YvnTua93qth1l2weJA783BJrXBOd1no5UADDPP6DOxmC90VGHnIrI7/\n" +
+    "bmRxOxJeJbYHLKiTZ6AGcqhXN/G98uKVD20/hvBawf8=\n" +
+    "-----END RSA PRIVATE KEY-----";
+  private static final String PASSPHRASE = "password";
+  private static final String EXPECTED_PUBLIC_KEY = "MHwwDQYJKoZIhvcNAQEBBQADawAwaAJhAJhY3ARbmyKD9432C9l/lTwSwcj98KjE" +
+    "ifmUKst4WJOb3C0mpC0CTAqhZVgX9KlFwaRQYVzNRWZuxr/JJ7HcNU5Y2bJxbd7/lKFXE2L9gtwEzcA2bj5Oxw9cuKvSq66ZNwIDAQAB";
+
+  // Daemon config
+  private static final String[] SHELL_ARGS = {"/bin/sh", "-i", "-l"};
+  private static final String EXPECTED_OUTPUT = "command successful";
+
+  // SSHAction config
+  private static final String COMMAND = "echo command successful";
+  private static final String USER = "test";
+  private static final String OUTPUT_KEY = "output";
+
+  // Test members
+  private SshServer sshServer;
+
+  @Before
+  public void setup() throws Exception {
+    sshServer = setupSSHDaemon();
+    sshServer.start();
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    if (sshServer != null) {
+      sshServer.stop();
+    }
+  }
+
+  private SshServer setupSSHDaemon() throws Exception {
+    SshServer sshServer = SshServer.setUpDefaultServer();
+    SimpleGeneratorHostKeyProvider simpleGeneratorHostKeyProvider = new SimpleGeneratorHostKeyProvider();
+    simpleGeneratorHostKeyProvider.setAlgorithm(KeyUtils.RSA_ALGORITHM);
+    sshServer.setKeyPairProvider(simpleGeneratorHostKeyProvider);
+    sshServer.setPublickeyAuthenticator(new PublickeyAuthenticator() {
+      @Override
+      public boolean authenticate(String username, PublicKey key, ServerSession session) {
+        return username.equals(USER) && Base64.encodeBase64String(key.getEncoded()).equals(EXPECTED_PUBLIC_KEY);
+      }
+    });
+    sshServer.setShellFactory(new ProcessShellFactory(SHELL_ARGS));
+    sshServer.setCommandFactory(EchoCommandFactory.INSTANCE);
+    return sshServer;
+  }
+
+  @Test
+  public void testSSHAction() throws Exception {
+    SSHAction.SSHActionConfig sshActionConfig = new SSHAction.SSHActionConfig(COMMAND, sshServer.getHost(), USER,
+                                                                              PRIVATE_KEY, sshServer.getPort(),
+                                                                              PASSPHRASE, OUTPUT_KEY);
+    SSHAction sshAction = new SSHAction(sshActionConfig);
+    MockActionContext mockActionContext = new MockActionContext();
+    sshAction.run(mockActionContext);
+    Assert.assertEquals(mockActionContext.getArguments().get(OUTPUT_KEY), EXPECTED_OUTPUT);
+  }
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/common/EchoCommand.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/common/EchoCommand.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import co.cask.cdap.api.common.Bytes;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Objects;
+
+public class EchoCommand implements Command {
+
+  private static final String ECHO_PREFIX = "echo ";
+
+  private final String command;
+  private final String message;
+
+  private OutputStream out;
+  private ExitCallback callback;
+
+  public EchoCommand(String command) {
+    this.command = ValidateUtils.checkNotNullAndNotEmpty(command, "No command provided.");
+    this.message = parseEchoCommand(command);
+  }
+
+  private String parseEchoCommand(String command) {
+    return command.substring(command.indexOf(ECHO_PREFIX) + ECHO_PREFIX.length());
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public void setInputStream(InputStream in) {
+    // No-op; unused
+  }
+
+  @Override
+  public void setOutputStream(OutputStream out) {
+    this.out = out;
+  }
+
+  @Override
+  public void setErrorStream(OutputStream err) {
+    // No-op; unused
+  }
+
+  @Override
+  public void setExitCallback(ExitCallback callback) {
+    this.callback = callback;
+  }
+
+  @Override
+  public void start(Environment environment) throws IOException {
+    ValidateUtils.checkNotNull(out, "No output stream");
+    out.write(Bytes.toBytes(message));
+    out.write('\n');
+    out.flush();
+    if (callback != null) {
+      callback.onExit(0, message);
+    }
+  }
+
+  @Override
+  public void destroy() {
+    // No-op; unused
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    } else {
+      return obj == this || Objects.equals(getCommand(), ((EchoCommand) obj).getCommand());
+    }
+  }
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/common/EchoCommandFactory.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/common/EchoCommandFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.CommandFactory;
+
+public class EchoCommandFactory implements CommandFactory {
+
+  public static final EchoCommandFactory INSTANCE = new EchoCommandFactory();
+
+  private EchoCommandFactory(){}
+
+  @Override
+  public Command createCommand(String command) {
+    return new EchoCommand(command);
+  }
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/common/MockActionContext.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/common/MockActionContext.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.common;
+
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
+import co.cask.cdap.etl.api.action.ActionContext;
+import co.cask.cdap.etl.api.action.SettableArguments;
+import co.cask.cdap.etl.batch.customaction.BasicSettableArguments;
+import co.cask.cdap.proto.id.NamespaceId;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MockActionContext implements ActionContext {
+
+  private SettableArguments settableArguments;
+
+  public MockActionContext() {
+    this.settableArguments = new BasicSettableArguments(new HashMap<String, String>());
+  }
+
+  @Override
+  public long getLogicalStartTime() {
+    return 0L;
+  }
+
+  @Override
+  public SettableArguments getArguments() {
+    return settableArguments;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId, MacroEvaluator evaluator) {
+    return null;
+  }
+
+  @Override
+  public String getNamespace() {
+    return NamespaceId.DEFAULT.getNamespace();
+  }
+
+  @Override
+  public List<SecureStoreMetadata> listSecureData(String namespace) {
+    return null;
+  }
+
+  @Override
+  public SecureStoreData getSecureData(String namespace, String name) {
+    return null;
+  }
+
+  @Override
+  public void putSecureData(String namespace, String name, String data, String description,
+                            Map<String, String> properties) {
+    // no-op; unused
+  }
+
+  @Override
+  public void deleteSecureData(String namespace, String name) {
+    // no-op; unused
+  }
+
+  @Override
+  public void execute(TxRunnable runnable) {
+    // no-op; unused
+  }
+}


### PR DESCRIPTION
Added a unit test for SSHAction. The unit tests uses Apache MINA's SSHD open source library (Apache License 2.0) to run an SSH daemon. The unit test checks against SSHAction's ability to establish a secure shell connection through the ganymed library on a given port with the proper credentials and collect the shell's output.

There was also a bug where the configuration's port was not being passed as a parameter to the Connection constructor, so the default of 22 was always being used.

JIRAs addressed:
- https://issues.cask.co/browse/HYDRA-384
- https://issues.cask.co/browse/HYDRA-385
