### PR TITLE
[HYDRA-702] Remove non-text-input macros

### DIFF
--- a/cassandra-plugins/docs/Cassandra-batchsink.md
+++ b/cassandra-plugins/docs/Cassandra-batchsink.md
@@ -33,9 +33,9 @@ Create the keyspace before starting the adapter. (Macro-enabled)
 Create the column family before starting the adapter. (Macro-enabled)
 
 **columns:** A comma-separated list of columns in the column family.
-The columns should be listed in the same order as they are stored in the column family. (Macro-enabled)
+The columns should be listed in the same order as they are stored in the column family.
 
-**primaryKey:** A comma-separated list of primary keys. (Macro-enabled)
+**primaryKey:** A comma-separated list of primary keys.
 
 
 Example

--- a/cassandra-plugins/docs/Cassandra-batchsource.md
+++ b/cassandra-plugins/docs/Cassandra-batchsource.md
@@ -41,7 +41,7 @@ If this is not empty, then you must supply a username. (Macro-enabled)
 **schema:** The schema for the data as it will be formatted in CDAP.
 
 **properties:** Any extra properties to include. The property-value pairs should be comma-separated,
-and each property should be separated by a colon from its corresponding value. (Macro-enabled)
+and each property should be separated by a colon from its corresponding value.
 
 
 Example

--- a/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCassandraSink.java
+++ b/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/BatchCassandraSink.java
@@ -161,12 +161,10 @@ public class BatchCassandraSink
     @Name(Cassandra.COLUMNS)
     @Description("A comma-separated list of columns in the column family. " +
       "The columns should be listed in the same order as they are stored in the column family.")
-    @Macro
     private String columns;
 
     @Name(Cassandra.PRIMARY_KEY)
     @Description("A comma-separated list of primary keys. For example: \"key1,key2\".")
-    @Macro
     private String primaryKey;
 
     public CassandraBatchConfig(String referenceName, String partitioner, @Nullable Integer port, String columnFamily,

--- a/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchCassandraSource.java
+++ b/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchCassandraSource.java
@@ -243,7 +243,6 @@ public class BatchCassandraSource extends ReferenceBatchSource<Long, Row, Struct
       "and each property should be separated by a colon from its corresponding value. " +
       "For example: \'cassandra.consistencylevel.read:LOCAL_ONE,cassandra.input.native.port:9042\'")
     @Nullable
