### PR TITLE
[HYDRA-681] Remove redundant null checks for plugin config properties

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCubeSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCubeSink.java
@@ -83,10 +83,8 @@ public class BatchCubeSink extends BatchWritableSink<StructuredRecord, byte[], C
   @Override
   protected Map<String, String> getProperties() {
     Map<String, String> properties = new HashMap<>();
-    // done only for testing
-    if (config.getProperties() != null) {
-      properties.putAll(config.getProperties().getProperties());
-    }
+    properties.putAll(config.getProperties().getProperties());
+
     // add aggregations
     if (!Strings.isNullOrEmpty(config.getAggregations())) {
       properties.remove(Properties.Cube.AGGREGATIONS);

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchWritableSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchWritableSink.java
@@ -48,8 +48,7 @@ public abstract class BatchWritableSink<IN, KEY_OUT, VAL_OUT> extends BatchSink<
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     // null check for tests, as macro fields map and properties are null in test cases
-    if (batchReadableWritableConfig.getProperties() != null &&
-      !batchReadableWritableConfig.containsMacro(Properties.BatchReadableWritable.NAME)) {
+    if (!batchReadableWritableConfig.containsMacro(Properties.BatchReadableWritable.NAME)) {
       String datasetName = getProperties().get(Properties.BatchReadableWritable.NAME);
       Preconditions.checkArgument(datasetName != null && !datasetName.isEmpty(), "Dataset name must be given.");
       String datasetType = getProperties().get(Properties.BatchReadableWritable.TYPE);

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/KVTableSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/KVTableSink.java
@@ -113,14 +113,9 @@ public class KVTableSink extends BatchWritableSink<StructuredRecord, byte[], byt
 
   @Override
   protected Map<String, String> getProperties() {
-
     Map<String, String> properties;
-    // will be null only in tests
-    if (kvTableConfig.getProperties() == null) {
-      properties = new HashMap<>();
-    } else {
-      properties = new HashMap<>(kvTableConfig.getProperties().getProperties());
-    }
+    properties = new HashMap<>(kvTableConfig.getProperties().getProperties());
+
     properties.put(Properties.BatchReadableWritable.NAME, kvTableConfig.getName());
     properties.put(Properties.BatchReadableWritable.TYPE, KeyValueTable.class.getName());
     return properties;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TableSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/TableSink.java
@@ -83,12 +83,8 @@ public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> 
   @Override
   protected Map<String, String> getProperties() {
     Map<String, String> properties;
-    if (tableSinkConfig.getProperties() == null) {
-      // NOTE : this is null only in unit-tests
-      properties = new HashMap<>();
-    } else {
-      properties = new HashMap<>(tableSinkConfig.getProperties().getProperties());
-    }
+    properties = new HashMap<>(tableSinkConfig.getProperties().getProperties());
+
     properties.put(Properties.BatchReadableWritable.NAME, tableSinkConfig.getName());
     properties.put(Properties.BatchReadableWritable.TYPE, Table.class.getName());
     return properties;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/dataset/SnapshotFileSet.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/dataset/SnapshotFileSet.java
@@ -66,16 +66,14 @@ public class SnapshotFileSet {
       propertiesBuilder.setBasePath(config.getBasePath());
     }
 
-    if (config.getProperties() != null) {
-      try {
-        Map<String, String> properties = GSON.fromJson(config.getFileProperties(), MAP_TYPE);
-        if (properties != null) {
-          propertiesBuilder.addAll(properties);
-        }
-      } catch (Exception e) {
-        throw new IllegalArgumentException("Could not decode the 'properties' setting. Please check that it " +
-          "is a JSON Object of string to string. Failed with error: " + e.getMessage(), e);
+    try {
+      Map<String, String> properties = GSON.fromJson(config.getFileProperties(), MAP_TYPE);
+      if (properties != null) {
+        propertiesBuilder.addAll(properties);
       }
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Could not decode the 'properties' setting. Please check that it " +
+        "is a JSON Object of string to string. Failed with error: " + e.getMessage(), e);
     }
 
     return propertiesBuilder;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/realtime/sink/RealtimeTableSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/realtime/sink/RealtimeTableSink.java
@@ -58,12 +58,7 @@ public class RealtimeTableSink extends RealtimeSink<StructuredRecord> {
     super.configurePipeline(pipelineConfigurer);
 
     Map<String, String> properties;
-    if (tableSinkConfig.getProperties() == null) {
-      // NOTE : this is null only in unit-tests
-      properties = new HashMap<>();
-    } else {
-      properties = tableSinkConfig.getProperties().getProperties();
-    }
+    properties = tableSinkConfig.getProperties().getProperties();
 
     Preconditions.checkArgument(!Strings.isNullOrEmpty(tableSinkConfig.getName()), "Dataset name must be given.");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(tableSinkConfig.getRowField()),

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/realtime/source/JmsSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/realtime/source/JmsSource.java
@@ -116,9 +116,7 @@ public class JmsSource extends ReferenceRealtimeSource<StructuredRecord> {
     super.initialize(context);
 
     Map<String, String> runtimeArguments = Maps.newHashMap();
-    if (config.getProperties() != null) {
-      runtimeArguments.putAll(config.getProperties().getProperties());
-    }
+    runtimeArguments.putAll(config.getProperties().getProperties());
 
     // if the JMS config has custom properties lets load it
     if (config.customProperties != null) {

--- a/kafka-plugins/src/main/java/co/cask/hydrator/plugin/realtime/KafkaSource.java
+++ b/kafka-plugins/src/main/java/co/cask/hydrator/plugin/realtime/KafkaSource.java
@@ -279,19 +279,15 @@ public class KafkaSource extends ReferenceRealtimeSource<StructuredRecord> {
         // try to parse the schema if there is one
         Schema schemaObj = parseSchema();
 
-        if (getProperties() != null) {
-          // strip format.settings. from any properties and use them in the format spec
-          ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-          for (Map.Entry<String, String> entry : getProperties().getProperties().entrySet()) {
-            if (entry.getKey().startsWith(FORMAT_SETTING_PREFIX)) {
-              String key = entry.getKey();
-              builder.put(key.substring(FORMAT_SETTING_PREFIX.length(), key.length()), entry.getValue());
-            }
+        // strip format.settings. from any properties and use them in the format spec
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (Map.Entry<String, String> entry : getProperties().getProperties().entrySet()) {
+          if (entry.getKey().startsWith(FORMAT_SETTING_PREFIX)) {
+            String key = entry.getKey();
+            builder.put(key.substring(FORMAT_SETTING_PREFIX.length(), key.length()), entry.getValue());
           }
-          formatSpec = new FormatSpecification(format, schemaObj, builder.build());
-        } else {
-          formatSpec = new FormatSpecification(format, schemaObj, null);
         }
+        formatSpec = new FormatSpecification(format, schemaObj, builder.build());
       }
       return formatSpec;
     }


### PR DESCRIPTION
After https://github.com/caskdata/cdap/pull/6434, PluginConfig will never have null properties, even in unit tests. We should remove the now-redundant checks and unit tests should still work.

Issue: https://issues.cask.co/browse/HYDRA-681
Build: http://builds.cask.co/browse/HYP-BAD63-1
