### PR TITLE
Enabled macros for remaining plugin packages

### DIFF
--- a/cassandra-plugins/docs/Cassandra-batchsink.md
+++ b/cassandra-plugins/docs/Cassandra-batchsink.md
@@ -19,23 +19,23 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**initialAddress:** The initial address to connect to.
+**initialAddress:** The initial address to connect to. (Macro-enabled)
 
 **port:** The RPC port for Cassandra.
-Check the configuration to make sure that ``start_rpc`` is true in ``cassandra.yaml``.
+Check the configuration to make sure that ``start_rpc`` is true in ``cassandra.yaml``. (Macro-enabled)
 
 **keyspace:** The keyspace to inject data into.
-Create the keyspace before starting the adapter.
+Create the keyspace before starting the adapter. (Macro-enabled)
 
-**partitioner:** The partitioner for the keyspace.
+**partitioner:** The partitioner for the keyspace. (Macro-enabled)
 
 **columnFamily:** The column family or table to inject data into.
-Create the column family before starting the adapter.
+Create the column family before starting the adapter. (Macro-enabled)
 
 **columns:** A comma-separated list of columns in the column family.
-The columns should be listed in the same order as they are stored in the column family.
+The columns should be listed in the same order as they are stored in the column family. (Macro-enabled)
 
-**primaryKey:** A comma-separated list of primary keys.
+**primaryKey:** A comma-separated list of primary keys. (Macro-enabled)
 
 
 Example

--- a/cassandra-plugins/docs/Cassandra-batchsource.md
+++ b/cassandra-plugins/docs/Cassandra-batchsource.md
@@ -19,29 +19,29 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**initialAddress:** The initial address to connect to.
+**initialAddress:** The initial address to connect to. (Macro-enabled)
 
 **port:** The RPC port for Cassandra.
-Check the configuration to make sure that ``start_rpc`` is true in ``cassandra.yaml``.
+Check the configuration to make sure that ``start_rpc`` is true in ``cassandra.yaml``. (Macro-enabled)
 
-**keyspace:** The keyspace to select data from.
+**keyspace:** The keyspace to select data from. (Macro-enabled)
 
-**partitioner:** The partitioner for the keyspace.
+**partitioner:** The partitioner for the keyspace. (Macro-enabled)
 
 **username:** The username for the keyspace (if one exists).
-If this is not empty, then you must supply a password.
+If this is not empty, then you must supply a password. (Macro-enabled)
 
 **password:** The password for the keyspace (if one exists).
-If this is not empty, then you must supply a username.
+If this is not empty, then you must supply a username. (Macro-enabled)
 
-**columnFamily:** The column family or table to select data from.
+**columnFamily:** The column family or table to select data from. (Macro-enabled)
 
-**query:** The query to select data on.
+**query:** The query to select data on. (Macro-enabled)
 
 **schema:** The schema for the data as it will be formatted in CDAP.
 
 **properties:** Any extra properties to include. The property-value pairs should be comma-separated,
-and each property should be separated by a colon from its corresponding value.
+and each property should be separated by a colon from its corresponding value. (Macro-enabled)
 
 
 Example

