### PR TITLE
Enabled macros for transform plugins

### DIFF
--- a/transform-plugins/docs/CSVFormatter-transform.md
+++ b/transform-plugins/docs/CSVFormatter-transform.md
@@ -10,9 +10,9 @@ delimiters that a CSV Record should use for separating fields.
 
 Configuration
 -------------
-**format:** Specifies the format of the CSV Record to be generated.
+**format:** Specifies the format of the CSV Record to be generated. (Macro-enabled)
 
 **delimiter:** Specifies the delimiter to be used to generate a CSV Record; 
-this option is available when the format is specified as ``DELIMITED``.
+this option is available when the format is specified as ``DELIMITED``. (Macro-enabled)
 
 **schema:** Specifies the output schema. Output schema should only have fields of type String.

--- a/transform-plugins/docs/CSVParser-transform.md
+++ b/transform-plugins/docs/CSVParser-transform.md
@@ -10,7 +10,7 @@ Supports these CSV Record types: ``DEFAULT``, ``EXCEL``, ``MYSQL``, ``RFC4180``,
 
 Configuration
 -------------
-**format:** Specifies the format of the CSV Record the input should be parsed as.
+**format:** Specifies the format of the CSV Record the input should be parsed as. (Macro-enabled)
 
 **field:** Specifies the input field that should be parsed as a CSV Record. 
 Input records with a null input field propagate all other fields and set fields that

--- a/transform-plugins/docs/CloneRecord-transform.md
+++ b/transform-plugins/docs/CloneRecord-transform.md
@@ -9,4 +9,4 @@ This transform does not change any record fields or types. It's an identity tran
 
 Configuration
 -------------
-**copies:** Specifies the numbers of copies of the input record that are to be emitted.
+**copies:** Specifies the numbers of copies of the input record that are to be emitted. (Macro-enabled)

--- a/transform-plugins/docs/Compressor-transform.md
+++ b/transform-plugins/docs/Compressor-transform.md
@@ -10,7 +10,7 @@ Plugin supports SNAPPY, ZIP, and GZIP types of compression of fields.
 Configuration
 -------------
 **compressor:** Specifies the configuration for compressing fields; in JSON configuration, 
-this is specified as ``<field>:<compressor>[,<field>:<compressor>]*``.
+this is specified as ``<field>:<compressor>[,<field>:<compressor>]*``. (Macro-enabled)
 
 **schema:** Specifies the output schema; the fields that are compressed will have the same field name 
 but they will be of type ``BYTES``.

--- a/transform-plugins/docs/Decoder-transform.md
+++ b/transform-plugins/docs/Decoder-transform.md
@@ -10,7 +10,7 @@ Available decoding methods are ``STRING_BASE64``, ``BASE64``, ``BASE32``, ``STRI
 Configuration
 -------------
 **decode:** Specifies the configuration for decode fields; in JSON configuration, 
-this is specified as ``<field>:<decoder>[,<field>:<decoder>]*``.
+this is specified as ``<field>:<decoder>[,<field>:<decoder>]*``. (Macro-enabled)
 
 **schema:** Specifies the output schema; the fields that are decoded will have the same field 
 name but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Decompressor-transform.md
+++ b/transform-plugins/docs/Decompressor-transform.md
@@ -11,7 +11,7 @@ decompression of fields.
 Configuration
 -------------
 **decompressor:** Specifies the configuration for decompressing fields; in JSON configuration, 
-this is specified as ``<field>:<decompressor>[,<field>:<decompressor>]*``.
+this is specified as ``<field>:<decompressor>[,<field>:<decompressor>]*``. (Macro-enabled)
 
 **schema:** Specifies the output schema; the fields that are decompressed will have the same field 
 name but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Decryptor-transform.md
+++ b/transform-plugins/docs/Decryptor-transform.md
@@ -9,7 +9,7 @@ that must be present on all nodes of the cluster.
 
 Configuration
 -------------
-**decryptFields** Specifies the fields to decrypt, separated by commas
+**decryptFields** Specifies the fields to decrypt, separated by commas (Macro-enabled)
 
 **schema** Schema to pull records from
 

