### PR TITLE
initial implementation for dynamic partitioning sink plugin

### DIFF
--- a/core-plugins/docs/DynamicPFSParquet-batchsink.md
+++ b/core-plugins/docs/DynamicPFSParquet-batchsink.md
@@ -1,0 +1,53 @@
+# Dynamic PartitionedFileSet Parquet Batch Sink
+
+
+Description
+-----------
+Sink for a ``PartitionedFileSet`` that writes data in Parquet format
+and leverages one or more record field values for creating partitions.
+All data for the run will be written to a partition based on the
+specified fields and their value.
+
+
+Use Case
+--------
+This sink is used whenever you want to write to a ``PartitionedFileSet`` in Parquet format
+using a value from the record as a partition. For example, you might want to load historical
+data from a database and partition the dataset on the original creation date of the data.
+
+
+Properties
+----------
+**name:** Name of the ``PartitionedFileSet`` to which records are written.
+If it doesn't exist, it will be created.
+
+**schema:** The Avro schema of the record being written to the sink as a JSON Object.
+
+**basePath:** Base path for the ``PartitionedFileSet``. Defaults to the name of the dataset.
+
+Example
+-------
+This example will write to a ``PartitionedFileSet`` named ``'users'`` using the original
+``'create_date'`` of the record as the partition:
+
+    {
+        "name": "DynamicPFSParquet",
+        "type": "batchsink",
+        "properties": {
+            "name": "users",
+            "fieldNames": "create_date",
+            "schema": "{
+                \"type\":\"record\",
+                \"name\":\"user\",
+                \"fields\":[
+                    {\"name\":\"id\",\"type\":\"long\"},
+                    {\"name\":\"name\",\"type\":\"string\"},
+                    {\"name\":\"create_date\",\"type\":\"string\"}
+                ]
+            }"
+        }
+    }
+
+It will write data in Parquet format using the given schema. Every time the pipeline runs, 
+partitions will be determined in the ``PartitionedFileSet`` based on the ``create_date``
+of each record.

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/DynamicPartitionFileSetParquetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/DynamicPartitionFileSetParquetSink.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.sink;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.hydrator.common.HiveSchemaConverter;
+import co.cask.hydrator.plugin.common.StructuredToAvroTransformer;
+import org.apache.avro.generic.GenericRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import parquet.avro.AvroParquetInputFormat;
+import parquet.avro.AvroParquetOutputFormat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link BatchSink} to write Parquet records to a {@link PartitionedFileSet}.
+ */
+@Plugin(type = "batchsink")
+@Name("DynamicPFSParquet")
+@Description("Sink for a PartitionedFileSet that writes data in Parquet format and uses a dynamic partition key.")
+public class DynamicPartitionFileSetParquetSink extends
+  PartitionedFileSetSink<Void, GenericRecord> {
+  public static final String NAME = "DynamicPFSParquet";
+  public static final String PARTITION_COL_PREFIX = "p_";
+
+  private static final Logger LOG = LoggerFactory.getLogger(DynamicPartitionFileSetParquetSink.class);
+  private static final String SCHEMA_DESC = "The Parquet schema of the record being written to the Sink as a JSON " +
+    "Object.";
+  private static final String FIELD_DESC = "The fields to be used for the partitions as comma separated values.";
+
+  private StructuredToAvroTransformer recordTransformer;
+  private final DynamicPartitionParquetSinkConfig config;
+
+  public DynamicPartitionFileSetParquetSink(DynamicPartitionParquetSinkConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) {
+    Map<String, String> sinkArgs = getAdditionalPFSArguments();
+    PartitionedFileSetArguments.setDynamicPartitioner(sinkArgs, FieldValueDynamicPartitioner.class);
+    context.addOutput(Output.ofDataset(config.name, sinkArgs));
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    String pfsName = config.name;
+    String basePath = config.basePath == null ? pfsName : config.basePath;
+
+    String schema = config.schema.toLowerCase();
+    // parse to make sure it's valid
+    new org.apache.avro.Schema.Parser().parse(schema);
+    String hiveSchema;
+    Schema parsedSchema;
+    try {
+      parsedSchema = Schema.parseJson(schema);
+      hiveSchema = HiveSchemaConverter.toHiveSchema(parsedSchema);
+    } catch (UnsupportedTypeException | IOException e) {
+      throw new RuntimeException("Error: Schema is not valid ", e);
+    }
+
+    Partitioning.Builder partitionBuilder = Partitioning.builder();
+    String[] partitionFields = config.fieldNames.split(",");
+    for (int i = 0; i < partitionFields.length; i++) {
+      // We need to make the name of the partitioned column unique to avoid 'Column repeated in partitioning columns'
+      // errors with Hive.
+      String partitionedFieldName = PARTITION_COL_PREFIX + partitionFields[i];
+      if (parsedSchema.getField(partitionedFieldName) == null) {
+        partitionBuilder.addStringField(PARTITION_COL_PREFIX + partitionFields[i]);
+      } else {
+        throw new IllegalArgumentException(String.format("The partition field: '%s' is already defined in the schema.",
+                                                         partitionedFieldName));
+      }
+    }
+
+    pipelineConfigurer.createDataset(pfsName, PartitionedFileSet.class.getName(),
+                                     PartitionedFileSetProperties.builder()
+                                       .setPartitioning(partitionBuilder.build())
+                                       .setBasePath(basePath)
+                                       .setInputFormat(AvroParquetInputFormat.class)
+                                       .setOutputFormat(AvroParquetOutputFormat.class)
+                                       .setEnableExploreOnCreate(true)
+                                       .setExploreFormat("parquet")
+                                       .setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1))
+                                       .add(DatasetProperties.SCHEMA, schema)
+                                       .build());
+  }
+
+  @Override
+  protected Map<String, String> getAdditionalPFSArguments() {
+    Map<String, String> args = new HashMap<>();
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "parquet.avro.schema", config.schema.toLowerCase());
+    return args;
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+    recordTransformer = new StructuredToAvroTransformer(config.schema);
+  }
+
+  @Override
+  public void transform(StructuredRecord input,
+                        Emitter<KeyValue<Void, GenericRecord>> emitter) throws Exception {
+    emitter.emit(new KeyValue<Void, GenericRecord>(null, recordTransformer.transform(input)));
+  }
+
+  /**
+   * Config for DynamicPartitionFileSetParquetSink
+   */
+  public static class DynamicPartitionParquetSinkConfig extends PartitionedFileSetSinkConfig {
+    public static final String FIELD_NAMES_PROPERTY_KEY = "fieldNames";
+
+    @Description(SCHEMA_DESC)
+    private String schema;
+    @Description(FIELD_DESC)
+    private String fieldNames;
+
+    public DynamicPartitionParquetSinkConfig(String name, String schema, String fieldNames, @Nullable String basePath) {
+      super(name, basePath);
+      this.schema = schema;
+      this.fieldNames = fieldNames;
+    }
+  }
+
+  /**
+   * Dynamic partitioner that creates partitions based on a list of fields in each record.
+   */
+  public static final class FieldValueDynamicPartitioner extends DynamicPartitioner<Void, GenericRecord> {
+    private String[] fieldNames;
+
+    @Override
+    public void initialize(MapReduceTaskContext mapReduceTaskContext) {
+      if (mapReduceTaskContext.getPluginProperties(DynamicPartitionFileSetParquetSink.NAME) == null) {
+        throw new IllegalArgumentException("Could not find a plugin with the name: " +
+                                             DynamicPartitionFileSetParquetSink.NAME + " in the list of plugins.");
+      }
+      // Need a better way to do this. [CDAP-7058]
+      fieldNames = mapReduceTaskContext
+        .getPluginProperties(DynamicPartitionFileSetParquetSink.NAME)
+        .getProperties().get(DynamicPartitionParquetSinkConfig.FIELD_NAMES_PROPERTY_KEY).split(",");
+    }
+
+    @Override
+    public PartitionKey getPartitionKey(Void key, GenericRecord value) {
+      PartitionKey.Builder keyBuilder = PartitionKey.builder();
+      for (int i = 0; i < fieldNames.length; i++) {
+        if (value.get(fieldNames[i]) == null) {
+          // This call will result in an exception but there's nothing else I can do. [CDAP-7053]
+          keyBuilder.addStringField(DynamicPartitionFileSetParquetSink.PARTITION_COL_PREFIX + fieldNames[i],
+                                    null);
+        } else {
+          keyBuilder.addStringField(DynamicPartitionFileSetParquetSink.PARTITION_COL_PREFIX + fieldNames[i],
+                                    String.valueOf(value.get(fieldNames[i])));
+        }
+      }
+      return keyBuilder.build();
+    }
+  }
+
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/PartitionedFileSetSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/PartitionedFileSetSink.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.sink;
+
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * PFS Batch Sink class that stores sink data
+ * @param <KEY_OUT> the type of key the sink outputs
+ * @param <VAL_OUT> the type of value the sink outputs
+ */
+public abstract class PartitionedFileSetSink<KEY_OUT, VAL_OUT>
+  extends BatchSink<StructuredRecord, KEY_OUT, VAL_OUT> {
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionedFileSetSink.class);
+
+  protected final PartitionedFileSetSinkConfig partitionedSinkConfig;
+
+  protected PartitionedFileSetSink(PartitionedFileSetSinkConfig partitionedSinkConfig) {
+    this.partitionedSinkConfig = partitionedSinkConfig;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    partitionedSinkConfig.validate();
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) {
+    Map<String, String> sinkArgs = getAdditionalPFSArguments();
+    context.addOutput(Output.ofDataset(partitionedSinkConfig.name, sinkArgs));
+  }
+
+  /**
+   * @return any additional properties that need to be set for the sink. For example, avro sink requires
+   *         setting some schema output key.
+   */
+  protected Map<String, String> getAdditionalPFSArguments() {
+    return new HashMap<>();
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/PartitionedFileSetSinkConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/PartitionedFileSetSinkConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.sink;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.plugin.PluginConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Abstract config for TimePartitionedFileSetSink
+ */
+public abstract class PartitionedFileSetSinkConfig extends PluginConfig {
+  private static final String DEFAULT_FORMAT = "value";
+
+  @Description("Name of the Partitioned FileSet Dataset to which the records " +
+               "are written to. If it doesn't exist, it will be created.")
+  protected String name;
+
+  @Description("The base path for the Partitioned FileSet. Defaults to the " +
+               "name of the dataset.")
+  @Nullable
+  protected String basePath;
+
+  public PartitionedFileSetSinkConfig(String name, @Nullable String basePath) {
+    this.name = name;
+    this.basePath = basePath;
+  }
+
+  public void validate() {
+
+  }
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
@@ -18,6 +18,8 @@ package co.cask.hydrator.plugin.batch;
 
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.datapipeline.DataPipelineApp;
 import co.cask.cdap.etl.api.PipelineConfigurable;
@@ -37,7 +39,9 @@ import co.cask.hydrator.plugin.batch.aggregator.DedupAggregator;
 import co.cask.hydrator.plugin.batch.aggregator.GroupByAggregator;
 import co.cask.hydrator.plugin.batch.joiner.Joiner;
 import co.cask.hydrator.plugin.batch.sink.BatchCubeSink;
+import co.cask.hydrator.plugin.batch.sink.DynamicPartitionFileSetParquetSink;
 import co.cask.hydrator.plugin.batch.sink.KVTableSink;
+import co.cask.hydrator.plugin.batch.sink.PartitionedFileSetSink;
 import co.cask.hydrator.plugin.batch.sink.S3AvroBatchSink;
 import co.cask.hydrator.plugin.batch.sink.S3ParquetBatchSink;
 import co.cask.hydrator.plugin.batch.sink.SnapshotFileBatchAvroSink;
@@ -140,6 +144,7 @@ public class ETLBatchTestBase extends TestBase {
                       TimePartitionedFileSetDatasetAvroSource.class,
                       TimePartitionedFileSetDatasetParquetSource.class, AvroParquetInputFormat.class,
                       BatchCubeSink.class, KVTableSink.class, TableSink.class,
+                      DynamicPartitionFileSetParquetSink.class, PartitionedFileSetSink.class,
                       TimePartitionedFileSetDatasetAvroSink.class, AvroKeyOutputFormat.class, AvroKey.class,
                       TimePartitionedFileSetDatasetParquetSink.class, AvroParquetOutputFormat.class,
                       SnapshotFileBatchAvroSink.class, SnapshotFileBatchParquetSink.class,
@@ -167,6 +172,13 @@ public class ETLBatchTestBase extends TestBase {
         records.addAll(readOutput(timeLoc, schema));
       }
     }
+    return records;
+  }
+
+  protected List<GenericRecord> readOutput(PartitionedFileSet fileSet, Schema schema, PartitionKey partitionKey)
+    throws IOException {
+    List<GenericRecord> records = Lists.newArrayList();
+    records.addAll(readOutput(fileSet.getPartition(partitionKey).getLocation(), schema));
     return records;
   }
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLDynamicPFSTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLDynamicPFSTestRun.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionFilter;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.batch.ETLWorkflow;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.WorkflowManager;
+import com.google.common.collect.ImmutableMap;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.hadoop.fs.Path;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Test;
+import parquet.avro.AvroParquetWriter;
+import parquet.hadoop.ParquetWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class ETLDynamicPFSTestRun extends ETLBatchTestBase {
+
+  @Test
+  public void testDynamicParquetSink() throws Exception {
+    Schema recordSchema = Schema.recordOf("record",
+                                          Schema.Field.of("i", Schema.of(Schema.Type.INT)),
+                                          Schema.Field.of("to_part_on", Schema.of(Schema.Type.STRING))
+    );
+
+    ETLPlugin sourceConfig = new ETLPlugin("TPFSParquet",
+                                           BatchSource.PLUGIN_TYPE,
+                                           ImmutableMap.of(
+                                             "schema", recordSchema.toString(),
+                                             "name", "inputParquet",
+                                             "delay", "0d",
+                                             "duration", "1h"),
+                                           null);
+    ETLPlugin sinkConfig = new ETLPlugin("DynamicPFSParquet",
+                                         BatchSink.PLUGIN_TYPE,
+                                         ImmutableMap.of(
+                                           "schema", recordSchema.toString(),
+                                           "name", "outputParquet",
+                                           "fieldNames", "to_part_on"),
+                                         null);
+
+    ETLStage source = new ETLStage("source", sourceConfig);
+    ETLStage sink = new ETLStage("DynamicPFSParquet", sinkConfig);
+
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(source)
+      .addStage(sink)
+      .addConnection(source.getName(), sink.getName())
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "parquetTest");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // write input to read
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(recordSchema.toString());
+    List<GenericRecord> toWrite = new ArrayList<>();
+    toWrite.add(new GenericRecordBuilder(avroSchema)
+      .set("i", Integer.MAX_VALUE)
+      .set("to_part_on", "something_else")
+      .build());
+    toWrite.add(new GenericRecordBuilder(avroSchema)
+      .set("i", Integer.MAX_VALUE)
+      .set("to_part_on", "something")
+      .build());
+    DataSetManager<TimePartitionedFileSet> inputManager = getDataset("inputParquet");
+
+    long timeInMillis = System.currentTimeMillis();
+    inputManager.get().addPartition(timeInMillis, "directory");
+    inputManager.flush();
+    Location location = inputManager.get().getPartitionByTime(timeInMillis).getLocation();
+    location = location.append("file.parquet");
+    ParquetWriter<GenericRecord> parquetWriter =
+      new AvroParquetWriter<>(new Path(location.toURI()), avroSchema);
+    for (GenericRecord record : toWrite) {
+      parquetWriter.write(record);
+    }
+    parquetWriter.close();
+    inputManager.flush();
+
+    // run the pipeline
+    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    // add a minute to the end time to make sure the newly added partition is included in the run.
+    workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis + 60 * 1000)));
+    workflowManager.waitForFinish(4, TimeUnit.MINUTES);
+
+    DataSetManager<PartitionedFileSet> outputManager = getDataset("outputParquet");
+    PartitionedFileSet newFileSet = outputManager.get();
+    Assert.assertEquals(1, newFileSet.getPartitioning().getFields().size());
+    Assert.assertTrue(newFileSet.getPartitioning().getFields().containsKey("p_to_part_on"));
+
+    Set<PartitionDetail> partitions = newFileSet.getPartitions(PartitionFilter.ALWAYS_MATCH);
+    Assert.assertEquals(2, partitions.size());
+
+    for (int i = 0; i < partitions.size(); i++) {
+
+      List<GenericRecord> newRecords = readOutput(newFileSet, recordSchema,
+                                                  ((PartitionDetail) partitions.toArray()[i]).getPartitionKey());
+      Assert.assertEquals(1, newRecords.size());
+      Assert.assertEquals(toWrite.get(i), newRecords.get(0));
+    }
+  }
+}

--- a/core-plugins/widgets/DynamicPFSParquet-batchsink.json
+++ b/core-plugins/widgets/DynamicPFSParquet-batchsink.json
@@ -1,0 +1,44 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Dynamic Partitioned Fileset - Parquet",
+      "properties": [
+        {
+          "widget-type": "dataset-selector",
+          "label": "Dataset Name",
+          "name": "name"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Dataset Base Path",
+          "name": "basePath"
+        },
+        {
+          "widget-type": "csv",
+          "label": "Field Names",
+          "name": "fieldNames"
+        }
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "schema",
+      "widget-type": "schema",
+      "widget-attributes": {
+        "schema-types": [
+          "boolean",
+          "int",
+          "long",
+          "float",
+          "double",
+          "string"
+        ],
+        "schema-default-type": "string"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The purpose of this plugin is to allow users to use values in each record for partitioning. For example, if a user has records with "name" and "original_create_date" and they specify they want to partition on original_create_date, the resulting File Dataset will have a partition for each value in original_create_date. The use case for this is a user loading historical data from a DB or set of files and would like to keep the data partitioned on the original transaction or load date instead of the run date of the load.
