### PR TITLE
Added macros to core plugin batch sources

### DIFF
--- a/core-plugins/docs/AzureBlobStore-batchsource.md
+++ b/core-plugins/docs/AzureBlobStore-batchsource.md
@@ -20,12 +20,12 @@ Properties
 
 **account:** The Microsoft Azure Blob Storage account to use. This is of the form 
 `mystorageaccount.blob.core.windows.net`, where `mystorageaccount` is the Microsoft 
-Azure Storage account name.
+Azure Storage account name. (Macro-enabled)
 
-**container:** The container to use on the specified Microsoft Azure Storage account.
+**container:** The container to use on the specified Microsoft Azure Storage account. (Macro-enabled)
 
 **storageKey:** The storage key for the specified container on the Microsoft Azure Storage account. 
-Must be a valid base64 encoded storage key provided by Microsoft Azure.
+Must be a valid base64 encoded storage key provided by Microsoft Azure. (Macro-enabled)
 
 Example
 -------

--- a/core-plugins/docs/Excel-batchsource.md
+++ b/core-plugins/docs/Excel-batchsource.md
@@ -21,25 +21,25 @@ not to reprocess a particular file.
 Properties
 ----------
 
-**filePath:** Path of the excel file(s) to be read. Supports below formats:
+**filePath:** Path of the excel file(s) to be read. (Macro-enabled) Supports below formats:
 
       Microsoft Excel 97(-2007) file format
       Microsoft Excel XML (2007+) file format
 
 **filePattern:** Regex pattern to select specific excel file(s) from the path provided
-in **filePath** input.
+in **filePath** input. (Macro-enabled)
 
 **memoryTableName:** KeyValue table name to keep the track of processed files. This can be
-a new table or existing one.
+a new table or existing one. (Macro-enabled)
 
-**reprocess:** Specify whether the files mentioned in the memory table should be reprocessed or not.
+**reprocess:** Specify whether the files mentioned in the memory table should be reprocessed or not. (Macro-enabled)
 
-**sheet:** Specifies whether sheet has to be processed by sheet name or sheet no.
+**sheet:** Specifies whether sheet has to be processed by sheet name or sheet no. (Macro-enabled)
 
 **sheetValue:** Specifies the value corresponding to 'sheet' input. Value can be either actual
 sheet name or sheet no.
 for example: 'Sheet1' or '1' in case user selects 'Sheet Name' or 'Sheet Number' as 'sheet'
-input respectively.
+input respectively. (Macro-enabled)
 
 **columnList:** Specify the excel column names which needs to be extracted from the excel sheet.
 Column name has to be same as excel column name; for example: A, B, etc.
@@ -48,13 +48,13 @@ Column name has to be same as excel column name; for example: A, B, etc.
 excel column to be renamed, with its corresponding value specifying the new name for that column.
 Column name has to be same as excel column name; for example: A, B, etc.
 
-**skipFirstRow:** Specify whether the first row in the excel sheet needs to be processed or not.
+**skipFirstRow:** Specify whether the first row in the excel sheet needs to be processed or not. (Macro-enabled)
 
 **terminateIfEmptyRow:** Specify whether processing needs to be terminated in case an empty row is
-encountered while processing excel files.
+encountered while processing excel files. (Macro-enabled)
 
 **rowsLimit:** Maximum row limit for each sheet to be processed. If, the limit is not provided then
-all the rows in the sheet will be processed.
+all the rows in the sheet will be processed. (Macro-enabled)
 
 **outputSchema:** Mapping of excel column names in the output schema to data types. Consists of
 a comma-separated list. This input is mandatory if no inputs for 'columnList' has been provided.
@@ -63,9 +63,9 @@ Column name has to be same as excel column name; for example: A, B, etc.
 If type has not been provided for a column mentioned in **columnList** input, then output data type
 of that column will be **string**.
 
-**ifErrorRecord:** Specifies the action to be take in case of an error.
+**ifErrorRecord:** Specifies the action to be take in case of an error. (Macro-enabled)
 
