### PR TITLE
Enabled macros for core plugin batch sinks

### DIFF
--- a/core-plugins/docs/S3Avro-batchsink.md
+++ b/core-plugins/docs/S3Avro-batchsink.md
@@ -19,19 +19,19 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**accessID:** Access ID of the Amazon S3 instance to connect to.
+**accessID:** Access ID of the Amazon S3 instance to connect to. (Macro-enabled)
 
-**accessKey:** Access Key of the Amazon S3 instance to connect to.
+**accessKey:** Access Key of the Amazon S3 instance to connect to. (Macro-enabled)
 
-**basePath:** The S3 path where the data is stored. Example: 's3n://logs'.
+**basePath:** The S3 path where the data is stored. Example: 's3n://logs'. (Macro-enabled)
 
 **fileSystemProperties:** A JSON string representing a map of properties needed for the
 distributed file system. The property names needed for S3 (*accessID* and *accessKey*)
-will be included as ``'fs.s3n.awsSecretAccessKey'`` and ``'fs.s3n.awsAccessKeyId'``.
+will be included as ``'fs.s3n.awsSecretAccessKey'`` and ``'fs.s3n.awsAccessKeyId'``. (Macro-enabled)
 
 **pathFormat:** The format for the path that will be suffixed to the basePath; for
 example: the format ``'yyyy-MM-dd-HH-mm'`` will create a file path ending in
-``'2015-01-01-20-42'``. Default format used is ``'yyyy-MM-dd-HH-mm'``.
+``'2015-01-01-20-42'``. Default format used is ``'yyyy-MM-dd-HH-mm'``. (Macro-enabled)
 
 **schema:** The Avro schema of the record being written to the sink as a JSON object.
 

--- a/core-plugins/docs/S3Parquet-batchsink.md
+++ b/core-plugins/docs/S3Parquet-batchsink.md
@@ -19,19 +19,19 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**accessID:** Access ID of the Amazon S3 instance to connect to.
+**accessID:** Access ID of the Amazon S3 instance to connect to. (Macro-enabled)
 
-**accessKey:** Access Key of the Amazon S3 instance to connect to.
+**accessKey:** Access Key of the Amazon S3 instance to connect to. (Macro-enabled)
 
-**basePath:** The S3 path where the data is stored. Example: 's3n://logs'.
+**basePath:** The S3 path where the data is stored. Example: 's3n://logs'. (Macro-enabled)
 
 **fileSystemProperties:** A JSON string representing a map of properties needed for the
 distributed file system. The property names needed for S3 (*accessID* and *accessKey*)
-will be included as ``'fs.s3n.awsSecretAccessKey'`` and ``'fs.s3n.awsAccessKeyId'``.
+will be included as ``'fs.s3n.awsSecretAccessKey'`` and ``'fs.s3n.awsAccessKeyId'``. (Macro-enabled)
 
 **pathFormat:** The format for the path that will be suffixed to the basePath; for
 example: the format ``'yyyy-MM-dd-HH-mm'`` will create a file path ending in
-``'2015-01-01-20-42'``. Default format used is ``'yyyy-MM-dd-HH-mm'``.
+``'2015-01-01-20-42'``. Default format used is ``'yyyy-MM-dd-HH-mm'``. (Macro-enabled)
 
 **schema:** The Parquet schema of the record being written to the sink as a JSON object.
 

--- a/core-plugins/docs/SnapshotAvro-batchsink.md
+++ b/core-plugins/docs/SnapshotAvro-batchsink.md
@@ -19,21 +19,21 @@ and then other programs can analyze the contents of the specified file.
 Properties
 ----------
 **name:** Name of the PartitionedFileSet to which records are written.
-If it doesn't exist, it will be created.
+If it doesn't exist, it will be created. (Macro-enabled)
 
 **schema:** The Avro schema of the record being written to the sink as a JSON object.
 
-**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset.
+**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset. (Macro-enabled)
 
 **fileProperties:** Advanced feature to specify any additional properties that should be used with the sink,
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
-The properties are also passed to the dataset at runtime as arguments.
+The properties are also passed to the dataset at runtime as arguments. (Macro-enabled)
 
 **cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
 If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
-and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/SnapshotParquet-batchsink.md
+++ b/core-plugins/docs/SnapshotParquet-batchsink.md
@@ -19,21 +19,21 @@ and then other programs can analyze the contents of the specified file.
 Properties
 ----------
 **name:** Name of the PartitionedFileSet to which records are written.
-If it doesn't exist, it will be created.
+If it doesn't exist, it will be created. (Macro-enabled)
 
 **schema:** The Parquet schema of the record being written to the sink as a JSON object.
 
-**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset.
+**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset. (Macro-enabled)
 
 **fileProperties:** Advanced feature to specify any additional properties that should be used with the sink,
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
-The properties are also passed to the dataset at runtime as arguments.
+The properties are also passed to the dataset at runtime as arguments. (Macro-enabled)
 
 **cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
 If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