-    @Macro
     private String properties;
 
     public CassandraSourceConfig(String referenceName, String partitioner, Integer port, String columnFamily,

--- a/copybookreader-plugins/docs/CopybookReader-batchsource.md
+++ b/copybookreader-plugins/docs/CopybookReader-batchsource.md
@@ -25,7 +25,7 @@ of a COBOL copybook or redefines or iterators in the structure.
 **binaryFilePath:** Complete path of the .bin to be read. This will be a fixed-length binary format file that matches
 the copybook. Supports compressed files using a native compressed codec. (Macro-enabled)
 
-**drop:** Comma-separated list of fields to drop. For example: 'field1,field2,field3'. (Macro-enabled)
+**drop:** Comma-separated list of fields to drop. For example: 'field1,field2,field3'.
 
 **maxSplitSize:** Maximum split-size(MB) for each mapper in the MapReduce Job. Defaults to 1MB. (Macro-enabled)
 

--- a/copybookreader-plugins/src/main/java/co/cask/hydrator/plugin/batch/CopybookSource.java
+++ b/copybookreader-plugins/src/main/java/co/cask/hydrator/plugin/batch/CopybookSource.java
@@ -252,7 +252,6 @@ public class CopybookSource extends BatchSource<LongWritable, Map<String, Abstra
 
     @Nullable
     @Description("Comma-separated list of fields to drop. For example: 'field1,field2,field3'.")
-    @Macro
     private String drop;
 
     @Nullable

--- a/core-plugins/docs/Excel-batchsource.md
+++ b/core-plugins/docs/Excel-batchsource.md
@@ -32,9 +32,9 @@ in **filePath** input. (Macro-enabled)
 **memoryTableName:** KeyValue table name to keep the track of processed files. This can be
 a new table or existing one. (Macro-enabled)
 
-**reprocess:** Specify whether the files mentioned in the memory table should be reprocessed or not. (Macro-enabled)
+**reprocess:** Specify whether the files mentioned in the memory table should be reprocessed or not.
 
-**sheet:** Specifies whether sheet has to be processed by sheet name or sheet no. (Macro-enabled)
+**sheet:** Specifies whether sheet has to be processed by sheet name or sheet no.
 
 **sheetValue:** Specifies the value corresponding to 'sheet' input. Value can be either actual
 sheet name or sheet no.
@@ -48,10 +48,10 @@ Column name has to be same as excel column name; for example: A, B, etc.
 excel column to be renamed, with its corresponding value specifying the new name for that column.
 Column name has to be same as excel column name; for example: A, B, etc.
 
-**skipFirstRow:** Specify whether the first row in the excel sheet needs to be processed or not. (Macro-enabled)
+**skipFirstRow:** Specify whether the first row in the excel sheet needs to be processed or not.
 
 **terminateIfEmptyRow:** Specify whether processing needs to be terminated in case an empty row is
-encountered while processing excel files. (Macro-enabled)
+encountered while processing excel files.
 
 **rowsLimit:** Maximum row limit for each sheet to be processed. If, the limit is not provided then
 all the rows in the sheet will be processed. (Macro-enabled)

--- a/core-plugins/docs/XMLReader-batchsource.md
+++ b/core-plugins/docs/XMLReader-batchsource.md
@@ -30,7 +30,7 @@ Examples:
 2. Use '$' to select files with names ending with 'catalog.xml', such as 'catalog.xml$'.
 3. Use '\*' to select file with name contains 'catalogBook', such as 'catalogBook*'.
 
-**actionAfterProcess:** Action to be taken after processing of the XML file. (Macro-enabled)
+**actionAfterProcess:** Action to be taken after processing of the XML file.
 Possible actions are:
 
 1. Delete from the HDFS;
@@ -40,7 +40,7 @@ Possible actions are:
 **targetFolder:** Target folder path if user select action after process, either ARCHIVE or MOVE.
 Target folder must be an existing directory. (Optional) (Macro-enabled)
 
-**reprocessingRequired:** Specifies whether the file(s) should be reprocessed. (Macro-enabled)
+**reprocessingRequired:** Specifies whether the file(s) should be reprocessed.
 
 **tableName:** Table name to be used to keep track of processed file(s). (Macro-enabled)
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/ExcelInputReader.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/ExcelInputReader.java
@@ -408,7 +408,6 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
     @Name("reprocess")
     @Description("Specifies whether the file(s) should be reprocessed. " +
       "Options to select are true or false")
-    @Macro
     private boolean reprocess;
 
     @Name("sheet")
@@ -416,7 +415,6 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
       "Shift 'Options are' in next line: " +
       "Sheet Name" +
       "Sheet Number")
-    @Macro
     private String sheet;
 
     @Name("sheetValue")
@@ -439,13 +437,11 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
     @Name("skipFirstRow")
     @Description("Specify whether first row in the excel sheet is to be skipped or not. " +
       "Options to select are true or false.")
-    @Macro
     private boolean skipFirstRow;
 
     @Name("terminateIfEmptyRow")
     @Description("Specify whether processing needs to be terminated in case an empty row is encountered " +
       "while processing excel files. Options to select are true or false.")
-    @Macro
     private String terminateIfEmptyRow;
 
     @Nullable
@@ -480,8 +476,7 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
     }
 
     public void validate() {
-      if (!containsMacro("sheet") && !containsMacro("sheetValue") &&
-        sheet.equalsIgnoreCase(SHEET_NO) && !StringUtils.isNumeric(sheetValue)) {
+      if (!containsMacro("sheetValue") && sheet.equalsIgnoreCase(SHEET_NO) && !StringUtils.isNumeric(sheetValue)) {
         throw new IllegalArgumentException("Invalid sheet number. The value should be greater than or equals to zero.");
       }
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
@@ -242,7 +242,6 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
       "1. Delete from the HDFS; " +
       "2. Archived to the target location; and " +
       "3. Moved to the target location.")
-    @Macro
     private final String actionAfterProcess;
 
     @Nullable
@@ -252,7 +251,6 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
     private final String targetFolder;
 
     @Description("Specifies whether the file(s) should be reprocessed.")
-    @Macro
     private final String reprocessingRequired;
 
     @Description("Table name to be used to keep track of processed file(s).")
@@ -322,16 +320,14 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
         Preconditions.checkArgument(!Strings.isNullOrEmpty(temporaryFolder), "Temporary folder cannot be empty.");
       }
 
