### PR TITLE
[CDAP-6535] Snapshot sink cleans up older snapshots

### DIFF
--- a/core-plugins/docs/SnapshotAvro-batchsink.md
+++ b/core-plugins/docs/SnapshotAvro-batchsink.md
@@ -29,6 +29,12 @@ If it doesn't exist, it will be created.
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
 The properties are also passed to the dataset at runtime as arguments.
 
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
+'m' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+
 
 Example
 -------

--- a/core-plugins/docs/SnapshotAvro-batchsource.md
+++ b/core-plugins/docs/SnapshotAvro-batchsource.md
@@ -29,6 +29,12 @@ If it doesn't exist, it will be created.
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
 The properties are also passed to the dataset at runtime as arguments.
 
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
+'m' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+
 
 Example
 -------

--- a/core-plugins/docs/SnapshotParquet-batchsink.md
+++ b/core-plugins/docs/SnapshotParquet-batchsink.md
@@ -29,6 +29,12 @@ If it doesn't exist, it will be created.
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
 The properties are also passed to the dataset at runtime as arguments.
 
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
+'m' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+
 
 Example
 -------

--- a/core-plugins/docs/SnapshotParquet-batchsource.md
+++ b/core-plugins/docs/SnapshotParquet-batchsource.md
@@ -29,6 +29,12 @@ If it doesn't exist, it will be created.
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
 The properties are also passed to the dataset at runtime as arguments.
 
+**cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
+If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
+The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
+'m' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+
 
 Example
 -------

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/SnapshotFileBatchAvroSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/SnapshotFileBatchAvroSink.java
@@ -93,7 +93,7 @@ public class SnapshotFileBatchAvroSink extends SnapshotFileBatchSink<AvroKey<Gen
     private String schema;
 
     public SnapshotAvroConfig(String name, @Nullable String basePath, String schema) {
-      super(name, basePath, null);
+      super(name, basePath, null, null);
       this.schema = schema;
     }
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/SnapshotFileBatchParquetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/SnapshotFileBatchParquetSink.java
@@ -96,7 +96,7 @@ public class SnapshotFileBatchParquetSink extends SnapshotFileBatchSink<Void, Ge
     private String schema;
 
     public SnapshotParquetConfig(String name, @Nullable String basePath, String schema) {
-      super(name, basePath, null);
+      super(name, basePath, null, null);
       this.schema = schema;
     }
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchAvroSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchAvroSource.java
@@ -100,7 +100,7 @@ public class SnapshotFileBatchAvroSource extends SnapshotFileBatchSource<AvroKey
     private String schema;
 
     public SnapshotAvroConfig(String name, @Nullable String basePath, String schema) {
-      super(name, basePath, null);
+      super(name, basePath, null, null);
       this.schema = schema;
     }
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchParquetSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/SnapshotFileBatchParquetSource.java
@@ -99,7 +99,7 @@ public class SnapshotFileBatchParquetSource extends SnapshotFileBatchSource<Null
     private String schema;
 
     public SnapshotParquetConfig(String name, @Nullable String basePath, String schema) {
-      super(name, basePath, null);
+      super(name, basePath, null, null);
       this.schema = schema;
     }
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/SnapshotFileSetConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/SnapshotFileSetConfig.java
@@ -44,10 +44,22 @@ public abstract class SnapshotFileSetConfig extends PluginConfig {
     "The properties are also passed to the dataset at runtime as arguments.")
   protected String fileProperties;
 
-  public SnapshotFileSetConfig(String name, @Nullable String basePath, @Nullable String fileProperties) {
+  @Description("Optional property that configures the sink to delete old partitions after successful runs. " +
+    "If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and " +
+    "delete any partitions older than that time. " +
+    "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
+    "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to " +
+    "run at midnight of January 1, 2016, and this property is set to 7d, the sink will delete any partitions " +
+    "for time partitions older than midnight Dec 25, 2015.")
+  @Nullable
+  protected String cleanPartitionsOlderThan;
+
+  public SnapshotFileSetConfig(String name, @Nullable String basePath, @Nullable String fileProperties,
+                               @Nullable String cleanPartitionsOlderThan) {
     this.name = name;
     this.basePath = basePath;
     this.fileProperties = fileProperties;
+    this.cleanPartitionsOlderThan = cleanPartitionsOlderThan;
   }
 
   public String getName() {
@@ -62,5 +74,10 @@ public abstract class SnapshotFileSetConfig extends PluginConfig {
   @Nullable
   public String getFileProperties() {
     return fileProperties;
+  }
+
+  @Nullable
+  public String getCleanPartitionsOlderThan() {
+    return cleanPartitionsOlderThan;
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/dataset/SnapshotFileSet.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/dataset/SnapshotFileSet.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.dataset;
 
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
@@ -36,6 +37,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -134,6 +136,16 @@ public class SnapshotFileSet {
       return args;
     } finally {
       lock.delete();
+    }
+  }
+
+  public void deleteMatchingPartitionsByTime(long upperLimit) throws IOException {
+    if (upperLimit > 0 && upperLimit < Long.MAX_VALUE) {
+      PartitionFilter filter = PartitionFilter.builder().addRangeCondition("millisecond", null, upperLimit).build();
+      Set<PartitionDetail> partitions = files.getPartitions(filter);
+      for (PartitionDetail partition : partitions) {
+        files.dropPartition(partition.getPartitionKey());
+      }
     }
   }
 

--- a/core-plugins/widgets/SnapshotAvro-batchsink.json
+++ b/core-plugins/widgets/SnapshotAvro-batchsink.json
@@ -20,6 +20,11 @@
           "widget-type": "json-editor",
           "label": "FileSet Properties",
           "name": "fileProperties"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Clean Partitions Older Than",
+          "name": "cleanPartitionsOlderThan"
         }
       ]
     }

--- a/core-plugins/widgets/SnapshotAvro-batchsource.json
+++ b/core-plugins/widgets/SnapshotAvro-batchsource.json
@@ -20,6 +20,11 @@
           "widget-type": "json-editor",
           "label": "FileSet Properties",
           "name": "fileProperties"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Clean Partitions Older Than",
+          "name": "cleanPartitionsOlderThan"
         }
       ]
     }

--- a/core-plugins/widgets/SnapshotParquet-batchsink.json
+++ b/core-plugins/widgets/SnapshotParquet-batchsink.json
@@ -20,6 +20,11 @@
           "widget-type": "json-editor",
           "label": "FileSet Properties",
           "name": "fileProperties"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Clean Partitions Older Than",
+          "name": "cleanPartitionsOlderThan"
         }
       ]
     }

--- a/core-plugins/widgets/SnapshotParquet-batchsource.json
+++ b/core-plugins/widgets/SnapshotParquet-batchsource.json
@@ -20,6 +20,11 @@
           "widget-type": "json-editor",
           "label": "FileSet Properties",
           "name": "fileProperties"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Clean Partitions Older Than",
+          "name": "cleanPartitionsOlderThan"
         }
       ]
     }


### PR DESCRIPTION
Snapshot sinks should now clean up snapshots older than a time specified by the user.