-and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/TPFSAvro-batchsink.md
+++ b/core-plugins/docs/TPFSAvro-batchsink.md
@@ -19,29 +19,29 @@ the entire contents of the table and writing to this sink.
 Properties
 ----------
 **name:** Name of the ``TimePartitionedFileSet`` to which records are written.
-If it doesn't exist, it will be created.
+If it doesn't exist, it will be created. (Macro-enabled)
 
 **schema:** The Avro schema of the record being written to the sink as a JSON Object.
 
-**basePath:** Base path for the ``TimePartitionedFileSet``. Defaults to the name of the dataset.
+**basePath:** Base path for the ``TimePartitionedFileSet``. Defaults to the name of the dataset. (Macro-enabled)
 
 **filePathFormat:** Format for the time partition, as used by ``SimpleDateFormat``.
-Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``.
+Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``. (Macro-enabled)
 
 **timeZone:** The string ID for the time zone to format the date in. Defaults to using UTC.
-This setting is only used if ``filePathFormat`` is not null.
+This setting is only used if ``filePathFormat`` is not null. (Macro-enabled)
 
 **partitionOffset:** Amount of time to subtract from the pipeline runtime to determine the output partition. Defaults to 0m.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit,
 with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
 For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
-and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015."
+and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015." (Macro-enabled)
 
 **cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
 If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
-and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015. (Macro-enabled)
 
 Example
 -------

--- a/core-plugins/docs/TPFSParquet-batchsink.md
+++ b/core-plugins/docs/TPFSParquet-batchsink.md
@@ -19,29 +19,29 @@ the entire contents of the table and writing to this sink.
 Properties
 ----------
 **name:** Name of the ``TimePartitionedFileSet`` to which records are written.
-If it doesn't exist, it will be created.
+If it doesn't exist, it will be created. (Macro-enabled)
 
 **schema:** The Avro schema of the record being written to the sink as a JSON Object.
 
-**basePath:** Base path for the ``TimePartitionedFileSet``. Defaults to the name of the dataset.
+**basePath:** Base path for the ``TimePartitionedFileSet``. Defaults to the name of the dataset. (Macro-enabled)
 
 **filePathFormat:** Format for the time partition, as used by ``SimpleDateFormat``.
-Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``.
+Defaults to formatting partitions such as ``2015-01-01/20-42.142017372000``. (Macro-enabled)
 
 **timeZone:** The string ID for the time zone to format the date in. Defaults to using UTC.
-This setting is only used if ``filePathFormat`` is not null.
+This setting is only used if ``filePathFormat`` is not null. (Macro-enabled)
 
 **partitionOffset:** Amount of time to subtract from the pipeline runtime to determine the output partition. Defaults to 0m.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit,
 with 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
 For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
-and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015."
+and the offset is set to '1d', data will be written to the partition for midnight Dec 31, 2015." (Macro-enabled)
 
 **cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
 If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any partitions for time partitions older than that.
 The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' for seconds,
 'm' for minutes, 'h' for hours, and 'd' for days. For example, if the pipeline is scheduled to run at midnight of January 1, 2016,
-and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015.
+and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015. (Macro-enabled)
 
 
 Example

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3BatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3BatchSink.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
@@ -60,8 +61,12 @@ public abstract class S3BatchSink<KEY_OUT, VAL_OUT> extends ReferenceBatchSink<S
     this.config = config;
     // update fileSystemProperties to include accessID and accessKey, so prepareRun can only set fileSystemProperties
     // in configuration, and not deal with accessID and accessKey separately
-    this.config.fileSystemProperties = updateFileSystemProperties(this.config.fileSystemProperties,
-                                                                  this.config.accessID, this.config.accessKey);
+    // do not create file system properties if macros were provided unless in a test case
+    if (!this.config.containsMacro("fileSystemProperties") && !this.config.containsMacro("accessID") &&
+        !this.config.containsMacro("accessKey")) {
+      this.config.fileSystemProperties = updateFileSystemProperties(this.config.fileSystemProperties,
+                                                                    this.config.accessID, this.config.accessKey);
+    }
   }
 
   @Override
@@ -107,23 +112,28 @@ public abstract class S3BatchSink<KEY_OUT, VAL_OUT> extends ReferenceBatchSink<S
 
     @Name(Properties.S3BatchSink.BASE_PATH)
     @Description(PATH_DESC)
+    @Macro
     protected String basePath;
 
     @Name(Properties.S3.ACCESS_ID)
     @Description(ACCESS_ID_DESCRIPTION)
+    @Macro
     protected String accessID;
 
     @Name(Properties.S3.ACCESS_KEY)
     @Description(ACCESS_KEY_DESCRIPTION)
+    @Macro
     protected String accessKey;
 
     @Name(Properties.S3BatchSink.PATH_FORMAT)
     @Description(PATH_FORMAT_DESCRIPTION)
     @Nullable
+    @Macro
     protected String pathFormat;
 
     @Description(FILESYSTEM_PROPERTIES_DESCRIPTION)
     @Nullable