-      if (!containsMacro("actionAfterProcess")) {
-        boolean onlyOneActionRequired = !actionAfterProcess.equalsIgnoreCase("NONE") && isReprocessingRequired();
-        Preconditions.checkArgument(!onlyOneActionRequired, "Please select either 'After Processing Action' or " +
-          "'Reprocessing Required'; both cannot be applied at the same time.");
+      boolean onlyOneActionRequired = !actionAfterProcess.equalsIgnoreCase("NONE") && isReprocessingRequired();
+      Preconditions.checkArgument(!onlyOneActionRequired, "Please select either 'After Processing Action' or " +
+        "'Reprocessing Required'; both cannot be applied at the same time.");
 
-        boolean targetFolderEmpty = (actionAfterProcess.equalsIgnoreCase("ARCHIVE") ||
-          actionAfterProcess.equalsIgnoreCase("MOVE")) && Strings.isNullOrEmpty(targetFolder);
-        Preconditions.checkArgument(!targetFolderEmpty, "Target folder cannot be empty for Action = '" +
-          actionAfterProcess + "'.");
-      }
+      boolean targetFolderEmpty = (actionAfterProcess.equalsIgnoreCase("ARCHIVE") ||
+        actionAfterProcess.equalsIgnoreCase("MOVE")) && Strings.isNullOrEmpty(targetFolder);
+      Preconditions.checkArgument(!targetFolderEmpty, "Target folder cannot be empty for Action = '" +
+        actionAfterProcess + "'.");
     }
   }
 }

--- a/database-plugins/docs/Database-batchsink.md
+++ b/database-plugins/docs/Database-batchsink.md
@@ -18,7 +18,7 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**tableName:** Name of the table to export to.
+**tableName:** Name of the table to export to. (Macro-enabled)
 
 **columns:** Comma-separated list of columns in the specified table to export to.
 
@@ -28,13 +28,13 @@ the names returned from the database are used as-is. Note that setting this prop
 of column name cases across different databases but might result in column name conflicts if multiple column
 names are the same when the case is ignored (optional).
 
-**connectionString:** JDBC connection string including database name.
+**connectionString:** JDBC connection string including database name. (Macro-enabled)
 
 **user:** User identity for connecting to the specified database. Required for databases that need
-authentication. Optional for databases that do not require authentication.
+authentication. Optional for databases that do not require authentication. (Macro-enabled)
 
 **password:** Password to use to connect to the specified database. Required for databases
-that need authentication. Optional for databases that do not require authentication.
+that need authentication. Optional for databases that do not require authentication. (Macro-enabled)
 
 **jdbcPluginName:** Name of the JDBC plugin to use. This is the value of the 'name' key
 defined in the JSON file for the JDBC plugin.

--- a/database-plugins/docs/Database-batchsource.md
+++ b/database-plugins/docs/Database-batchsource.md
@@ -22,14 +22,14 @@ Properties
 You can specify an arbitrary number of columns to import, or import all columns using \*. The Query should
 contain the '$CONDITIONS' string. For example, 'SELECT * FROM table WHERE $CONDITIONS'.
 The '$CONDITIONS' string will be replaced by 'splitBy' field limits specified by the bounding query.
-The '$CONDITIONS' string is not required if numSplits is set to one.
+The '$CONDITIONS' string is not required if numSplits is set to one. (Macro-enabled)
 
 **boundingQuery:** Bounding Query should return the min and max of the values of the 'splitBy' field.
-For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is set to one.
+For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is set to one. (Macro-enabled)
 
-**splitBy:** Field Name which will be used to generate splits. Not required if numSplits is set to one.
+**splitBy:** Field Name which will be used to generate splits. Not required if numSplits is set to one. (Macro-enabled)
 
-**numSplits:** Number of splits to generate.
+**numSplits:** Number of splits to generate. (Macro-enabled)
 
 **columnCase:** Sets the case of the column names returned from the query.
 Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
@@ -37,13 +37,13 @@ the names returned from the database are used as-is. Note that setting this prop
 of column name cases across different databases but might result in column name conflicts if multiple column
 names are the same when the case is ignored (optional).
 
