### PR TITLE
Enabled macros for spark plugins

### DIFF
--- a/spark-plugins/docs/Kafka-streamingsource.md
+++ b/spark-plugins/docs/Kafka-streamingsource.md
@@ -18,9 +18,9 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**brokers:** Comma-separated list of Kafka brokers specified in host1:port1,host2:port2 form.
+**brokers:** Comma-separated list of Kafka brokers specified in host1:port1,host2:port2 form. (Macro-enabled)
 
-**topics:** Comma-separated list of Kafka topics to read from.
+**topics:** Comma-separated list of Kafka topics to read from. (Macro-enabled)
 
 **schema:** Output schema of the source. If you would like the output records to contain a field with the
 Kafka message key, the schema must include a field of type bytes or nullable bytes, and you must set the

--- a/spark-plugins/docs/NaiveBayesClassifier-sparkcompute.md
+++ b/spark-plugins/docs/NaiveBayesClassifier-sparkcompute.md
@@ -11,16 +11,16 @@ This transform can be used when you have a saved NaiveBayes model and want to cl
 
 Properties
 ----------
-**fileSetName:** The name of the FileSet to load the model from.
+**fileSetName:** The name of the FileSet to load the model from. (Macro-enabled)
 
-**path:** Path of the FileSet to load the model from.
+**path:** Path of the FileSet to load the model from. (Macro-enabled)
 
 **fieldToClassify:** A space-separated sequence of words to classify.
 
 **predictionField:** The field on which to set the prediction. It will be of type double.
 
 **numFeatures:** The number of features to use when classifying with the trained model. This should be the same as
-the number of features used to train the model in NaiveBayesTrainer. The default value if none is provided will be 100.
+the number of features used to train the model in NaiveBayesTrainer. The default value if none is provided will be 100. (Macro-enabled)
 
 
 Example

--- a/spark-plugins/docs/NaiveBayesTrainer-sparksink.md
+++ b/spark-plugins/docs/NaiveBayesTrainer-sparksink.md
@@ -13,16 +13,16 @@ can be used for classification later on.
 
 Properties
 ----------
-**fileSetName:** The name of the FileSet to save the model to.
+**fileSetName:** The name of the FileSet to save the model to. (Macro-enabled)
 
-**path:** Path of the FileSet to save the model to.
+**path:** Path of the FileSet to save the model to. (Macro-enabled)
 
 **fieldToClassify:** A space-separated sequence of words to use for training.
 
 **predictionField:** The field from which to get the prediction. It must be of type double.
 
 **numFeatures:** The number of features to train the model with. This should be the same as the number of features
-used for the NaiveBayesClassifier. The default value if none is provided will be 100.
+used for the NaiveBayesClassifier. The default value if none is provided will be 100. (Macro-enabled)
 
 
 Example

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/batch/spark/KafkaConfig.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/batch/spark/KafkaConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.spark;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.format.RecordFormats;
@@ -44,9 +45,11 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
   private static final long serialVersionUID = 8069169417140954175L;
 
   @Description("Comma-separated list of Kafka brokers specified in host1:port1,host2:port2 form.")
+  @Macro
   private String brokers;
 
   @Description("Comma-separated list of Kafka topics to read from.")
+  @Macro
   private String topics;
 
   @Description("Output schema of the source, including the timeField and keyField. " +

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/batch/spark/NaiveBayesClassifier.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/batch/spark/NaiveBayesClassifier.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.spark;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -66,9 +67,11 @@ public class NaiveBayesClassifier extends SparkCompute<StructuredRecord, Structu
   public static class Config extends PluginConfig {
 
     @Description("The name of the FileSet to load the model from.")
+    @Macro
     private final String fileSetName;
 
     @Description("Path of the FileSet to load the model from.")
+    @Macro
     private final String path;
 
     @Description("A space-separated sequence of words to classify.")
@@ -81,6 +84,7 @@ public class NaiveBayesClassifier extends SparkCompute<StructuredRecord, Structu
     @Description("The number of features to use in training the model. It must be of type integer and equal to the" +
                   " number of features used in NaiveBayesTrainer. The default value if none is provided will be" +
                   " 100.")
+    @Macro
     private final Integer numFeatures;
 
     public Config(String fileSetName, String path, String fieldToClassify, String predictionField,

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/batch/spark/NaiveBayesTrainer.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/batch/spark/NaiveBayesTrainer.java
@@ -17,10 +17,12 @@
 package co.cask.hydrator.plugin.batch.spark;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.PipelineConfigurer;
@@ -56,9 +58,11 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
   public static class Config extends PluginConfig {
 
     @Description("The name of the FileSet to save the model to.")
+    @Macro
     private final String fileSetName;
 
     @Description("Path of the FileSet to save the model to.")
+    @Macro
     private final String path;
 
     @Description("A space-separated sequence of words to use for training.")
@@ -71,6 +75,7 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
     @Description("The number of features to use in training the model. It must be of type integer and equal to the" +
                   " number of features used in NaiveBayesClassifier. The default value if none is provided will be" +
                   " 100.")
+    @Macro
     private final Integer numFeatures;
 
     public Config(String fileSetName, String path, String fieldToClassify, String predictionField,
@@ -85,7 +90,9 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-    pipelineConfigurer.createDataset(config.fileSetName, FileSet.class);
+    if (!config.containsMacro("fileSetName")) {
+      pipelineConfigurer.createDataset(config.fileSetName, FileSet.class);
+    }
 
     Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
     if (inputSchema != null) {
@@ -104,7 +111,10 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
 
   @Override
   public void prepareRun(SparkPluginContext context) throws Exception {
-    // no-op; no need to do anything
+    // if macros were provided at configure time
+    if (!context.datasetExists(config.fileSetName)) {
+      context.createDataset(config.fileSetName, FileSet.class.getName(), DatasetProperties.EMPTY);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fields that have been macro enabled:

`NaiveBayesTrainer`:
- fileSetName
- path
- numFeatures

`NaiveBayesClassifier`:
- fileSetName
- path
- numFeatures

`KafkaStreamingSource`:
- brokers
- topics