+    @Macro
     protected String fileSystemProperties;
 
     public S3BatchSinkConfig() {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TPFSSinkConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TPFSSinkConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.hydrator.common.TimeParser;
 import com.google.common.base.Strings;
@@ -31,11 +32,13 @@ public abstract class TPFSSinkConfig extends PluginConfig {
 
   @Description("Name of the Time Partitioned FileSet Dataset to which the records " +
     "are written to. If it doesn't exist, it will be created.")
+  @Macro
   protected String name;
 
   @Description("The base path for the Time Partitioned FileSet. Defaults to the " +
     "name of the dataset.")
   @Nullable
+  @Macro
   protected String basePath;
 
   @Description("The format for the path; for example: " +
@@ -44,6 +47,7 @@ public abstract class TPFSSinkConfig extends PluginConfig {
     "If left blank, the partitions will be of the form '2015-01-01/20-42.142017372000'. " +
     "Note that each partition must have a unique file path or a runtime exception will be thrown.")
   @Nullable
+  @Macro
   protected String filePathFormat;
 
   @Description("The time zone to format the partition. " +
@@ -51,6 +55,7 @@ public abstract class TPFSSinkConfig extends PluginConfig {
     "Note that the time zone provided must be recognized by TimeZone.getTimeZone(String); " +
     "for example: \"America/Los_Angeles\"")
   @Nullable
+  @Macro
   protected String timeZone;
 
   @Description("Amount of time to subtract from the pipeline runtime to determine the output partition. " +
@@ -59,6 +64,7 @@ public abstract class TPFSSinkConfig extends PluginConfig {
     "For example, if the pipeline is scheduled to run at midnight of January 1, 2016, and the offset is set to '1d', " +
     "data will be written to the partition for midnight Dec 31, 2015.")
   @Nullable
+  @Macro
   protected String partitionOffset;
 
   @Description("Optional property that configures the sink to delete old partitions after successful runs. " +
@@ -69,6 +75,7 @@ public abstract class TPFSSinkConfig extends PluginConfig {
     "run at midnight of January 1, 2016, and this property is set to 7d, the sink will delete any partitions " +
     "for time partitions older than midnight Dec 25, 2015.")
   @Nullable
+  @Macro
   protected String cleanPartitionsOlderThan;
 
   public TPFSSinkConfig(String name, @Nullable String basePath,
@@ -80,9 +87,11 @@ public abstract class TPFSSinkConfig extends PluginConfig {
   }
 
   public void validate() {
-    if (!Strings.isNullOrEmpty(timeZone) && Strings.isNullOrEmpty(filePathFormat)) {
+    if (!containsMacro("filePathFormat") && !Strings.isNullOrEmpty(timeZone) && Strings.isNullOrEmpty(filePathFormat)) {
       throw new IllegalArgumentException("The filePathFormat setting must be set in order to set timeZone.");
     }
+
+    // no macro checks necessary as at config time, string properties configured with macros are null
     if (partitionOffset != null) {
       TimeParser.parseDuration(partitionOffset);
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/SnapshotFileSetConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/SnapshotFileSetConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.common;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.plugin.PluginConfig;
 
@@ -29,12 +30,14 @@ public abstract class SnapshotFileSetConfig extends PluginConfig {
   @Name(Properties.SnapshotFileSetSink.NAME)
   @Description("Name of the PartitionedFileset Dataset to which the records are written to. " +
     "If it doesn't exist, it will be created.")
+  @Macro
   protected String name;
 
   @Name(Properties.SnapshotFileSetSink.BASE_PATH)
   @Description("The path where the data will be recorded. " +
     "Defaults to the name of the dataset.")
   @Nullable
+  @Macro
   protected String basePath;
 
   @Name(Properties.SnapshotFileSetSink.FILE_PROPERTIES)
@@ -42,6 +45,7 @@ public abstract class SnapshotFileSetConfig extends PluginConfig {
   @Description("Advanced feature to specify any additional properties that should be used with the sink, " +
     "specified as a JSON object of string to string. These properties are set on the dataset if one is created. " +
     "The properties are also passed to the dataset at runtime as arguments.")
+  @Macro
   protected String fileProperties;
 
   @Description("Optional property that configures the sink to delete old partitions after successful runs. " +
@@ -52,6 +56,7 @@ public abstract class SnapshotFileSetConfig extends PluginConfig {
     "run at midnight of January 1, 2016, and this property is set to 7d, the sink will delete any partitions " +
     "for time partitions older than midnight Dec 25, 2015.")
   @Nullable
+  @Macro
   protected String cleanPartitionsOlderThan;
 
   public SnapshotFileSetConfig(String name, @Nullable String basePath, @Nullable String fileProperties,


### PR DESCRIPTION
The following properties have had macros enabled:

`S3BatchSink(s)`:
- basePath
- accessID
- accessKey
- pathFormat
- fileSystemProperties

`TPFSSink(s)`:
- name
- basePath
- filePathFormat
- timeZone
- partitionOffset
- cleanPartitionsOlderThan

`SnapshotFileSetSink`:
- name
- basePath
- fileProperties
- cleanPartitionsOlderThan

Also addresses this JIRA: https://issues.cask.co/browse/HYDRA-394
