### PR TITLE
Check for bounding and splitby fields only if split size is greater than 1

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -303,11 +303,11 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
                                                          importQuery));
       }
 
-      if (!containsMacro("splitBy") && (splitBy == null || splitBy.isEmpty())) {
+      if (!hasOneSplit && !containsMacro("splitBy") && (splitBy == null || splitBy.isEmpty())) {
         throw new IllegalArgumentException("The splitBy must be specified if numSplits is not set to 1.");
       }
 
-      if (!containsMacro("boundingQuery") && (boundingQuery == null || boundingQuery.isEmpty())) {
+      if (!hasOneSplit && !containsMacro("boundingQuery") && (boundingQuery == null || boundingQuery.isEmpty())) {
         throw new IllegalArgumentException("The boundingQuery must be specified if numSplits is not set to 1.");
       }
 


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-7110
Without this fix a pipeline with DBSource cannot be published.
Build: http://builds.cask.co/browse/HYP-BAD72-1