--- a/transform-plugins/docs/Encoder-transform.md
+++ b/transform-plugins/docs/Encoder-transform.md
@@ -10,7 +10,7 @@ Available encoding methods are ``STRING_BASE64``, ``BASE64``, ``BASE32``, ``STRI
 Configuration
 -------------
 **encode:** Specifies the configuration for encode fields; in JSON configuration, 
-this is specified as ``<field>:<encoder>[,<field>:<encoder>]*``.
+this is specified as ``<field>:<encoder>[,<field>:<encoder>]*``. (Macro-enabled)
 
 **schema:** Specifies the output schema; the fields that are encoded will have the same field name 
 but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Encryptor-transform.md
+++ b/transform-plugins/docs/Encryptor-transform.md
@@ -9,7 +9,7 @@ that must be present on all nodes of the cluster.
 
 Configuration
 -------------
-**encyrptFields** Specifies the fields to encrypt, separated by commas.
+**encyrptFields** Specifies the fields to encrypt, separated by commas. (Macro-enabled)
 
 **transformation** Transformation algorithm/mode/padding. For example, AES/CBC/PKCS5Padding.
 

--- a/transform-plugins/docs/Hasher-transform.md
+++ b/transform-plugins/docs/Hasher-transform.md
@@ -8,6 +8,6 @@ Hashes fields using a digest algorithm such as ``MD2``, ``MD5``, ``SHA1``, ``SHA
 
 Configuration
 -------------
-**fields:** Specifies the fields to be hashed.
+**fields:** Specifies the fields to be hashed. (Macro-enabled)
 
-**hash:** Specifies the hashing algorithm.
+**hash:** Specifies the hashing algorithm. (Macro-enabled)

--- a/transform-plugins/docs/StreamFormatter-transform.md
+++ b/transform-plugins/docs/StreamFormatter-transform.md
@@ -9,11 +9,11 @@ It will include a header and body configurations. The body of the Stream event c
 
 Configuration
 -------------
-**body:** Specifies the input Structured Record fields that should be included in the body of the Stream event.
+**body:** Specifies the input Structured Record fields that should be included in the body of the Stream event. (Macro-enabled)
 
-**header:** Specifies the input Structured Record fields that should be included in the header of the Stream event.
+**header:** Specifies the input Structured Record fields that should be included in the header of the Stream event. (Macro-enabled)
 
-**format:** Specifies the format of the body. Currently supported formats are ``JSON``, ``CSV``, ``TSV``, and ``PSV``.
+**format:** Specifies the format of the body. Currently supported formats are ``JSON``, ``CSV``, ``TSV``, and ``PSV``. (Macro-enabled)
 
 **schema:** Specifies the output schema; the output schema can have only two fields: one of type ``STRING`` 
 and the other of type ``MAP<STRING, STRING>``.

--- a/transform-plugins/docs/ValueMapper-transform.md
+++ b/transform-plugins/docs/ValueMapper-transform.md
@@ -29,7 +29,7 @@ Properties
 **mapping:** A comma-separated list that defines the mapping of a source
 field to a target field and the mapping table name for looking up values.
 Contains three properties separated by a colon (":") as the source field, the
-mapping table name, and the target field:
+mapping table name, and the target field (Macro-enabled):
 
          <source-field>:<mapping-table-name>:<target-field>
 
@@ -39,7 +39,7 @@ Note: **source field** supports only STRING types.
 source field and its default value for cases where the source field
 value is either null or empty or if the mapping key-value is not present. If
 a default value has not been provided, the source field value will be
-mapped to the target field. Only STRING NULLABLE type values are accepted.
+mapped to the target field. Only STRING NULLABLE type values are accepted. (Macro-enabled)
 Example: <source field>:<defaultValue>
 
 

--- a/transform-plugins/docs/XMLParser-transform.md
+++ b/transform-plugins/docs/XMLParser-transform.md
@@ -17,9 +17,9 @@ Reader Batch Source to extract values from XMLNews documents and create structur
 Properties
 ----------
 