--- a/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCassandraSink.java
+++ b/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCassandraSink.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Output;
@@ -132,33 +133,40 @@ public class BatchCassandraSink
   public static class CassandraBatchConfig extends ReferencePluginConfig {
     @Name(Cassandra.PARTITIONER)
     @Description("The partitioner for the keyspace")
+    @Macro
     private String partitioner;
 
     @Name(Cassandra.PORT)
     @Nullable
     @Description("The RPC port for Cassandra. For example, 9160. " +
       "Please also check the configuration to make sure that start_rpc is true in cassandra.yaml.")
+    @Macro
     private Integer port;
 
     @Name(Cassandra.COLUMN_FAMILY)
     @Description("The column family to inject data into. Create the column family before starting the application.")
+    @Macro
     private String columnFamily;
 
     @Name(Cassandra.KEYSPACE)
     @Description("The keyspace to inject data into. Create the keyspace before starting the application.")
+    @Macro
     private String keyspace;
 
     @Name(Cassandra.INITIAL_ADDRESS)
     @Description("The initial address to connect to. For example: \"10.11.12.13\".")
+    @Macro
     private String initialAddress;
 
     @Name(Cassandra.COLUMNS)
     @Description("A comma-separated list of columns in the column family. " +
       "The columns should be listed in the same order as they are stored in the column family.")
+    @Macro
     private String columns;
 
     @Name(Cassandra.PRIMARY_KEY)
     @Description("A comma-separated list of primary keys. For example: \"key1,key2\".")
+    @Macro
     private String primaryKey;
 
     public CassandraBatchConfig(String referenceName, String partitioner, @Nullable Integer port, String columnFamily,

--- a/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchCassandraSource.java
+++ b/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchCassandraSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Input;
@@ -175,41 +176,49 @@ public class BatchCassandraSource extends ReferenceBatchSource<Long, Row, Struct
   public static class CassandraSourceConfig extends ReferencePluginConfig {
     @Name(Cassandra.PARTITIONER)
     @Description("The partitioner for the keyspace")
+    @Macro
     private String partitioner;
 
     @Name(Cassandra.PORT)
     @Nullable
     @Description("The RPC port for Cassandra; for example: 9160 (default value). " +
       "Check the configuration to make sure that start_rpc is true in cassandra.yaml.")
+    @Macro
     private Integer port;
 
     @Name(Cassandra.COLUMN_FAMILY)
     @Description("The column family to select data from.")
+    @Macro
     private String columnFamily;
 
     @Name(Cassandra.KEYSPACE)
     @Description("The keyspace to select data from.")
+    @Macro
     private String keyspace;
 
     @Name(Cassandra.INITIAL_ADDRESS)
     @Description("The initial address to connect to. For example: \"10.11.12.13\".")
+    @Macro
     private String initialAddress;
 
     @Name(Cassandra.USERNAME)
     @Description("The username for the keyspace (if one exists). " +
       "If this is not empty, then you must supply a password.")
     @Nullable
+    @Macro
     private String username;
 
     @Name(Cassandra.PASSWORD)
     @Description("The password for the keyspace (if one exists). " +
       "If this is not empty, then you must supply a username.")
     @Nullable
+    @Macro
     private String password;
 
     @Name(Cassandra.QUERY)
     @Description("The query to select data on. For example: \'SELECT * from table " +
       "where token(id) > ? and token(id) <= ?\'")
+    @Macro
     private String query;
 
     @Name(Cassandra.SCHEMA)
@@ -234,6 +243,7 @@ public class BatchCassandraSource extends ReferenceBatchSource<Long, Row, Struct
       "and each property should be separated by a colon from its corresponding value. " +
       "For example: \'cassandra.consistencylevel.read:LOCAL_ONE,cassandra.input.native.port:9042\'")
     @Nullable
+    @Macro
     private String properties;
 
     public CassandraSourceConfig(String referenceName, String partitioner, Integer port, String columnFamily,

--- a/copybookreader-plugins/docs/CopybookReader-batchsource.md
+++ b/copybookreader-plugins/docs/CopybookReader-batchsource.md
@@ -23,11 +23,11 @@ in sync with the underlying binary data to be read. This first implementation do
 of a COBOL copybook or redefines or iterators in the structure.
 
 **binaryFilePath:** Complete path of the .bin to be read. This will be a fixed-length binary format file that matches
-the copybook. Supports compressed files using a native compressed codec.
+the copybook. Supports compressed files using a native compressed codec. (Macro-enabled)
 
-**drop:** Comma-separated list of fields to drop. For example: 'field1,field2,field3'.
+**drop:** Comma-separated list of fields to drop. For example: 'field1,field2,field3'. (Macro-enabled)
 
-**maxSplitSize:** Maximum split-size(MB) for each mapper in the MapReduce Job. Defaults to 1MB.
+**maxSplitSize:** Maximum split-size(MB) for each mapper in the MapReduce Job. Defaults to 1MB. (Macro-enabled)
 
 Example
 -------

--- a/copybookreader-plugins/src/main/java/co/cask/hydrator/plugin/batch/CopybookSource.java
+++ b/copybookreader-plugins/src/main/java/co/cask/hydrator/plugin/batch/CopybookSource.java
@@ -16,6 +16,7 @@
 package co.cask.hydrator.plugin.batch;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Input;
@@ -231,6 +232,7 @@ public class CopybookSource extends BatchSource<LongWritable, Map<String, Abstra
       "or 'file:///home/cdap/DTAR020_FB.bin'.\n " +
       "This will be a fixed-length binary format file that matches the copybook.\n" +
       "(This is done to accept files present on a remote HDFS location.)")
+    @Macro
     private String binaryFilePath;
 
     @Description("Contents of the COBOL copybook file which will contain the data structure. For example: \n" +
@@ -250,10 +252,12 @@ public class CopybookSource extends BatchSource<LongWritable, Map<String, Abstra
 
     @Nullable
     @Description("Comma-separated list of fields to drop. For example: 'field1,field2,field3'.")
+    @Macro
     private String drop;
 
     @Nullable
     @Description("Maximum split-size(MB) for each mapper in the MapReduce Job. Defaults to 1MB.")
+    @Macro
     private Long maxSplitSize;
 
     public CopybookSourceConfig() {

--- a/elasticsearch-plugins/docs/Elasticsearch-batchsink.md
+++ b/elasticsearch-plugins/docs/Elasticsearch-batchsink.md
@@ -16,16 +16,16 @@ Configuration
 -------------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**es.host:** The hostname and port for the Elasticsearch instance.
+**es.host:** The hostname and port for the Elasticsearch instance. (Macro-enabled)
 
 **es.index:** The name of the index where the data will be stored; if the index does not
-already exist, it will be created using Elasticsearch's default properties.
+already exist, it will be created using Elasticsearch's default properties. (Macro-enabled)
 
 **es.type:** The name of the type where the data will be stored; if it does not already
-exist, it will be created.
+exist, it will be created. (Macro-enabled)
 
 **es.idField:** The field that will determine the id for the document; it should match a fieldname
-in the Structured Record of the input.
+in the Structured Record of the input. (Macro-enabled)
 
 
 Example

--- a/elasticsearch-plugins/docs/Elasticsearch-batchsource.md
+++ b/elasticsearch-plugins/docs/Elasticsearch-batchsource.md
@@ -15,14 +15,14 @@ Configuration
 -------------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**es.host:** The hostname and port for the Elasticsearch instance.
+**es.host:** The hostname and port for the Elasticsearch instance. (Macro-enabled)
 
-**es.index:** The name of the index to query.
+**es.index:** The name of the index to query. (Macro-enabled)
 
-**es.type:** The name of the type where the data is stored.
+**es.type:** The name of the type where the data is stored. (Macro-enabled)
 
 **query:** The query to use to import data from the specified index and type;
-see Elasticsearch for additional query examples.
+see Elasticsearch for additional query examples. (Macro-enabled)
 
 **schema:** The schema or mapping of the data in Elasticsearch.
 

--- a/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchElasticsearchSink.java
+++ b/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchElasticsearchSink.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Output;
@@ -98,18 +99,22 @@ public class BatchElasticsearchSink extends ReferenceBatchSink<StructuredRecord,
   public static class ESConfig extends ReferencePluginConfig {
     @Name(ESProperties.HOST)
     @Description(HOST_DESCRIPTION)
+    @Macro
     private String hostname;
 
     @Name(ESProperties.INDEX_NAME)
     @Description(INDEX_DESCRIPTION)
+    @Macro
     private String index;
 
     @Name(ESProperties.TYPE_NAME)
     @Description(TYPE_DESCRIPTION)
+    @Macro
     private String type;
 
     @Name(ESProperties.ID_FIELD)
     @Description(ID_DESCRIPTION)
+    @Macro
     private String idField;
 
     public ESConfig(String referenceName, String hostname, String index, String type, String idField) {

--- a/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/ElasticsearchSource.java
+++ b/elasticsearch-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/ElasticsearchSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Input;
@@ -123,18 +124,22 @@ public class ElasticsearchSource extends ReferenceBatchSource<Text, MapWritable,
   public static class ESConfig extends ReferencePluginConfig {
     @Name(ESProperties.HOST)
     @Description(HOST_DESCRIPTION)
+    @Macro
     private String hostname;
 
     @Name(ESProperties.INDEX_NAME)
     @Description(INDEX_DESCRIPTION)
+    @Macro
     private String index;
 
     @Name(ESProperties.TYPE_NAME)
     @Description(TYPE_DESCRIPTION)
+    @Macro
     private String type;
 
     @Name(ESProperties.QUERY)
     @Description(QUERY_DESCRIPTION)
+    @Macro
     private String query;
 
     @Name(ESProperties.SCHEMA)

--- a/hbase-plugins/docs/HBase-batchsink.md
+++ b/hbase-plugins/docs/HBase-batchsink.md
@@ -20,9 +20,9 @@ Properties
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
 **tableName:** The name of the table to write to. **Note:** Prior to running the pipeline,
-this table should already exist.
+this table should already exist. (Macro-enabled)
 
-**columnFamily:** The name of the column family to write to.
+**columnFamily:** The name of the column family to write to. (Macro-enabled)
 
 **schema:** Schema of records written to the table. Record fields map to row columns. For
 example, if the schema contains a field named 'user' of type string, the value of that
@@ -36,11 +36,11 @@ the schema, and must not be nullable.
 **zkQuorum:** The ZooKeeper quorum for the hbase instance you are writing to. This should
 be a comma-separated list of hosts that make up the quorum. You can find the correct value
 by looking at the ``hbase.zookeeper.quorum`` setting in your ``hbase-site.xml`` file. This value
-defaults to ``'localhost'``.
+defaults to ``'localhost'``. (Macro-enabled)
 
 **zkClientPort:** The client port used to connect to the ZooKeeper quorum.
 You can find the correct value by looking at the ``hbase.zookeeper.quorum`` setting in your ``hbase-site.xml``.
-This value defaults to ``2181``.
+This value defaults to ``2181``. (Macro-enabled)
 
 **zkNodeParent:** The parent node of HBase in ZooKeeper. 
 You can find the correct value by looking at the ``hbase.zookeeper.quorum`` setting in your ``hbase-site.xml``.

--- a/hbase-plugins/docs/HBase-batchsource.md
+++ b/hbase-plugins/docs/HBase-batchsource.md
@@ -19,9 +19,9 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**tableName:** The name of the table to read from.
+**tableName:** The name of the table to read from. (Macro-enabled)
 
-**columnFamily:** The name of the column family to read from.
+**columnFamily:** The name of the column family to read from. (Macro-enabled)
 
 **schema:** Schema of records read from the table. Row columns map to record
 fields. For example, if the schema contains a field named 'user' of type string, the value
@@ -35,11 +35,11 @@ the schema, and must not be nullable.
 **zkQuorum:** The ZooKeeper quorum for the hbase instance you are reading from. This should
 be a comma separated list of hosts that make up the quorum. You can find the correct value
 by looking at the hbase.zookeeper.quorum setting in your hbase-site.xml file. This value
-defaults to 'localhost'.
+defaults to 'localhost'. (Macro-enabled)
 
 **zkClientPort:** The client port used to connect to the ZooKeeper quorum.
 You can find the correct value by looking at the hbase.zookeeper.quorum setting in your hbase-site.xml.
-This value defaults to 2181.
+This value defaults to 2181. (Macro-enabled)
 
 
 Example

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/HBaseConfig.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/HBaseConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.hydrator.common.ReferencePluginConfig;
 import co.cask.hydrator.plugin.sink.HBaseSink;
 import co.cask.hydrator.plugin.source.HBaseSource;
@@ -28,9 +29,11 @@ import javax.annotation.Nullable;
 */
 public class HBaseConfig extends ReferencePluginConfig {
   @Description("Name of the HBase Table")
+  @Macro
   public String tableName;
 
   @Description("Name of the Column Family")
+  @Macro
   public String columnFamily;
 
   @Description("Schema of the Record to be emitted (in case of Source) or received (in case of Sink)")
@@ -41,10 +44,12 @@ public class HBaseConfig extends ReferencePluginConfig {
 
   @Description("Zookeeper Quorum. By default it is set to 'localhost'")
   @Nullable
+  @Macro
   public String zkQuorum;
 
   @Description("Zookeeper Client Port. By default it is set to 2181")
   @Nullable
+  @Macro
   public String zkClientPort;
 
   public HBaseConfig(String referenceName, String tableName, String rowField, @Nullable String schema) {

--- a/hive-plugins/docs/Hive-batchsink.md
+++ b/hive-plugins/docs/Hive-batchsink.md
@@ -21,7 +21,7 @@ Example: ``thrift://somehost.net:9083``.
 partition keys and values for that partition. For example: if the partition column is 'type', then this property
 should be specified as ``{"type": "typeOne"}``.
 To write multiple partitions simultaneously you can leave this empty; but all of the partitioning columns must
-be present in the data you are writing to the sink.
+be present in the data you are writing to the sink. (Macro-enabled)
 
 **schema:** Optional schema to use while writing to the Hive table. If no schema is provided, then the schema of the
 table will be used and it should match the schema of the data being written.

--- a/hive-plugins/docs/Hive-batchsource.md
+++ b/hive-plugins/docs/Hive-batchsource.md
@@ -19,7 +19,7 @@ Example: ``thrift://somehost.net:9083``.
 **databaseName:** The name of the database. Defaults to 'default'.
 
 **partitions:** Optional Hive expression filter for scan. This filter must only reference partition columns.
-Values from other columns will cause the pipeline to fail.
+Values from other columns will cause the pipeline to fail. (Macro-enabled)
 
 **schema:** Optional schema to use while reading from the Hive table. If no schema is provided, then the schema of the
 table will be used. Note: if you want to use a Hive table which has non-primitive types as a source, then you

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveSinkConfig.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveSinkConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.hydrator.plugin.batch.HiveConfig;
 
@@ -34,6 +35,7 @@ public class HiveSinkConfig extends HiveConfig {
     "To write multiple partitions simultaneously you can leave this empty, but all of the partitioning columns must " +
     "be present in the data you are writing to the sink.")
   @Nullable
+  @Macro
   public String partitions;
 
   @Name(Hive.SCHEMA)

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveSourceConfig.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveSourceConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.hydrator.plugin.batch.HiveConfig;
 
@@ -31,6 +32,7 @@ public class HiveSourceConfig extends HiveConfig {
     "partitioned on 'type' and you want to read 'type1' partition: 'type = \"type1\"'" +
     "This filter must reference only partition columns. Values from other columns will cause the pipeline to fail.")
   @Nullable
+  @Macro
   public String partitions;
 
   @Name(Hive.SCHEMA)

--- a/http-plugins/src/main/java/co/cask/hydrator/plugin/batch/HTTPCallbackAction.java
+++ b/http-plugins/src/main/java/co/cask/hydrator/plugin/batch/HTTPCallbackAction.java
@@ -64,10 +64,10 @@ public class HTTPCallbackAction extends PostAction {
   @SuppressWarnings("ConstantConditions")
   @Override
   public void run(BatchActionContext batchActionContext) throws Exception {
+    conf.validate();
     if (!conf.shouldRun(batchActionContext)) {
       return;
     }
-    conf.validate();
 
     int retries = 0;
     Exception exception = null;
@@ -152,7 +152,7 @@ public class HTTPCallbackAction extends PostAction {
     @SuppressWarnings("ConstantConditions")
     public void validate() {
       super.validate();
-      if (!METHODS.contains(method.toUpperCase())) {
+      if (!containsMacro("method") && !METHODS.contains(method.toUpperCase())) {
         throw new IllegalArgumentException(String.format("Invalid request method %s, must be one of %s.",
                                                          method, Joiner.on(',').join(METHODS)));
       }
@@ -163,7 +163,11 @@ public class HTTPCallbackAction extends PostAction {
     }
 
     public boolean shouldRun(BatchActionContext context) {
-      return new ConditionConfig(runCondition).shouldRun(context);
+      if (!containsMacro("runCondition")) {
+        return new ConditionConfig(runCondition).shouldRun(context);
+      } else {
+        return false;
+      }
     }
   }
 }

--- a/mongodb-plugins/docs/MongoDB-batchsink.md
+++ b/mongodb-plugins/docs/MongoDB-batchsink.md
@@ -10,5 +10,5 @@ Configuration
 -------------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**connectionString:** MongoDB Connection String. Example: `mongodb://localhost:27017/analytics.users`
+**connectionString:** MongoDB Connection String. Example: `mongodb://localhost:27017/analytics.users` (Macro-enabled)
 [Reference](http://docs.mongodb.org/manual/reference/connection-string)

--- a/mongodb-plugins/docs/MongoDB-batchsource.md
+++ b/mongodb-plugins/docs/MongoDB-batchsource.md
@@ -11,21 +11,21 @@ Configuration
 -------------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**connectionString:** MongoDB connection string. Example: `mongodb://localhost:27017/analytics.users` 
+**connectionString:** MongoDB connection string. Example: `mongodb://localhost:27017/analytics.users` (Macro-enabled)
 [Reference](http://docs.mongodb.org/manual/reference/connection-string)
 
 **schema:** Specifies the schema of the documents.
 
-**authConnectionString:** Auxiliary MongoDB connection string to authenticate against when constructing splits.
+**authConnectionString:** Auxiliary MongoDB connection string to authenticate against when constructing splits. (Macro-enabled)
 
 **inputQuery:** Optionally filter the input collection with a query. This query must be represented in JSON format
-and use the MongoDB extended-JSON format to represent non-native JSON data types.
+and use the MongoDB extended-JSON format to represent non-native JSON data types. (Macro-enabled)
 
 **inputFields:** Projection document that can limit the fields that appear in each document. 
-If no projection document is provided, all fields will be read.
+If no projection document is provided, all fields will be read. (Macro-enabled)
 
 **splitterClass:** The name of the Splitter class to use. If left empty, the MongoDB Hadoop Connector will attempt
-to make a best-guess as to which Splitter to use. The Hadoop connector provides these Splitters:
+to make a best-guess as to which Splitter to use. (Macro-enabled) The Hadoop connector provides these Splitters:
 
   - `com.mongodb.hadoop.splitter.StandaloneMongoSplitter`
   - `com.mongodb.hadoop.splitter.ShardMongoSplitter`

--- a/mongodb-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/MongoDBBatchSink.java
+++ b/mongodb-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/MongoDBBatchSink.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Output;
@@ -95,6 +96,7 @@ public class MongoDBBatchSink extends ReferenceBatchSink<StructuredRecord, NullW
     @Name(Properties.CONNECTION_STRING)
     @Description("MongoDB Connection String (see http://docs.mongodb.org/manual/reference/connection-string); " +
       "Example: 'mongodb://localhost:27017/analytics.users'.")
+    @Macro
     private String connectionString;
 
     public MongoDBSinkConfig(String referenceName, String connectionString) {

--- a/mongodb-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/MongoDBBatchSource.java
+++ b/mongodb-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/MongoDBBatchSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Input;
@@ -120,11 +121,13 @@ public class MongoDBBatchSource extends ReferenceBatchSource<Object, BSONObject,
     @Name(Properties.CONNECTION_STRING)
     @Description("MongoDB Connection String (see http://docs.mongodb.org/manual/reference/connection-string); " +
       "Example: 'mongodb://localhost:27017/analytics.users'.")
+    @Macro
     private String connectionString;
 
     @Name(Properties.AUTH_CONNECTION_STRING)
     @Nullable
     @Description("Auxiliary MongoDB connection string to authenticate against when constructing splits.")
+    @Macro
     private String authConnectionString;
 
     @Name(Properties.SCHEMA)
@@ -148,6 +151,7 @@ public class MongoDBBatchSource extends ReferenceBatchSource<Object, BSONObject,
     @Description("Optionally filter the input collection with a query. This query must be represented in JSON " +
       "format, and use the MongoDB extended JSON format to represent non-native JSON data types.")
     @Nullable
+    @Macro
     private String inputQuery;
 
 
@@ -155,12 +159,14 @@ public class MongoDBBatchSource extends ReferenceBatchSource<Object, BSONObject,
     @Nullable
     @Description("A projection document limiting the fields that appear in each document. " +
       "If no projection document is provided, all fields will be read.")
+    @Macro
     private String inputFields;
 
     @Name(Properties.SPLITTER_CLASS)
     @Nullable
     @Description("The name of the Splitter class to use. If left empty, the MongoDB Hadoop Connector will attempt " +
       "to make a best guess as to what Splitter to use.")
+    @Macro
     private String splitterClass;
 
     public MongoDBConfig(String referenceName, String connectionString, String authConnectionString,


### PR DESCRIPTION
The following properties have been macro-enabled:
## Cassandra Plugins

`BatchCassandraSink`:
- partitioner
- port
- columnFamily
- keySpace
- initialAddress
- columns
- primaryKey

`BatchCassandraSource`:
- partitioner
- port
- columnFamily
- keyspace
- initialAddress
- username
- password
- query
- properties
## Copybook Plugins

`CopybookSource`:
- binaryFilePath
- drop
- maxSplitSize
## Elasticsearch Plugins

`BatchElasticsearchSink`:
- hostname
- index
- type
- idField

`ElasticsearchSource`:
- hostname
- index
- type
- query
## HBase Plugins

`HBaseSource`:
- tableName
- columnFamily
- zkQuorum
- zkClientPort

`HBaseSink`:
- tableName
- columnFamily
- zkQuorum
- zkClientPort
## Hive Plugins

`HiveSink`:
- partitions

`HiveSource`:
- partitions
## HTTP Plugins

Fixed a bug with validating the `method` property.
## MongoDB Plugins

`MongoDBBatchSink`:
- connectionString

`MongoDBBatchSource`:
- connectionString
- authConnectionString
- inputQuery
- inputFields
- splitterClass
