### PR TITLE
Uncomment RedundantModifier since this is the current active release

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -317,15 +317,13 @@ page at http://checkstyle.sourceforge.net/config.html -->
         -->
     </module>
 
-    <!-- Commented per Terence since there will be very little new code in this branch
     <module name="RedundantModifier">
-      <!- Checks for redundant modifiers in:
+      <!-- Checks for redundant modifiers in:
            - interface and annotation definitions,
            - the final modifier on methods of final classes, and
            - inner interface declarations that are declared as static.
-        ->
+        -->
     </module>
-    -->
 
 
     <!--


### PR DESCRIPTION
This was accidentally commented in #368 for this branch. The `release/1.4` branch is under active development, so we should perform this test. We only disabled it on patch-only branches.