-**input:** The field in the input record that is the source of the XML event or record.
+**input:** The field in the input record that is the source of the XML event or record. (Macro-enabled)
 
-**encoding:** The source XML character set encoding (default UTF-8).
+**encoding:** The source XML character set encoding (default UTF-8). (Macro-enabled)
 
 **xPathMappings:** Mapping of the field names to the XPaths of the XML record. A comma-separated list, each element of
 which is a field name, followed by a colon, followed by an XPath expression. XPath location paths can include predicates

--- a/transform-plugins/docs/XMLToJSON-transform.md
+++ b/transform-plugins/docs/XMLToJSON-transform.md
@@ -19,4 +19,4 @@ be converted to a JSON string.
 
 **outputField:** Specifies the output field where the JSON string will
 be stored. If it is not present in the output schema, it will be
-added.
+added. (Macro-enabled)

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVFormatter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVFormatter.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -27,6 +28,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.csv.CSVFormat;
@@ -101,23 +103,7 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-
-    if (!delimMap.containsKey(config.delimiter)) {
-      throw new IllegalArgumentException("Unknown delimiter '" + config.delimiter + "' specified. ");
-    }
-
-    // Check if the format specified is valid.
-    if (config.format == null || config.format.isEmpty()) {
-      throw new IllegalArgumentException("Format is not specified. Allowed values are DELIMITED, EXCEL, MYSQL," +
-                                           " RFC4180 & TDF");
-    }
-
-    if (!config.format.equalsIgnoreCase("DELIMITED") && !config.format.equalsIgnoreCase("EXCEL") &&
-      !config.format.equalsIgnoreCase("MYSQL") && !config.format.equalsIgnoreCase("RFC4180") &&
-      !config.format.equalsIgnoreCase("TDF")) {
-      throw new IllegalArgumentException("Format specified is not one of the allowed values. Allowed values are " +
-                                           "DELIMITED, EXCEL, MYSQL, RFC4180 & TDF");
-    }
+    config.validate();
 
     // Check if schema specified is a valid schema or no.
     try {
@@ -139,6 +125,7 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
   @Override
   public void initialize(TransformContext context) throws Exception {
     super.initialize(context);
+    config.validate();
 
     try {
       outSchema = Schema.parseJson(config.schema);
@@ -209,10 +196,12 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
 
     @Name("format")
     @Description("Specify one of the predefined formats. DEFAULT, EXCEL, MYSQL, RFC4180 & TDF are supported formats.")
+    @Macro
     private final String format;
 
     @Name("delimiter")
     @Description("Specify delimiter to be used for separating fields.")
+    @Macro
     private final String delimiter;
 
     @Name("schema")
@@ -223,6 +212,26 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
       this.format = format;
       this.delimiter = delimiter;
       this.schema = schema;
+    }
+
+    private void validate() {
+      if (!containsMacro("delimiter") && !delimMap.containsKey(delimiter)) {
+        throw new IllegalArgumentException("Unknown delimiter '" + delimiter + "' specified. Allowed values are " +
+                                             Joiner.on(", ").join(delimMap.keySet()));
+      }
+
+      // Check if the format specified is valid.
+      if (!containsMacro("format") && (format == null || format.isEmpty())) {
+        throw new IllegalArgumentException("Format is not specified. Allowed values are DELIMITED, EXCEL, MYSQL," +
+                                             " RFC4180 & TDF");
+      }
+
+      if (!containsMacro("format") && !format.equalsIgnoreCase("DELIMITED") && !format.equalsIgnoreCase("EXCEL") &&
+        !format.equalsIgnoreCase("MYSQL") && !format.equalsIgnoreCase("RFC4180") &&
+        !format.equalsIgnoreCase("TDF")) {
+        throw new IllegalArgumentException("Format specified is not one of the allowed values. Allowed values are " +
+                                             "DELIMITED, EXCEL, MYSQL, RFC4180 & TDF");
+      }
     }
   }
 }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Compressor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Compressor.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.common.Bytes;
