### PR TITLE
add TINYINT and SMALLINT transform

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBRecord.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBRecord.java
@@ -152,11 +152,7 @@ public class DBRecord implements Writable, DBWritable {
       switch (sqlColumnType) {
         case Types.SMALLINT:
         case Types.TINYINT:
-          if (original.getClass() == Short.class) {
-            return ((Short) original).intValue();
-          } else {
-            break;
-          }
+          return ((Number) original).intValue();
         case Types.NUMERIC:
         case Types.DECIMAL:
           return ((BigDecimal) original).doubleValue();

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBRecord.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBRecord.java
@@ -152,7 +152,11 @@ public class DBRecord implements Writable, DBWritable {
       switch (sqlColumnType) {
         case Types.SMALLINT:
         case Types.TINYINT:
-          return ((Short) original).intValue();
+          if (original.getClass() == Short.class) {
+            return ((Short) original).intValue();
+          } else {
+            break;
+          }
         case Types.NUMERIC:
         case Types.DECIMAL:
           return ((BigDecimal) original).doubleValue();

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBRecord.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBRecord.java
@@ -150,6 +150,9 @@ public class DBRecord implements Writable, DBWritable {
   private Object transformValue(int sqlColumnType, Object original) throws SQLException {
     if (original != null) {
       switch (sqlColumnType) {
+        case Types.SMALLINT:
+        case Types.TINYINT:
+          return ((Short) original).intValue();
         case Types.NUMERIC:
         case Types.DECIMAL:
           return ((BigDecimal) original).doubleValue();

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/DatabasePluginTestBase.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/DatabasePluginTestBase.java
@@ -54,6 +54,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
+import java.sql.Array;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -69,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.sql.rowset.serial.SerialArray;
 import javax.sql.rowset.serial.SerialBlob;
 
 /**
@@ -144,8 +146,12 @@ public class DatabasePluginTestBase extends HydratorTestBase {
                              Schema.Field.of("TIME_COL", nullableLong),
                              Schema.Field.of("TIMESTAMP_COL", nullableLong),
                              Schema.Field.of("BINARY_COL", nullableBytes),
+                             Schema.Field.of("LONGVARBINARY_COL", nullableBytes),
                              Schema.Field.of("BLOB_COL", nullableBytes),
-                             Schema.Field.of("CLOB_COL", nullableString));
+                             Schema.Field.of("CLOB_COL", nullableString),
+                             Schema.Field.of("CHAR_COL", nullableString),
+                             Schema.Field.of("LONGVARCHAR_COL", nullableString),
+                             Schema.Field.of("VARBINARY_COL", nullableBytes));
 
   }
 
@@ -177,9 +183,13 @@ public class DatabasePluginTestBase extends HydratorTestBase {
                      "DATE_COL DATE, " +
                      "TIME_COL TIME, " +
                      "TIMESTAMP_COL TIMESTAMP, " +
-                     "BINARY_COL BINARY(100)," +
+                     "BINARY_COL Binary(100)," +
+                     "LONGVARBINARY_COL LONGVARBINARY(100)," +
                      "BLOB_COL BLOB(100), " +
-                     "CLOB_COL CLOB(100)" +
+                     "CLOB_COL CLOB(100)," +
+                     "CHAR_COL CHAR(100)," +
+                     "LONGVARCHAR_COL LONGVARCHAR," +
+                     "VARBINARY_COL VARBINARY(20)" +
                      ")");
       stmt.execute("CREATE TABLE \"MY_DEST_TABLE\" AS (" +
                      "SELECT * FROM \"my_table\") WITH DATA");
@@ -192,10 +202,10 @@ public class DatabasePluginTestBase extends HydratorTestBase {
     try (
       PreparedStatement pStmt1 =
         conn.prepareStatement("INSERT INTO \"my_table\" " +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
       PreparedStatement pStmt2 =
         conn.prepareStatement("INSERT INTO \"your_table\" " +
-                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+                                "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
     ) {
       // insert the same data into both tables: my_table and your_table
       final PreparedStatement[] preparedStatements = {pStmt1, pStmt2};
@@ -223,8 +233,12 @@ public class DatabasePluginTestBase extends HydratorTestBase {
           pStmt.setTime(15, new Time(CURRENT_TS));
           pStmt.setTimestamp(16, new Timestamp(CURRENT_TS));
           pStmt.setBytes(17, name.getBytes(Charsets.UTF_8));
-          pStmt.setBlob(18, new SerialBlob(name.getBytes(Charsets.UTF_8)));
-          pStmt.setClob(19, new InputStreamReader(new ByteArrayInputStream(CLOB_DATA.getBytes(Charsets.UTF_8))));
+          pStmt.setBytes(18, name.getBytes(Charsets.UTF_8));
+          pStmt.setBlob(19, new SerialBlob(name.getBytes(Charsets.UTF_8)));
+          pStmt.setClob(20, new InputStreamReader(new ByteArrayInputStream(CLOB_DATA.getBytes(Charsets.UTF_8))));
+          pStmt.setString(21, "char" + i);
+          pStmt.setString(22, "longvarchar" + i);
+          pStmt.setBytes(23, name.getBytes(Charsets.UTF_8));
           pStmt.executeUpdate();
         }
       }

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
@@ -86,7 +86,8 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
   @SuppressWarnings("ConstantConditions")
   public void testDBSource() throws Exception {
     String importQuery = "SELECT ID, NAME, SCORE, GRADUATED, TINY, SMALL, BIG, FLOAT_COL, REAL_COL, NUMERIC_COL, " +
-      "DECIMAL_COL, BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, BLOB_COL, CLOB_COL FROM \"my_table\"" +
+      "DECIMAL_COL, BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, LONGVARBINARY_COL, BLOB_COL, " +
+      "CLOB_COL, CHAR_COL, LONGVARCHAR_COL, VARBINARY_COL FROM \"my_table\"" +
       "WHERE ID < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(ID),MAX(ID) from \"my_table\"";
     String splitBy = "ID";
@@ -122,6 +123,10 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
     // Verify data
     Assert.assertEquals("user1", row1.get("NAME"));
     Assert.assertEquals("user2", row2.get("NAME"));
+    Assert.assertEquals("longvarchar1", row1.get("LONGVARCHAR_COL"));
+    Assert.assertEquals("longvarchar2", row2.get("LONGVARCHAR_COL"));
+    Assert.assertEquals("char1", ((String) row1.get("CHAR_COL")).trim());
+    Assert.assertEquals("char2", ((String) row2.get("CHAR_COL")).trim());
     Assert.assertEquals(124.45, (double) row1.get("SCORE"), 0.000001);
     Assert.assertEquals(125.45, (double) row2.get("SCORE"), 0.000001);
     Assert.assertEquals(false, row1.get("GRADUATED"));
@@ -161,6 +166,10 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
     // verify binary columns
     Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("BINARY_COL"), 0, 5));
     Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("BINARY_COL"), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("LONGVARBINARY_COL"), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("LONGVARBINARY_COL"), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("VARBINARY_COL"), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("VARBINARY_COL"), 0, 5));
     Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("BLOB_COL"), 0, 5));
     Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("BLOB_COL"), 0, 5));
     Assert.assertEquals(CLOB_DATA, row1.get("CLOB_COL"));


### PR DESCRIPTION
When getting JDBC types of small int and tiny int, instead of transforming them to short by default, transform them to Integer. 
JIRA:
https://issues.cask.co/browse/HYDRA-47
Build and Test:
http://builds.cask.co/browse/HYP-BAD31-6
Here are the data type mapping. 
https://msdn.microsoft.com/en-us/library/ms378878(v=sql.110).aspx
http://docs.oracle.com/javase/6/docs/technotes/guides/jdbc/getstart/mapping.html
Found that only tinyint and smallint mapping are different. add all necessary type in test.
