### PR TITLE
HYDRA-665 move runtime check for $CONDITIONS

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -193,11 +193,6 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
     Configuration hConf = new Configuration();
     hConf.clear();
 
-    if (!sourceConfig.getImportQuery().contains("$CONDITIONS")) {
-      throw new IllegalArgumentException(String.format("Import Query %s must contain the string '$CONDITIONS'.",
-                                                       sourceConfig.importQuery));
-    }
-
     // Load the plugin class to make sure it is available.
     Class<? extends Driver> driverClass = context.loadPluginClass(getJDBCPluginId());
     if (sourceConfig.user == null && sourceConfig.password == null) {
@@ -210,6 +205,10 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
                                         sourceConfig.getImportQuery(), sourceConfig.getBoundingQuery(),
                                         sourceConfig.getEnableAutoCommit());
     if (sourceConfig.numSplits == null || sourceConfig.numSplits != 1) {
+      if (!sourceConfig.getImportQuery().contains("$CONDITIONS")) {
+        throw new IllegalArgumentException(String.format("Import Query %s must contain the string '$CONDITIONS'.",
+                                                         sourceConfig.importQuery));
+      }
       hConf.set(DBConfiguration.INPUT_ORDER_BY_PROPERTY, sourceConfig.splitBy);
     }
     if (sourceConfig.numSplits != null) {


### PR DESCRIPTION
Moving the runtime check for $CONDITIONS in the import query so
that it is only checked if numSplits is not set to 1.
