### PR TITLE
Fix macro validation for DB plugins

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/action/QueryAction.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/action/QueryAction.java
@@ -50,7 +50,7 @@ public class QueryAction extends PostAction {
 
   @Override
   public void run(BatchActionContext batchContext) throws Exception {
-    config.validate();
+    config.validateProperties();
 
     if (!config.shouldRun(batchContext)) {
       return;
@@ -90,7 +90,9 @@ public class QueryAction extends PostAction {
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    config.validate();
+    if (!config.containsMacro("runCondition")) {
+      config.validateProperty("runCondition");
+    }
     DBManager dbManager = new DBManager(config);
     dbManager.validateJDBCPluginPipeline(pipelineConfigurer, JDBC_PLUGIN_ID);
   }

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/action/QueryConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/action/QueryConfig.java
@@ -47,10 +47,15 @@ public class QueryConfig extends ConnectionConfig {
     runCondition = Condition.SUCCESS.name();
   }
 
-  public void validate() {
-    // have to delegate instead of inherit, since we can't extend both ConditionConfig and ConnectionConfig.
-    if (!containsMacro("runCondition")) {
-      new ConditionConfig(runCondition).validate();
+  public void validateProperties() {
+    validateProperty("runCondition");
+  }
+
+  public void validateProperty(String property) {
+    switch(property) {
+      case "runCondition":
+        new ConditionConfig(runCondition).validate();
+        break;
     }
   }
 


### PR DESCRIPTION
At runtime, properties that were provided macro syntax when configured will still have `containsMacro(property)` return true. This ensures that validation always happens at runtime and only conditionally at configure time.