@@ -115,7 +116,9 @@ public final class Compressor extends Transform<StructuredRecord, StructuredReco
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    parseConfiguration(config.compressor);
+    if (!config.containsMacro("compressor")) {
+      parseConfiguration(config.compressor);
+    }
     // Check if schema specified is a valid schema or no. 
     try {
       Schema outputSchema = Schema.parseJson(config.schema);
@@ -283,6 +286,7 @@ public final class Compressor extends Transform<StructuredRecord, StructuredReco
     @Name("compressor")
     @Description("Specify the field and compression type combination. " +
       "Format is <field>:<compressor-type>[,<field>:<compressor-type>]*")
+    @Macro
     private final String compressor;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decoder.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decoder.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -97,7 +98,9 @@ public final class Decoder extends Transform<StructuredRecord, StructuredRecord>
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    parseConfiguration(config.decode);
+    if (!config.containsMacro("decode")) {
+      parseConfiguration(config.decode);
+    }
 
     Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
 
@@ -228,6 +231,7 @@ public final class Decoder extends Transform<StructuredRecord, StructuredRecord>
     @Name("decode")
     @Description("Specify the field and decode type combination. " +
       "Format is <field>:<decode-type>[,<field>:<decode-type>]*")
+    @Macro
     private final String decode;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decompressor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decompressor.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -92,7 +93,9 @@ public final class Decompressor extends Transform<StructuredRecord, StructuredRe
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    parseConfiguration(config.decompressor);
+    if (!config.containsMacro("decompressor")) {
+      parseConfiguration(config.decompressor);
+    }
 
     // Check if schema specified is a valid schema or no.
     try {
@@ -286,6 +289,7 @@ public final class Decompressor extends Transform<StructuredRecord, StructuredRe
     @Name("decompressor")
     @Description("Specify the field and decompression type combination. " +
       "Format is <field>:<decompressor-type>[,<field>:<decompressor-type>]*")
+    @Macro
     private final String decompressor;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encoder.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encoder.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -94,7 +95,9 @@ public final class Encoder extends Transform<StructuredRecord, StructuredRecord>
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    parseConfiguration(config.encode);
+    if (!config.containsMacro("encode")) {
+      parseConfiguration(config.encode);
+    }
 
     Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
     // for the fields in input schema, if they are to be encoded (if present in encodeMap)
@@ -228,6 +231,7 @@ public final class Encoder extends Transform<StructuredRecord, StructuredRecord>
     @Name("encode")
     @Description("Specify the field and encode type combination. " +
       "Format is <field>:<encode-type>[,<field>:<encode-type>]*")
+    @Macro
     private final String encode;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encryptor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encryptor.java
@@ -61,7 +61,9 @@ public final class Encryptor extends Transform<StructuredRecord, StructuredRecor
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
     Schema inputSchema = stageConfigurer.getInputSchema();
-    encryptFields = conf.getEncryptFields();
+    if (!conf.containsMacro("encryptFields")) {
+      encryptFields = conf.getEncryptFields();
+    }
     Schema outputSchema = inputSchema == null ? null : getOutputSchema(inputSchema);
     stageConfigurer.setOutputSchema(outputSchema);
   }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Hasher.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Hasher.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -53,6 +54,7 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
   @Override
   public void initialize(TransformContext context) throws Exception {
     super.initialize(context);
+    config.validate();
     // Split the fields to be hashed.
     String[] fields = config.fields.split(",");
     for (String field : fields) {
@@ -63,14 +65,7 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    
-    // Checks if hash specified is one of the supported types. 
-    if (!config.hash.equalsIgnoreCase("md2") && !config.hash.equalsIgnoreCase("md5") &&
-        !config.hash.equalsIgnoreCase("sha1") && !config.hash.equalsIgnoreCase("sha256") &&
-        !config.hash.equalsIgnoreCase("sha384") && !config.hash.equalsIgnoreCase("sha512")) {
-      throw new IllegalArgumentException("Invalid hasher '" + config.hash + "' specified. Allowed hashers are md2, " +
-                                           "md5, sha1, sha256, sha384 and sha512");  
-    }
+    config.validate();
     pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
   }
 
@@ -119,15 +114,27 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
     @Name("hash")
     @Description("Specifies the Hash method for hashing fields.")
     @Nullable
+    @Macro
     private final String hash;
     
     @Name("fields")
     @Description("List of fields to hash. Only string fields are allowed")
+    @Macro
     private final String fields;
     
     public Config(String hash, String fields) {
       this.hash = hash;
       this.fields = fields;
+    }
+
+    private void validate() {
+      // Checks if hash specified is one of the supported types.
+      if (!containsMacro("hash") && !hash.equalsIgnoreCase("md2") && !hash.equalsIgnoreCase("md5") &&
+        !hash.equalsIgnoreCase("sha1") && !hash.equalsIgnoreCase("sha256") &&
+        !hash.equalsIgnoreCase("sha384") && !hash.equalsIgnoreCase("sha512")) {
+        throw new IllegalArgumentException("Invalid hasher '" + hash + "' specified. Allowed hashers are md2, " +
+                                             "md5, sha1, sha256, sha384 and sha512");
+      }
     }
   }
 }

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Normalize.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Normalize.java
@@ -61,7 +61,7 @@ public class Normalize extends Transform<StructuredRecord, StructuredRecord> {
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    config.validateConfig();
+    config.validate();
 
     try {
       outputSchema = Schema.parseJson(config.outputSchema);
@@ -228,7 +228,7 @@ public class Normalize extends Transform<StructuredRecord, StructuredRecord> {
       this.outputSchema = outputSchema;
     }
 
-    void validateConfig() {
+    private void validate() {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(fieldMapping), "Fields to mapped cannot be empty.");
       Preconditions.checkArgument(!Strings.isNullOrEmpty(fieldNormalizing), "Fields to normalized cannot be empty.");
       Preconditions.checkArgument(!Strings.isNullOrEmpty(outputSchema), "Output schema cannot be empty.");

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/ValueMapper.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/ValueMapper.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -64,12 +65,14 @@ public class ValueMapper extends Transform<StructuredRecord, StructuredRecord> {
             "[,<source-field>:<lookup-table-name>:<target-field>]*" +
             "Source and target field can only of type string." +
             "For example: lang_code:language_code_lookup:lang_desc,country_code:country_lookup:country_name")
+    @Macro
     private final String mapping;
 
     @Name("defaults")
     @Description("Specify the defaults for source fields if the lookup does not exist or inputs are NULL or EMPTY. " +
             "Format is <source-field>:<default-value>[,<source-field>:<default-value>]*" +
             "For example: lang_code:English,country_code:Britain")
+    @Macro
     private final String defaults;
 
     public Config(String mapping, String defaults) {

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLParser.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -223,9 +224,11 @@ public class XMLParser extends Transform<StructuredRecord, StructuredRecord> {
 
     @Name("input")
     @Description("The field in the input record that is the source of the XML event or record.")
+    @Macro
     private final String inputField;
 
     @Description("The source XML character set encoding (default UTF-8).")
+    @Macro
     private final String encoding;
 
     @Name("xPathMappings")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLToJSON.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/XMLToJSON.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -133,6 +134,7 @@ public final class XMLToJSON extends Transform<StructuredRecord, StructuredRecor
 
     @Name("outputField")
     @Description("The field containing the XML string to convert into a JSON string.")
+    @Macro
     private String outputField;
 
     @Name("schema")


### PR DESCRIPTION
The following properties have been macro-enabled:

`CSVFormatter`:
- format
- delimiter

`CSVParser`:
- format

`CloneRecord`:
- copies

`Compressor`:
- compressor

`Decoder`:
- decode

`Decompressor`:
- decompressor

`Decryptor`:
- decryptFields

`Encoder`:
- encode

`Encryptor`:
- encryptFields

`Hasher`:
- hash
- fields

`Normalize`:
- Updated `validate` method to align with other plugins.

`StreamFormatter`: 
- body
- header
- format

`ValueMapper`:
- mapping
- defaults

`XMLParser`:
- inputField
- encoding

`XMLToJSON`:
- outputFields