-**connectionString:** JDBC connection string including database name.
+**connectionString:** JDBC connection string including database name. (Macro-enabled)
 
 **user:** User identity for connecting to the specified database. Required for databases that need
-authentication. Optional for databases that do not require authentication.
+authentication. Optional for databases that do not require authentication. (Macro-enabled)
 
 **password:** Password to use to connect to the specified database. Required for databases
-that need authentication. Optional for databases that do not require authentication.
+that need authentication. Optional for databases that do not require authentication. (Macro-enabled)
 
 **jdbcPluginName:** Name of the JDBC plugin to use. This is the value of the 'name' key
 defined in the JSON file for the JDBC plugin.

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/ConnectionConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/ConnectionConfig.java
@@ -71,7 +71,6 @@ public class ConnectionConfig extends PluginConfig {
     "auto commit, or a driver that does not support the commit call. For example, the Hive jdbc driver will throw " +
     "an exception whenever a commit is called. For drivers like that, this should be set to true.")
   @Nullable
-  @Macro
   public Boolean enableAutoCommit;
 
   public ConnectionConfig() {

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
@@ -39,7 +39,6 @@ public class DBConfig extends ConnectionConfig {
     "of column name cases across different databases but might result in column name conflicts if multiple column " +
     "names are the same when the case is ignored.")
   @Nullable
-  @Macro
   public String columnNameCase;
 
   public DBConfig() {

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
@@ -202,7 +202,6 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
 
     @Name(COLUMNS)
     @Description("Comma-separated list of columns in the specified table to export to.")
-    @Macro
     public String columns;
 
     @Name(TABLE_NAME)

--- a/hive-plugins/docs/Hive-batchsink.md
+++ b/hive-plugins/docs/Hive-batchsink.md
@@ -21,7 +21,7 @@ Example: ``thrift://somehost.net:9083``.
 partition keys and values for that partition. For example: if the partition column is 'type', then this property
 should be specified as ``{"type": "typeOne"}``.
 To write multiple partitions simultaneously you can leave this empty; but all of the partitioning columns must
-be present in the data you are writing to the sink. (Macro-enabled)
+be present in the data you are writing to the sink.
 
 **schema:** Optional schema to use while writing to the Hive table. If no schema is provided, then the schema of the
 table will be used and it should match the schema of the data being written.

--- a/hive-plugins/docs/Hive-batchsource.md
+++ b/hive-plugins/docs/Hive-batchsource.md
@@ -19,7 +19,7 @@ Example: ``thrift://somehost.net:9083``.
 **databaseName:** The name of the database. Defaults to 'default'.
 
 **partitions:** Optional Hive expression filter for scan. This filter must only reference partition columns.
-Values from other columns will cause the pipeline to fail. (Macro-enabled)
+Values from other columns will cause the pipeline to fail.
 
 **schema:** Optional schema to use while reading from the Hive table. If no schema is provided, then the schema of the
 table will be used. Note: if you want to use a Hive table which has non-primitive types as a source, then you

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveSinkConfig.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveSinkConfig.java
@@ -35,7 +35,6 @@ public class HiveSinkConfig extends HiveConfig {
     "To write multiple partitions simultaneously you can leave this empty, but all of the partitioning columns must " +
     "be present in the data you are writing to the sink.")
   @Nullable
-  @Macro
   public String partitions;
 
   @Name(Hive.SCHEMA)

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveSourceConfig.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveSourceConfig.java
@@ -32,7 +32,6 @@ public class HiveSourceConfig extends HiveConfig {
     "partitioned on 'type' and you want to read 'type1' partition: 'type = \"type1\"'" +
     "This filter must reference only partition columns. Values from other columns will cause the pipeline to fail.")
   @Nullable
-  @Macro
   public String partitions;
 
   @Name(Hive.SCHEMA)

--- a/transform-plugins/docs/CSVFormatter-transform.md
+++ b/transform-plugins/docs/CSVFormatter-transform.md
@@ -10,9 +10,9 @@ delimiters that a CSV Record should use for separating fields.
 
 Configuration
 -------------
-**format:** Specifies the format of the CSV Record to be generated. (Macro-enabled)
+**format:** Specifies the format of the CSV Record to be generated.
 
 **delimiter:** Specifies the delimiter to be used to generate a CSV Record; 
-this option is available when the format is specified as ``DELIMITED``. (Macro-enabled)
+this option is available when the format is specified as ``DELIMITED``.
 
 **schema:** Specifies the output schema. Output schema should only have fields of type String.

--- a/transform-plugins/docs/CSVParser-transform.md
+++ b/transform-plugins/docs/CSVParser-transform.md
@@ -10,7 +10,7 @@ Supports these CSV Record types: ``DEFAULT``, ``EXCEL``, ``MYSQL``, ``RFC4180``,
 
 Configuration
 -------------
-**format:** Specifies the format of the CSV Record the input should be parsed as. (Macro-enabled)
+**format:** Specifies the format of the CSV Record the input should be parsed as.
 
 **field:** Specifies the input field that should be parsed as a CSV Record. 
 Input records with a null input field propagate all other fields and set fields that

--- a/transform-plugins/docs/Compressor-transform.md
+++ b/transform-plugins/docs/Compressor-transform.md
@@ -10,7 +10,7 @@ Plugin supports SNAPPY, ZIP, and GZIP types of compression of fields.
 Configuration
 -------------
 **compressor:** Specifies the configuration for compressing fields; in JSON configuration, 
-this is specified as ``<field>:<compressor>[,<field>:<compressor>]*``. (Macro-enabled)
+this is specified as ``<field>:<compressor>[,<field>:<compressor>]*``.
 
 **schema:** Specifies the output schema; the fields that are compressed will have the same field name 
 but they will be of type ``BYTES``.

--- a/transform-plugins/docs/Decoder-transform.md
+++ b/transform-plugins/docs/Decoder-transform.md
@@ -10,7 +10,7 @@ Available decoding methods are ``STRING_BASE64``, ``BASE64``, ``BASE32``, ``STRI
 Configuration
 -------------
 **decode:** Specifies the configuration for decode fields; in JSON configuration, 
-this is specified as ``<field>:<decoder>[,<field>:<decoder>]*``. (Macro-enabled)
+this is specified as ``<field>:<decoder>[,<field>:<decoder>]*``.
 
 **schema:** Specifies the output schema; the fields that are decoded will have the same field 
 name but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Decompressor-transform.md
+++ b/transform-plugins/docs/Decompressor-transform.md
@@ -11,7 +11,7 @@ decompression of fields.
 Configuration
 -------------
 **decompressor:** Specifies the configuration for decompressing fields; in JSON configuration, 
-this is specified as ``<field>:<decompressor>[,<field>:<decompressor>]*``. (Macro-enabled)
+this is specified as ``<field>:<decompressor>[,<field>:<decompressor>]*``.
 
 **schema:** Specifies the output schema; the fields that are decompressed will have the same field 
 name but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Decryptor-transform.md
+++ b/transform-plugins/docs/Decryptor-transform.md
@@ -9,7 +9,7 @@ that must be present on all nodes of the cluster.
 
 Configuration
 -------------
-**decryptFields** Specifies the fields to decrypt, separated by commas (Macro-enabled)
+**decryptFields** Specifies the fields to decrypt, separated by commas
 
 **schema** Schema to pull records from
 

--- a/transform-plugins/docs/Encoder-transform.md
+++ b/transform-plugins/docs/Encoder-transform.md
@@ -10,7 +10,7 @@ Available encoding methods are ``STRING_BASE64``, ``BASE64``, ``BASE32``, ``STRI
 Configuration
 -------------
 **encode:** Specifies the configuration for encode fields; in JSON configuration, 
-this is specified as ``<field>:<encoder>[,<field>:<encoder>]*``. (Macro-enabled)
+this is specified as ``<field>:<encoder>[,<field>:<encoder>]*``.
 
 **schema:** Specifies the output schema; the fields that are encoded will have the same field name 
 but they will be of type ``BYTES`` or ``STRING``.

--- a/transform-plugins/docs/Encryptor-transform.md
+++ b/transform-plugins/docs/Encryptor-transform.md
@@ -9,7 +9,7 @@ that must be present on all nodes of the cluster.
 
 Configuration
 -------------
-**encyrptFields** Specifies the fields to encrypt, separated by commas. (Macro-enabled)
+**encyrptFields** Specifies the fields to encrypt, separated by commas.
 
 **transformation** Transformation algorithm/mode/padding. For example, AES/CBC/PKCS5Padding.
 

--- a/transform-plugins/docs/Hasher-transform.md
+++ b/transform-plugins/docs/Hasher-transform.md
@@ -8,6 +8,6 @@ Hashes fields using a digest algorithm such as ``MD2``, ``MD5``, ``SHA1``, ``SHA
 
 Configuration
 -------------
-**fields:** Specifies the fields to be hashed. (Macro-enabled)
+**fields:** Specifies the fields to be hashed.
 
-**hash:** Specifies the hashing algorithm. (Macro-enabled)
+**hash:** Specifies the hashing algorithm.

--- a/transform-plugins/docs/StreamFormatter-transform.md
+++ b/transform-plugins/docs/StreamFormatter-transform.md
@@ -9,11 +9,11 @@ It will include a header and body configurations. The body of the Stream event c
 
 Configuration
 -------------
-**body:** Specifies the input Structured Record fields that should be included in the body of the Stream event. (Macro-enabled)
+**body:** Specifies the input Structured Record fields that should be included in the body of the Stream event.
 
-**header:** Specifies the input Structured Record fields that should be included in the header of the Stream event. (Macro-enabled)
+**header:** Specifies the input Structured Record fields that should be included in the header of the Stream event.
 
-**format:** Specifies the format of the body. Currently supported formats are ``JSON``, ``CSV``, ``TSV``, and ``PSV``. (Macro-enabled)
+**format:** Specifies the format of the body. Currently supported formats are ``JSON``, ``CSV``, ``TSV``, and ``PSV``.
 
 **schema:** Specifies the output schema; the output schema can have only two fields: one of type ``STRING`` 
 and the other of type ``MAP<STRING, STRING>``.

--- a/transform-plugins/docs/ValueMapper-transform.md
+++ b/transform-plugins/docs/ValueMapper-transform.md
@@ -29,7 +29,7 @@ Properties
 **mapping:** A comma-separated list that defines the mapping of a source
 field to a target field and the mapping table name for looking up values.
 Contains three properties separated by a colon (":") as the source field, the
-mapping table name, and the target field (Macro-enabled):
+mapping table name, and the target field:
 
          <source-field>:<mapping-table-name>:<target-field>
 
@@ -39,7 +39,7 @@ Note: **source field** supports only STRING types.
 source field and its default value for cases where the source field
 value is either null or empty or if the mapping key-value is not present. If
 a default value has not been provided, the source field value will be
-mapped to the target field. Only STRING NULLABLE type values are accepted. (Macro-enabled)
+mapped to the target field. Only STRING NULLABLE type values are accepted.
 Example: <source field>:<defaultValue>
 
 

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVFormatter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVFormatter.java
@@ -196,12 +196,10 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
 
     @Name("format")
     @Description("Specify one of the predefined formats. DEFAULT, EXCEL, MYSQL, RFC4180 & TDF are supported formats.")
-    @Macro
     private final String format;
 
     @Name("delimiter")
     @Description("Specify delimiter to be used for separating fields.")
-    @Macro
     private final String delimiter;
 
     @Name("schema")
@@ -215,18 +213,18 @@ public final class CSVFormatter extends Transform<StructuredRecord, StructuredRe
     }
 
     private void validate() {
-      if (!containsMacro("delimiter") && !delimMap.containsKey(delimiter)) {
+      if (!delimMap.containsKey(delimiter)) {
         throw new IllegalArgumentException("Unknown delimiter '" + delimiter + "' specified. Allowed values are " +
                                              Joiner.on(", ").join(delimMap.keySet()));
       }
 
       // Check if the format specified is valid.
-      if (!containsMacro("format") && (format == null || format.isEmpty())) {
+      if (format == null || format.isEmpty()) {
         throw new IllegalArgumentException("Format is not specified. Allowed values are DELIMITED, EXCEL, MYSQL," +
                                              " RFC4180 & TDF");
       }
 
-      if (!containsMacro("format") && !format.equalsIgnoreCase("DELIMITED") && !format.equalsIgnoreCase("EXCEL") &&
+      if (!format.equalsIgnoreCase("DELIMITED") && !format.equalsIgnoreCase("EXCEL") &&
         !format.equalsIgnoreCase("MYSQL") && !format.equalsIgnoreCase("RFC4180") &&
         !format.equalsIgnoreCase("TDF")) {
         throw new IllegalArgumentException("Format specified is not one of the allowed values. Allowed values are " +

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
@@ -251,7 +251,6 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
     @Name("format")
     @Description("Specify one of the predefined formats. DEFAULT, EXCEL, MYSQL, RFC4180, PDL & TDF " +
       "are supported formats.")
-    @Macro
     private final String format;
 
     @Name("field")
@@ -271,13 +270,13 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
 
     private void validate() {
       // Check if the format specified is valid.
-      if (!containsMacro("format") && (format == null || format.isEmpty())) {
+      if (format == null || format.isEmpty()) {
         throw new IllegalArgumentException("Format is not specified. Allowed values are DEFAULT, EXCEL, MYSQL," +
                                              " RFC4180, PDL & TDF");
       }
 
       // Check if format is one of the allowed types.
-      if (!containsMacro("format") && !format.equalsIgnoreCase("DEFAULT") && !format.equalsIgnoreCase("EXCEL") &&
+      if (!format.equalsIgnoreCase("DEFAULT") && !format.equalsIgnoreCase("EXCEL") &&
         !format.equalsIgnoreCase("MYSQL") && !format.equalsIgnoreCase("RFC4180") &&
         !format.equalsIgnoreCase("TDF") && !format.equalsIgnoreCase("PDL")) {
         throw new IllegalArgumentException("Format specified is not one of the allowed values. Allowed values are " +

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Compressor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Compressor.java
@@ -116,9 +116,8 @@ public final class Compressor extends Transform<StructuredRecord, StructuredReco
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    if (!config.containsMacro("compressor")) {
-      parseConfiguration(config.compressor);
-    }
+    parseConfiguration(config.compressor);
+
     // Check if schema specified is a valid schema or no. 
     try {
       Schema outputSchema = Schema.parseJson(config.schema);
@@ -286,7 +285,6 @@ public final class Compressor extends Transform<StructuredRecord, StructuredReco
     @Name("compressor")
     @Description("Specify the field and compression type combination. " +
       "Format is <field>:<compressor-type>[,<field>:<compressor-type>]*")
-    @Macro
     private final String compressor;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decoder.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decoder.java
@@ -98,9 +98,7 @@ public final class Decoder extends Transform<StructuredRecord, StructuredRecord>
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    if (!config.containsMacro("decode")) {
-      parseConfiguration(config.decode);
-    }
+    parseConfiguration(config.decode);
 
     Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
 
@@ -231,7 +229,6 @@ public final class Decoder extends Transform<StructuredRecord, StructuredRecord>
     @Name("decode")
     @Description("Specify the field and decode type combination. " +
       "Format is <field>:<decode-type>[,<field>:<decode-type>]*")
-    @Macro
     private final String decode;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decompressor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decompressor.java
@@ -93,9 +93,7 @@ public final class Decompressor extends Transform<StructuredRecord, StructuredRe
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    if (!config.containsMacro("decompressor")) {
-      parseConfiguration(config.decompressor);
-    }
+    parseConfiguration(config.decompressor);
 
     // Check if schema specified is a valid schema or no.
     try {
@@ -289,7 +287,6 @@ public final class Decompressor extends Transform<StructuredRecord, StructuredRe
     @Name("decompressor")
     @Description("Specify the field and decompression type combination. " +
       "Format is <field>:<decompressor-type>[,<field>:<decompressor-type>]*")
-    @Macro
     private final String decompressor;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decryptor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Decryptor.java
@@ -101,7 +101,6 @@ public final class Decryptor extends Transform<StructuredRecord, StructuredRecor
    */
   public static class Conf extends KeystoreConf {
     @Description("The fields to decrypt, separated by commas")
-    @Macro
     private String decryptFields;
 
     @Description("Schema to pull fields from")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encoder.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encoder.java
@@ -95,9 +95,7 @@ public final class Encoder extends Transform<StructuredRecord, StructuredRecord>
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     super.configurePipeline(pipelineConfigurer);
-    if (!config.containsMacro("encode")) {
-      parseConfiguration(config.encode);
-    }
+    parseConfiguration(config.encode);
 
     Schema inputSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
     // for the fields in input schema, if they are to be encoded (if present in encodeMap)
@@ -231,7 +229,6 @@ public final class Encoder extends Transform<StructuredRecord, StructuredRecord>
     @Name("encode")
     @Description("Specify the field and encode type combination. " +
       "Format is <field>:<encode-type>[,<field>:<encode-type>]*")
-    @Macro
     private final String encode;
 
     @Name("schema")

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encryptor.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Encryptor.java
@@ -61,9 +61,7 @@ public final class Encryptor extends Transform<StructuredRecord, StructuredRecor
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
     Schema inputSchema = stageConfigurer.getInputSchema();
-    if (!conf.containsMacro("encryptFields")) {
-      encryptFields = conf.getEncryptFields();
-    }
+    encryptFields = conf.getEncryptFields();
     Schema outputSchema = inputSchema == null ? null : getOutputSchema(inputSchema);
     stageConfigurer.setOutputSchema(outputSchema);
   }
@@ -106,7 +104,6 @@ public final class Encryptor extends Transform<StructuredRecord, StructuredRecor
    */
   public static class Conf extends KeystoreConf {
     @Description("The fields to encrypt, separated by commas")
-    @Macro
     private String encryptFields;
 
     private Set<String> getEncryptFields() {

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/Hasher.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/Hasher.java
@@ -114,12 +114,10 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
     @Name("hash")
     @Description("Specifies the Hash method for hashing fields.")
     @Nullable
-    @Macro
     private final String hash;
     
     @Name("fields")
     @Description("List of fields to hash. Only string fields are allowed")
-    @Macro
     private final String fields;
     
     public Config(String hash, String fields) {
@@ -129,7 +127,7 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
 
     private void validate() {
       // Checks if hash specified is one of the supported types.
-      if (!containsMacro("hash") && !hash.equalsIgnoreCase("md2") && !hash.equalsIgnoreCase("md5") &&
+      if (!hash.equalsIgnoreCase("md2") && !hash.equalsIgnoreCase("md5") &&
         !hash.equalsIgnoreCase("sha1") && !hash.equalsIgnoreCase("sha256") &&
         !hash.equalsIgnoreCase("sha384") && !hash.equalsIgnoreCase("sha512")) {
         throw new IllegalArgumentException("Invalid hasher '" + hash + "' specified. Allowed hashers are md2, " +

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/StreamFormatter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/StreamFormatter.java
@@ -206,17 +206,14 @@ public final class StreamFormatter extends Transform<StructuredRecord, Structure
     @Name("body")
     @Description("Specify the fields to be set in the body")
     @Nullable
-    @Macro
     private String body;
     
     @Name("header")
     @Description("Specify the fields to be set in the header")
-    @Macro
     private String header;
     
     @Name("format")
     @Description("Format of the body to be written to stream. Defaults CSV")
-    @Macro
     private String format;
 
     @Name("schema")
@@ -233,7 +230,7 @@ public final class StreamFormatter extends Transform<StructuredRecord, Structure
 
     private void validate() {
       // If the format specified is not of one of the allowed types, then throw an exception.
-      if (!containsMacro("format") && !format.equalsIgnoreCase("CSV") && !format.equalsIgnoreCase("TSV")
+      if (!format.equalsIgnoreCase("CSV") && !format.equalsIgnoreCase("TSV")
         && !format.equalsIgnoreCase("JSON") && !format.equalsIgnoreCase("PSV")) {
         throw new IllegalArgumentException("Invalid format '" + format + "', specified. Allowed values are " +
                                              "CSV, TSV, PSV or JSON.");

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/ValueMapper.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/ValueMapper.java
@@ -65,14 +65,12 @@ public class ValueMapper extends Transform<StructuredRecord, StructuredRecord> {
             "[,<source-field>:<lookup-table-name>:<target-field>]*" +
             "Source and target field can only of type string." +
             "For example: lang_code:language_code_lookup:lang_desc,country_code:country_lookup:country_name")
-    @Macro
     private final String mapping;
 
     @Name("defaults")
     @Description("Specify the defaults for source fields if the lookup does not exist or inputs are NULL or EMPTY. " +
             "Format is <source-field>:<default-value>[,<source-field>:<default-value>]*" +
             "For example: lang_code:English,country_code:Britain")
-    @Macro
     private final String defaults;
 
     public Config(String mapping, String defaults) {


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/HYDRA-702
Build: http://builds.cask.co/browse/HYP-BAD77-3

This change is to remove all macros set on fields that are not configured with text boxes/text areas in the UI.