-**errorDatasetName:** Table name to keep the error record encountered while processing the excel file(s).
+**errorDatasetName:** Table name to keep the error record encountered while processing the excel file(s). (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/FTP-batchsource.md
+++ b/core-plugins/docs/FTP-batchsource.md
@@ -16,15 +16,15 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**path:** Path to file(s) to be read. Path is expected to be of the form prefix://username:password@hostname:port/path
+**path:** Path to file(s) to be read. Path is expected to be of the form prefix://username:password@hostname:port/path (Macro-enabled)
 
-**fileRegex:** Regex to filter out filenames in the path.
+**fileRegex:** Regex to filter out filenames in the path. (Macro-enabled)
 
 **fileSystemProperties:** A JSON string representing a map of properties
-needed for the distributed file system.
+needed for the distributed file system. (Macro-enabled)
 
 **inputFormatClassName:** Name of the input format class, which must be a subclass of FileInputFormat.
-Defaults to CombineTextInputFormat.
+Defaults to CombineTextInputFormat. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -22,7 +22,7 @@ Properties
 **fileSystemProperties:** A JSON string representing a map of properties
 needed for the distributed file system.
 For example, the property names needed for S3 are "fs.s3n.awsSecretAccessKey"
-and "fs.s3n.awsAccessKeyId".
+and "fs.s3n.awsAccessKeyId". (Macro-enabled)
 
 **path:** Path to file(s) to be read. If a directory is specified,
 terminate the path name with a '/'.
@@ -33,15 +33,15 @@ reading in files with the File log naming convention of *YYYY-MM-DD-HH-mm-SS-Tag
 The TimeFilter reads in files from the previous hour if the field ``timeTable`` is
 left blank. If it's currently *2015-06-16-15* (June 16th 2015, 3pm), it will read
 in files that contain *2015-06-16-14* in the filename. If the field ``timeTable`` is
-present, then it will read in files that have not yet been read.
+present, then it will read in files that have not yet been read. (Macro-enabled)
 
 **timeTable:** Name of the Table that keeps track of the last time files
-were read in.
+were read in. (Macro-enabled)
 
 **inputFormatClass:** Name of the input format class, which must be a
-subclass of FileInputFormat. Defaults to CombineTextInputFormat.
+subclass of FileInputFormat. Defaults to CombineTextInputFormat. (Macro-enabled)
 
-**maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB.
+**maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/KVTable-batchsource.md
+++ b/core-plugins/docs/KVTable-batchsource.md
@@ -15,7 +15,7 @@ you may want to periodically dump the contents of a KeyValueTable to a Table.
 
 Properties
 ----------
-**name:** KeyValueTable name. If the table does not already exist, it will be created.
+**name:** KeyValueTable name. If the table does not already exist, it will be created. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/S3-batchsource.md
+++ b/core-plugins/docs/S3-batchsource.md
@@ -17,12 +17,12 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**accessID:** Access ID of the Amazon S3 instance to connect to.
+**accessID:** Access ID of the Amazon S3 instance to connect to. (Macro-enabled)
 
-**accessKey:** Access Key of the Amazon S3 instance to connect to.
+**accessKey:** Access Key of the Amazon S3 instance to connect to. (Macro-enabled)
 
 **path:** Path to file(s) to be read. If a directory is specified,
-terminate the path name with a '/'.
+terminate the path name with a '/'. (Macro-enabled)
 
 **fileRegex:** Regex to filter out filenames in the path.
 To use the *TimeFilter*, input ``timefilter``. The TimeFilter assumes that it is
@@ -30,15 +30,15 @@ reading in files with the File log naming convention of *YYYY-MM-DD-HH-mm-SS-Tag
 The TimeFilter reads in files from the previous hour if the field ``timeTable`` is
 left blank. If it is currently *2015-06-16-15* (June 16th 2015, 3pm), it will read
 in files that contain *2015-06-16-14* in the filename. If the field ``timeTable`` is
-present, then it will read in files that have not yet been read.
+present, then it will read in files that have not yet been read. (Macro-enabled)
 
 **timeTable:** Name of the Table that keeps track of the last time files
-were read in.
+were read in. (Macro-enabled)
 
 **inputFormatClass:** Name of the input format class, which must be a
-subclass of FileInputFormat. Defaults to TextInputFormat.
+subclass of FileInputFormat. Defaults to TextInputFormat. (Macro-enabled)
 
-**maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB.
+**maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/SnapshotAvro-batchsource.md
+++ b/core-plugins/docs/SnapshotAvro-batchsource.md
@@ -19,15 +19,15 @@ read the most recent snapshot and run some data analysis on it.
 Properties
 ----------
 **name:** Name of the PartitionedFileSet to which records are written.
-If it doesn't exist, it will be created.
+If it doesn't exist, it will be created. (Macro-enabled)
 
 **schema:** The Avro schema of the record being written to the sink as a JSON object.
 
-**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset.
+**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset. (Macro-enabled)
 
 **fileProperties:** Advanced feature to specify any additional properties that should be used with the sink,
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
-The properties are also passed to the dataset at runtime as arguments.
+The properties are also passed to the dataset at runtime as arguments. (Macro-enabled)
 
 **cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
 If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.

--- a/core-plugins/docs/SnapshotParquet-batchsource.md
+++ b/core-plugins/docs/SnapshotParquet-batchsource.md
@@ -19,15 +19,15 @@ this source to read the most recent snapshot and run a data analysis on it.
 Properties
 ----------
 **name:** Name of the PartitionedFileSet to which records are written.
-If it doesn't exist, it will be created.
+If it doesn't exist, it will be created. (Macro-enabled)
 
 **schema:** The Parquet schema of the record being written to the sink as a JSON object.
 
-**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset.
+**basePath:** Base path for the PartitionedFileSet. Defaults to the name of the dataset. (Macro-enabled)
 
 **fileProperties:** Advanced feature to specify any additional properties that should be used with the sink,
 specified as a JSON object of string to string. These properties are set on the dataset if one is created.
-The properties are also passed to the dataset at runtime as arguments.
+The properties are also passed to the dataset at runtime as arguments. (Macro-enabled)
 
 **cleanPartitionsOlderThan:** Optional property that configures the sink to delete partitions older than a specified date-time after a successful run.
 If set, when a run successfully finishes, the sink will subtract this amount of time from the runtime and delete any delete any partitions for time partitions older than that.

--- a/core-plugins/docs/Stream-batchsource.md
+++ b/core-plugins/docs/Stream-batchsource.md
@@ -22,17 +22,17 @@ the cleansed data for that hour as Avro files.
 Properties
 ----------
 **name:** Name of the stream. Must be a valid stream name. If the stream does not exist,
-it will be created.
+it will be created. (Macro-enabled)
     
 **duration:** Size of the time window to read with each run of the pipeline. The format is
 expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with
 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of
-'5m' means each run of the pipeline will read 5 minutes of events from the stream.
+'5m' means each run of the pipeline will read 5 minutes of events from the stream. (Macro-enabled)
 
 **delay:** Optional delay for reading stream events. The value must be of the same format
 as the duration value. For example, a duration of '5m' and a delay of '10m' means each run
 of the pipeline will read events from 15 minutes before its logical start time to 10
-minutes before its logical start time. The default value is 0.
+minutes before its logical start time. The default value is 0. (Macro-enabled)
 
 **format:** Optional format of the stream. Any format supported by CDAP is also supported.
 For example, a value of 'csv' will attempt to parse stream events as comma separated

--- a/core-plugins/docs/TPFSAvro-batchsource.md
+++ b/core-plugins/docs/TPFSAvro-batchsource.md
@@ -16,22 +16,22 @@ reads the newly-arrived files, performs data validation and cleansing, and then 
 
 Properties
 ----------
-**name:** Name of the TimePartitionedFileSet from which the records are to be read from.
+**name:** Name of the TimePartitionedFileSet from which the records are to be read from. (Macro-enabled)
 
 **schema:** The Avro schema of the record being read from the source as a JSON Object.
 
 **basePath:** Base path for the TimePartitionedFileSet. Defaults to the name of the
-dataset.
+dataset. (Macro-enabled)
 
 **duration:** Size of the time window to read with each run of the pipeline. The format is
 expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with
 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of
-'5m' means each run of the pipeline will read 5 minutes of events from the TPFS source.
+'5m' means each run of the pipeline will read 5 minutes of events from the TPFS source. (Macro-enabled)
 
 **delay:** Optional delay for reading from TPFS source. The value must be of the same
 format as the duration value. For example, a duration of '5m' and a delay of '10m' means
 each run of the pipeline will read events 5 minutes of data from 15 minutes before its logical
-start time to 10 minutes before its logical start time. The default value is 0.
+start time to 10 minutes before its logical start time. The default value is 0. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/TPFSParquet-batchsource.md
+++ b/core-plugins/docs/TPFSParquet-batchsource.md
@@ -16,22 +16,22 @@ reads the newly-arrived files, performs data validation and cleansing, and then 
 
 Properties
 ----------
-**name:** Name of the TimePartitionedFileSet from which the records are to be read from.
+**name:** Name of the TimePartitionedFileSet from which the records are to be read from. (Macro-enabled)
 
 **schema:** The Parquet schema of the record being read from the source as a JSON Object.
 
 **basePath:** Base path for the TimePartitionedFileSet. Defaults to the name of the
-dataset.
+dataset. (Macro-enabled)
 
 **duration:** Size of the time window to read with each run of the pipeline. The format is
 expected to be a number followed by an 's', 'm', 'h', or 'd' (specifying the time unit), with
 's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of
-'5m' means each run of the pipeline will read 5 minutes of events from the TPFS source.
+'5m' means each run of the pipeline will read 5 minutes of events from the TPFS source. (Macro-enabled)
 
 **delay:** Optional delay for reading from TPFS source. The value must be of the same
 format as the duration value. For example, a duration of '5m' and a delay of '10m' means
 each run of the pipeline will read events for 5 minutes of data from 15 minutes before its logical
-start time to 10 minutes before its logical start time. The default value is 0.
+start time to 10 minutes before its logical start time. The default value is 0. (Macro-enabled)
 
 
 Example

--- a/core-plugins/docs/Table-batchsource.md
+++ b/core-plugins/docs/Table-batchsource.md
@@ -15,7 +15,7 @@ you may want to periodically dump the contents of a CDAP Table to a relational d
 
 Properties
 ----------
-**name:** Table name. If the table does not already exist, it will be created.
+**name:** Table name. If the table does not already exist, it will be created. (Macro-enabled)
 
 **schema:** Schema of records read from the table. Row columns map to record
 fields. For example, if the schema contains a field named 'user' of type string, the value

--- a/core-plugins/docs/XMLReader-batchsource.md
+++ b/core-plugins/docs/XMLReader-batchsource.md
@@ -18,19 +18,19 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**path:** Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'.
+**path:** Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'. (Macro-enabled)
 
 **nodePath:** Node path to emit as an individual event from the XML schema.
-Example: '/book/price' to read only the price from under the book node.
+Example: '/book/price' to read only the price from under the book node. (Macro-enabled)
 
-**pattern:** Pattern to select specific file(s). (Optional)
+**pattern:** Pattern to select specific file(s). (Optional) (Macro-enabled)
 Examples:
 
 1. Use '^' to select files with names starting with 'catalog', such as '^catalog'.
 2. Use '$' to select files with names ending with 'catalog.xml', such as 'catalog.xml$'.
 3. Use '\*' to select file with name contains 'catalogBook', such as 'catalogBook*'.
 
-**actionAfterProcess:** Action to be taken after processing of the XML file.
+**actionAfterProcess:** Action to be taken after processing of the XML file. (Macro-enabled)
 Possible actions are:
 
 1. Delete from the HDFS;
@@ -38,19 +38,19 @@ Possible actions are:
 3. Moved to the target location.
 
 **targetFolder:** Target folder path if user select action after process, either ARCHIVE or MOVE.
-Target folder must be an existing directory. (Optional)
+Target folder must be an existing directory. (Optional) (Macro-enabled)
 
-**reprocessingRequired:** Specifies whether the file(s) should be reprocessed.
+**reprocessingRequired:** Specifies whether the file(s) should be reprocessed. (Macro-enabled)
 
-**tableName:** Table name to be used to keep track of processed file(s).
+**tableName:** Table name to be used to keep track of processed file(s). (Macro-enabled)
 
 **tableExpiryPeriod:** Expiry period (days) for data in the table. Default is 30 days.
-Example: For tableExpiryPeriod = 30, data before 30 days get deleted from the table.
+Example: For tableExpiryPeriod = 30, data before 30 days get deleted from the table. (Macro-enabled)
 
 **temporaryFolder:** An existing HDFS folder path with read and write access for the current user;
 required for storing temporary files containing paths of the processed XML files.
 These temporary files will be read at the end of the job to update the file track table.
-Default to /tmp.
+Default to /tmp. (Macro-enabled)
 
 Example
 -------

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/KVTableSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/KVTableSink.java
@@ -46,7 +46,6 @@ import javax.annotation.Nullable;
 @Description("Writes records to a KeyValueTable, using configurable fields from input records as the key and value.")
 public class KVTableSink extends BatchWritableSink<StructuredRecord, byte[], byte[]> {
 
-  private static final String NAME_DESC = "Name of the dataset. If it does not already exist, one will be created.";
   private static final String KEY_FIELD_DESC = "The name of the field to use as the key. Defaults to 'key'.";
   private static final String VALUE_FIELD_DESC = "The name of the field to use as the value. Defaults to 'value'.";
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AzureBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AzureBatchSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.etl.api.batch.BatchSource;
@@ -69,13 +70,16 @@ public class AzureBatchSource extends FileBatchSource {
    */
   public static class AzureBatchConfig extends FileBatchConfig {
     @Description("The Microsoft Azure Storage account to use.")
+    @Macro
     private final String account;
 
     @Description("The container to use on the specified Microsoft Azure Storage account.")
+    @Macro
     private final String container;
 
     @Description("The storage key for the specified container on the specified Azure Storage account. Must be a " +
       "valid base64 encoded storage key provided by Microsoft Azure.")
+    @Macro
     private final String storageKey;
 
     public AzureBatchConfig(String referenceName, String path, String account, String container, String storageKey) {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.etl.api.batch.BatchSource;
@@ -69,18 +70,22 @@ public class FTPBatchSource extends FileBatchSource {
    */
   public static class FTPBatchSourceConfig extends ReferencePluginConfig {
     @Description(PATH_DESCRIPTION)
+    @Macro
     public String path;
 
     @Description(FileBatchSource.FILESYSTEM_PROPERTIES_DESCRIPTION)
     @Nullable
+    @Macro
     public String fileSystemProperties;
 
     @Description("Regex to filter out filenames in the path. Defaults to '.*'")
     @Nullable
+    @Macro
     public String fileRegex;
 
     @Description(FileBatchSource.INPUT_FORMAT_CLASS_DESCRIPTION)
     @Nullable
+    @Macro
     public String inputFormatClassName;
 
     public FTPBatchSourceConfig(String referenceName, String path, @Nullable String fileSystemProperties,

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.common.Bytes;
@@ -112,7 +113,7 @@ public class FileBatchSource extends ReferenceBatchSource<LongWritable, Object, 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
-    if (config.timeTable != null) {
+    if (!config.containsMacro("timeTable") && config.timeTable != null) {
       pipelineConfigurer.createDataset(config.timeTable, KeyValueTable.class, DatasetProperties.EMPTY);
     }
     pipelineConfigurer.getStageConfigurer().setOutputSchema(DEFAULT_SCHEMA);
@@ -120,6 +121,11 @@ public class FileBatchSource extends ReferenceBatchSource<LongWritable, Object, 
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
+    // Need to create dataset now if macro was provided at configure time
+    if (config.timeTable != null && !context.datasetExists(config.timeTable)) {
+      context.createDataset(config.timeTable, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    }
+
     //SimpleDateFormat needs to be local because it is not threadsafe
     SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH");
 
@@ -202,26 +208,32 @@ public class FileBatchSource extends ReferenceBatchSource<LongWritable, Object, 
    */
   public static class FileBatchConfig extends ReferencePluginConfig {
     @Description(PATH_DESCRIPTION)
+    @Macro
     public String path;
 
     @Nullable
     @Description(FILESYSTEM_PROPERTIES_DESCRIPTION)
+    @Macro
     public String fileSystemProperties;
 
     @Nullable
     @Description(REGEX_DESCRIPTION)
+    @Macro
     public String fileRegex;
 
     @Nullable
     @Description(TABLE_DESCRIPTION)
+    @Macro
     public String timeTable;
 
     @Nullable
     @Description(INPUT_FORMAT_CLASS_DESCRIPTION)
+    @Macro
     public String inputFormatClass;
 
     @Nullable
     @Description(MAX_SPLIT_SIZE_DESCRIPTION)
+    @Macro
     public Long maxSplitSize;
 
     public FileBatchConfig() {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/KVTableSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/KVTableSource.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.hydrator.plugin.common.BatchReadableWritableConfig;
 import co.cask.hydrator.plugin.common.Properties;
 import com.google.common.collect.Maps;
 
@@ -45,17 +46,13 @@ public class KVTableSource extends BatchReadableSource<byte[], byte[], Structure
     Schema.Field.of("value", Schema.of(Schema.Type.BYTES))
   );
 
-  private static final String NAME_DESC = "Name of the dataset. If it does not already exist, one will be created.";
-
   /**
    * Config class for KVTableSource
    */
-  public static class KVTableConfig extends PluginConfig {
-    @Description(NAME_DESC)
-    String name;
+  public static class KVTableConfig extends BatchReadableWritableConfig {
 
     public KVTableConfig(String name) {
-      this.name = name;
+      super(name);
     }
   }
 
@@ -68,13 +65,14 @@ public class KVTableSource extends BatchReadableSource<byte[], byte[], Structure
   }
 
   public KVTableSource(KVTableConfig kvTableConfig) {
+    super(kvTableConfig);
     this.kvTableConfig = kvTableConfig;
   }
 
   @Override
   protected Map<String, String> getProperties() {
     Map<String, String> properties = Maps.newHashMap(kvTableConfig.getProperties().getProperties());
-    properties.put(Properties.BatchReadableWritable.NAME, kvTableConfig.name);
+    properties.put(Properties.BatchReadableWritable.NAME, kvTableConfig.getName());
     properties.put(Properties.BatchReadableWritable.TYPE, KeyValueTable.class.getName());
     return properties;
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/S3BatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/S3BatchSource.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.etl.api.batch.BatchSource;
@@ -70,9 +71,11 @@ public class S3BatchSource extends FileBatchSource {
    */
   public static class S3BatchConfig extends FileBatchConfig {
     @Description(ACCESS_ID_DESCRIPTION)
+    @Macro
     private final String accessID;
 
     @Description(ACCESS_KEY_DESCRIPTION)
+    @Macro
     private final String accessKey;
 
     public S3BatchConfig(String referenceName, String accessID, String accessKey, String path) {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TableSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TableSource.java
@@ -48,6 +48,7 @@ public class TableSource extends BatchReadableSource<byte[], Row, StructuredReco
   private final TableSourceConfig tableConfig;
 
   public TableSource(TableSourceConfig tableConfig) {
+    super(tableConfig);
     this.tableConfig = tableConfig;
   }
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/TimePartitionedFileSetSource.java
@@ -17,8 +17,10 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
@@ -50,16 +52,19 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
   @SuppressWarnings("unused")
   public static class TPFSConfig extends PluginConfig {
     @Description("Name of the TimePartitionedFileSet to read.")
+    @Macro
     private String name;
 
     @Description("Base path for the TimePartitionedFileSet. Defaults to the name of the dataset.")
     @Nullable
+    @Macro
     private String basePath;
 
     @Description("Size of the time window to read with each run of the pipeline. " +
       "The format is expected to be a number followed by an 's', 'm', 'h', or 'd' specifying the time unit, with 's' " +
       "for seconds, 'm' for minutes, 'h' for hours, and 'd' for days. For example, a value of '5m' means each run of " +
       "the pipeline will read 5 minutes of events from the TPFS source.")
+    @Macro
     private String duration;
 
     @Description("Optional delay for reading from TPFS source. The value must be " +
@@ -67,13 +72,16 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
       "of the pipeline will read 5 minutes of data from 15 minutes before its logical start time to 10 minutes " +
       "before its logical start time. The default value is 0.")
     @Nullable
+    @Macro
     private String delay;
 
     protected void validate() {
       // check duration and delay
-      long durationInMs = TimeParser.parseDuration(duration);
-      Preconditions.checkArgument(durationInMs > 0, "Duration must be greater than 0");
-      if (!Strings.isNullOrEmpty(delay)) {
+      if (!containsMacro("duration")) {
+        long durationInMs = TimeParser.parseDuration(duration);
+        Preconditions.checkArgument(durationInMs > 0, "Duration must be greater than 0");
+      }
+      if (!containsMacro("delay") && !Strings.isNullOrEmpty(delay)) {
         TimeParser.parseDuration(delay);
       }
     }
@@ -86,17 +94,32 @@ public abstract class TimePartitionedFileSetSource<KEY, VALUE> extends BatchSour
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     config.validate();
-    String tpfsName = config.name;
-    FileSetProperties.Builder properties = FileSetProperties.builder();
-    if (!Strings.isNullOrEmpty(config.basePath)) {
-      properties.setBasePath(config.basePath);
+    if (!config.containsMacro("name") && !config.containsMacro("basePath")) {
+      String tpfsName = config.name;
+      FileSetProperties.Builder properties = FileSetProperties.builder();
+      if (!Strings.isNullOrEmpty(config.basePath)) {
+        properties.setBasePath(config.basePath);
+      }
+      addFileSetProperties(properties);
+      pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), properties.build());
     }
-    addFileSetProperties(properties);
-    pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), properties.build());
   }
 
   @Override
-  public final void prepareRun(BatchSourceContext context) {
+  public final void prepareRun(BatchSourceContext context) throws DatasetManagementException {
+    config.validate();
+    // If macros provided at runtime, dataset still needs to be created
+    if (!context.datasetExists(config.name)) {
+      String tpfsName = config.name;
+      FileSetProperties.Builder properties = FileSetProperties.builder();
+      if (!Strings.isNullOrEmpty(config.basePath)) {
+        properties.setBasePath(config.basePath);
+      }
+      addFileSetProperties(properties);
+      context.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), properties.build());
+    }
+
+
     long duration = TimeParser.parseDuration(config.duration);
     long delay = Strings.isNullOrEmpty(config.delay) ? 0 : TimeParser.parseDuration(config.delay);
     long endTime = context.getLogicalStartTime() - delay;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
@@ -17,12 +17,14 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
@@ -103,13 +105,20 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
-    config.validateConfig();
+    config.validate();
     pipelineConfigurer.getStageConfigurer().setOutputSchema(DEFAULT_XML_SCHEMA);
-    pipelineConfigurer.createDataset(config.tableName, KeyValueTable.class.getName());
+    if (!config.containsMacro("tableName")) {
+      pipelineConfigurer.createDataset(config.tableName, KeyValueTable.class.getName());
+    }
   }
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
+    config.validate();
+    // Create dataset if macros were provided at configure time
+    if (!context.datasetExists(config.tableName)) {
+      context.createDataset(config.tableName, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    }
     Job job = JobUtils.createInstance();
     Configuration conf = job.getConfiguration();
     conf.set(XMLInputFormat.XML_INPUTFORMAT_PATH_NAME, config.path);
@@ -211,6 +220,7 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
    */
   public static class XMLReaderConfig extends ReferencePluginConfig {
     @Description("Path to file(s) to be read. If a directory is specified, terminate the path name with a \'/\'.")
+    @Macro
     private final String path;
 
     @Nullable
@@ -219,10 +229,12 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
       "1. Use '^' to select files with names starting with 'catalog', such as '^catalog'. " +
       "2. Use '$' to select files with names ending with 'catalog.xml', such as 'catalog.xml$'. " +
       "3. Use '*' to select file with name contains 'catalogBook', such as 'catalogBook*'.")
+    @Macro
     private final String pattern;
 
     @Description("Node path to emit as an individual event from the XML schema. " +
       "Example: '/book/price' to read only price under the book node")
+    @Macro
     private final String nodePath;
 
     @Description("Action to be taken after processing of the XML file. " +
@@ -230,26 +242,32 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
       "1. Delete from the HDFS; " +
       "2. Archived to the target location; and " +
       "3. Moved to the target location.")
+    @Macro
     private final String actionAfterProcess;
 
     @Nullable
     @Description("Target folder path if user select action after process, either ARCHIVE or MOVE. " +
       "Target folder must be an existing directory.")
+    @Macro
     private final String targetFolder;
 
     @Description("Specifies whether the file(s) should be reprocessed.")
+    @Macro
     private final String reprocessingRequired;
 
     @Description("Table name to be used to keep track of processed file(s).")
+    @Macro
     private final String tableName;
 
     @Description("Expiry period (days) for data in the table. Default is 30 days. " +
       "Example: For tableExpiryPeriod = 30, data before 30 days get deleted from the table.")
+    @Macro
     private final String tableExpiryPeriod;
 
     @Description("An existing HDFS folder path with read and write access for the current user; required for storing " +
       "temporary files containing paths of the processed XML files. These temporary files will be read at the end of " +
       "the job to update the file track table. Default to /tmp.")
+    @Macro
     private final String temporaryFolder;
 
     @VisibleForTesting
@@ -287,21 +305,33 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
       return nodePath;
     }
 
-    void validateConfig() {
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(path), "Path cannot be empty.");
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(nodePath), "Node path cannot be empty.");
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(tableName), "Table name cannot be empty.");
-      Preconditions.checkArgument(tableExpiryPeriod != null, "Table expiry period cannot be empty.");
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(temporaryFolder), "Temporary folder cannot be empty.");
+    void validate() {
+      if (!containsMacro("path")) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(path), "Path cannot be empty.");
+      }
+      if (!containsMacro("nodePath")) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(nodePath), "Node path cannot be empty.");
+      }
+      if (!containsMacro("tableName")) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableName), "Table name cannot be empty.");
+      }
+      if (!containsMacro("tableExpiryPeriod")) {
+        Preconditions.checkArgument(tableExpiryPeriod != null, "Table expiry period cannot be empty.");
+      }
+      if (!containsMacro("temporaryFolder")) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(temporaryFolder), "Temporary folder cannot be empty.");
+      }
 
-      boolean onlyOneActionRequired = !actionAfterProcess.equalsIgnoreCase("NONE") && isReprocessingRequired();
-      Preconditions.checkArgument(!onlyOneActionRequired, "Please select either 'After Processing Action' or " +
-        "'Reprocessing Required'; both cannot be applied at the same time.");
+      if (!containsMacro("actionAfterProcess")) {
+        boolean onlyOneActionRequired = !actionAfterProcess.equalsIgnoreCase("NONE") && isReprocessingRequired();
+        Preconditions.checkArgument(!onlyOneActionRequired, "Please select either 'After Processing Action' or " +
+          "'Reprocessing Required'; both cannot be applied at the same time.");
 
-      boolean targetFolderEmpty = (actionAfterProcess.equalsIgnoreCase("ARCHIVE") ||
-        actionAfterProcess.equalsIgnoreCase("MOVE")) && Strings.isNullOrEmpty(targetFolder);
-      Preconditions.checkArgument(!targetFolderEmpty, "Target folder cannot be empty for Action = '" +
-        actionAfterProcess + "'.");
+        boolean targetFolderEmpty = (actionAfterProcess.equalsIgnoreCase("ARCHIVE") ||
+          actionAfterProcess.equalsIgnoreCase("MOVE")) && Strings.isNullOrEmpty(targetFolder);
+        Preconditions.checkArgument(!targetFolderEmpty, "Target folder cannot be empty for Action = '" +
+          actionAfterProcess + "'.");
+      }
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/TableSourceConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/TableSourceConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin.common;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.hydrator.plugin.batch.sink.TableSink;
@@ -28,10 +29,7 @@ import javax.annotation.Nullable;
 /**
  * {@link PluginConfig} for {@link TableSource}, {@link TableSink} and {@link RealtimeTableSink}
  */
-public class TableSourceConfig extends PluginConfig {
-  @Name(Properties.Table.NAME)
-  @Description("Name of the table. If the table does not already exist, one will be created.")
-  private String name;
+public class TableSourceConfig extends BatchReadableWritableConfig {
 
   @Name(Properties.Table.PROPERTY_SCHEMA)
   @Description("Optional schema of the table as a JSON Object. If the table does not already exist, one will be " +
@@ -43,10 +41,13 @@ public class TableSourceConfig extends PluginConfig {
   @Description("Optional field name indicating that the field value should come from the row key instead of a " +
     "row column. The field name specified must be present in the schema, and must not be nullable.")
   @Nullable
+  @Macro
   private String rowField;
 
-  public String getName() {
-    return name;
+  public TableSourceConfig(String name, String rowField, @Nullable String schemaStr) {
+    super(name);
+    this.rowField = rowField;
+    this.schemaStr = schemaStr;
   }
 
   @Nullable

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/XMLReaderConfigTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/XMLReaderConfigTest.java
@@ -46,7 +46,7 @@ public class XMLReaderConfigTest {
                                                                                            null, null, "Yes",
                                                                                            "XMLTrackingTable", "30",
                                                                                            "/tmp");
-    config.validateConfig();
+    config.validate();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -56,7 +56,7 @@ public class XMLReaderConfigTest {
                                                                                            null, "", null, null,
                                                                                            "Yes", "XMLTrackingTable",
                                                                                            "30", "/tmp");
-    config.validateConfig();
+    config.validate();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -67,7 +67,7 @@ public class XMLReaderConfigTest {
                                                                                            "Delete", null, "Yes",
                                                                                            "XMLTrackingTable", "30",
                                                                                            "/tmp");
-    config.validateConfig();
+    config.validate();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -78,7 +78,7 @@ public class XMLReaderConfigTest {
                                                                                            "Move", "", "No",
                                                                                            "XMLTrackingTable", "30",
                                                                                            "/tmp");
-    config.validateConfig();
+    config.validate();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -88,7 +88,7 @@ public class XMLReaderConfigTest {
                                                                                            null, "/catalog/book/",
                                                                                            "Delete", null, "No", null,
                                                                                            "30", "/tmp");
-    config.validateConfig();
+    config.validate();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -99,6 +99,6 @@ public class XMLReaderConfigTest {
                                                                                            "Delete", null, "No",
                                                                                            "XMLTrackingTable", "30",
                                                                                            null);
-    config.validateConfig();
+    config.validate();
   }
 }


### PR DESCRIPTION
Enabled macros on the following properties:

`AzureBatchSource(s)`:
- account
- container
- storageKey

`BatchReadableSource(s)`:
- name

`ExcelInputReader`:
- filePath
- filePattern
- memoryTableName
- tableExpiryPeriod
- reprocess
- sheet
- sheetValue
- skipFirstRow
- terminateIfEmptyRow
- rowsLimit
- ifErrorRecord
- errorDatasetName

`FTPBatchSource`:
- path
- fileSystemProperties
- fileRegex
- inputFormatClassName

`FileBatchSource`:
- path
- fileSystemProperties
- fileRegex
- timeTable
- inputFormatClass
- maxSplitSize

`KVTableSource`
- name

`S3BatchSource(s)`:
- accessID
- accessKey

`SnapshotFileBatchSource(s)`:
- name
- basePath
- fileProperties

`TimePartitionedFileSetSource(s)`:
- name
- basePath
- duration
- delay

`XMLReaderBatchSource`:
- path
- nodePath
- pattern
- actionAfterProcess
- targetFolder
- reprocessingRequired
- tableName
- tableExpiryPeriod
- temporaryFolder

`TableSource`:
- rowField
