### PR TITLE
Add schema in runtime

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -73,7 +73,6 @@ public class TimePartitionedFileSetDatasetAvroSink extends
 
   @Override
   protected Map<String, String> getAdditionalTPFSArguments() {
-    // Backward compatibility between older plugins requires setting the schema in runtime.
     Map<String, String> args = new HashMap<>();
     args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "avro.schema.output.key", config.schema);
     return args;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -32,6 +32,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.hadoop.io.NullWritable;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -67,6 +69,14 @@ public class TimePartitionedFileSetDatasetAvroSink extends
   public void transform(StructuredRecord input,
                         Emitter<KeyValue<AvroKey<GenericRecord>, NullWritable>> emitter) throws Exception {
     emitter.emit(new KeyValue<>(new AvroKey<>(recordTransformer.transform(input)), NullWritable.get()));
+  }
+
+  @Override
+  protected Map<String, String> getAdditionalTPFSArguments() {
+    // Backward compatibility between older plugins requires setting the schema in runtime.
+    Map<String, String> args = new HashMap<>();
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "avro.schema.output.key", config.schema);
+    return args;
   }
 
   /**

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -30,6 +30,8 @@ import co.cask.hydrator.plugin.common.FileSetUtil;
 import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -68,6 +70,12 @@ public class TimePartitionedFileSetDatasetParquetSink extends
     emitter.emit(new KeyValue<Void, GenericRecord>(null, recordTransformer.transform(input)));
   }
 
+  @Override
+  protected Map<String, String> getAdditionalTPFSArguments() {
+    Map<String, String> args = new HashMap<>();
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "parquet.avro.schema", config.schema.toLowerCase());
+    return args;
+  }
 
   /**
    * Config for TimePartitionedFileSetParquetSink

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetSink.java
@@ -62,7 +62,7 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
 
   @Override
   public void prepareRun(BatchSinkContext context) {
-    Map<String, String> sinkArgs = new HashMap<>();
+    Map<String, String> sinkArgs = getAdditionalTPFSArguments();
     long outputPartitionTime = context.getLogicalStartTime();
     if (tpfsSinkConfig.partitionOffset != null) {
       outputPartitionTime -= TimeParser.parseDuration(tpfsSinkConfig.partitionOffset);
@@ -74,6 +74,14 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
                                                           tpfsSinkConfig.timeZone);
     }
     context.addOutput(Output.ofDataset(tpfsSinkConfig.name, sinkArgs));
+  }
+
+  /**
+   * @return any additional properties that need to be set for the sink. For example, avro sink requires
+   *         setting some schema output key.
+   */
+  protected Map<String, String> getAdditionalTPFSArguments() {
+    return new HashMap<>();
   }
 
   /**

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TimePartitionedFileSetSink.java
@@ -81,6 +81,9 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
    *         setting some schema output key.
    */
   protected Map<String, String> getAdditionalTPFSArguments() {
+    // release 1.4 hydrator plugins uses FileSetUtil to set all the properties that the input and output formats
+    // require when it creates the dataset, so it doesn't need to set those arguments at runtime. inorder to be
+    // backward compatible to older versions of the plugins we need to set this at runtime.
     return new HashMap<>();
   }
 


### PR DESCRIPTION
- Setting schema in runtime for parquet and avro sinks. Need this because we introduced a backward incompat change
