### PR TITLE
Tweet Post Action

### DIFF
--- a/core-plugins/docs/Tweet-postaction.md
+++ b/core-plugins/docs/Tweet-postaction.md
@@ -38,6 +38,10 @@ the relevant app to find the consumer key and secret.
 
 **Tweet:** The text to post in the Tweet.
 
+**Namespace:** The namespace the pipeline will be run in.
+
+**PipelineName:** The name of the pipeline.
+
 Example
 -------
 This example sends an email from 'team-ops@example.com' to 'team-alerts@example.com' whenever a run fails:

--- a/core-plugins/docs/Tweet-postaction.md
+++ b/core-plugins/docs/Tweet-postaction.md
@@ -42,6 +42,8 @@ the relevant app to find the consumer key and secret.
 
 **PipelineName:** The name of the pipeline.
 
+**GeckoDriverPath:** The path to the Gecko driver used by Selenium.
+
 Example
 -------
 This example sends an email from 'team-ops@example.com' to 'team-alerts@example.com' whenever a run fails:

--- a/core-plugins/docs/Tweet-postaction.md
+++ b/core-plugins/docs/Tweet-postaction.md
@@ -1,0 +1,56 @@
+# Tweet Post Action
+
+
+Description
+-----------
+Posts a Tweet at the end of a pipeline run.
+
+
+Use Case
+--------
+This action can be used when you want to send an email at the end of a pipeline run.
+For example, you may want to configure a pipeline so that an email is sent whenever
+the run failed for any reason.
+
+
+Properties
+----------
+**runCondition:**" When to run the action. Must be 'completion', 'success', or 'failure'. Defaults to 'completion'.
+If set to 'completion', the action will be executed regardless of whether the pipeline run succeeded or failed.
+If set to 'success', the action will only be executed if the pipeline run succeeded.
+If set to 'failure', the action will only be executed if the pipeline run failed.
+
+See the [Twitter OAuth documentation] for more information on obtaining
+your access token and access token secret. The consumer key and secret
+are specific to your Twitter app. Login, view [your apps], then click on
+the relevant app to find the consumer key and secret.
+
+  [Twitter OAuth documentation]: https://dev.twitter.com/oauth/overview
+  [your apps]: https://apps.twitter.com/
+
+**ConsumerKey:** Twitter Consumer Key.
+
+**ConsumerSecret:** Twitter Consumer Secret.
+
+**AccessToken:** Twitter Access Token.
+
+**AccessTokenSecret:** Twitter Access Token Secret.
+
+**Tweet:** The text to post in the Tweet.
+
+Example
+-------
+This example sends an email from 'team-ops@example.com' to 'team-alerts@example.com' whenever a run fails:
+
+    {
+        "name": "Tweet",
+        "type": "postaction",
+        "properties": {
+            "consumerKey": "XXXX",
+            "consumerSecret": "XXXX",
+            "accessToken": "XXXX",
+            "accessTokenSecret": "XXXX",
+            "tweet": "Just finished a #BigData pipeline with #CaskHydrator",
+            "runCondition": "failure"
+        }
+    }

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -248,6 +248,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-firefox-driver</artifactId>
+      <version>3.0.0-beta2</version>
+    </dependency>
 
   </dependencies>
 

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -274,7 +274,8 @@
               co.cask.hydrator.plugin.validator.*;
               org.apache.avro.mapreduce;
               parquet.avro.*;
-              org.apache.orc.*
+              org.apache.orc.*;
+              org.openqa.selenium.*;
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -251,7 +251,6 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-firefox-driver</artifactId>
-      <version>3.0.0-beta2</version>
     </dependency>
 
   </dependencies>

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/TweetAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/TweetAction.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.action;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.etl.api.batch.BatchActionContext;
+import co.cask.cdap.etl.api.batch.PostAction;
+import co.cask.hydrator.common.batch.action.ConditionConfig;
+import twitter4j.Twitter;
+import twitter4j.TwitterFactory;
+import twitter4j.auth.AccessToken;
+
+import javax.annotation.Nullable;
+
+/**
+ * Posts a Tweet after an ETL Batch Application run is completed.
+ */
+@Plugin(type = PostAction.PLUGIN_TYPE)
+@Name("Tweet")
+@Description("Posts a Tweet after a pipeline run.")
+public class TweetAction extends PostAction {
+
+  private final Config config;
+
+  public TweetAction(Config config) {
+    this.config = config;
+  }
+
+  public void run(BatchActionContext context) throws Exception {
+    if (!config.shouldRun(context)) {
+      return;
+    }
+    // Build a Twitter object with the TwitterFactory, but make sure to pay well above minimum wage.
+    // Cask Data does not support sweat shops.
+    Twitter twitter = new TwitterFactory().getInstance();
+
+    // Do some fancy stuff with authorization, because not just ANYBODY can post to your account (You're special).
+    twitter.setOAuthConsumer(config.consumerKey, config.consumerSecret);
+    AccessToken accessToken = new AccessToken(config.accessToken, config.accessTokenSecret);
+    twitter.setOAuthAccessToken(accessToken);
+
+    // Just do it.
+    twitter.updateStatus(config.tweet);
+  }
+
+  /**
+   * Config class for TweetAction.
+   */
+  public static class Config extends ConditionConfig {
+    @Name("ConsumerKey")
+    @Description("Consumer Key for general consumption")
+    @Macro
+    private String consumerKey;
+
+    @Name("ConsumerSecret")
+    @Description("Consumer Secret for consuming in secret")
+    @Macro
+    private String consumerSecret;
+
+    @Name("AccessToken")
+    @Description("Access Token for accessing things")
+    @Macro
+    private String accessToken;
+
+    @Name("AccessTokenSecret")
+    @Description("Access Token Secret as a secret access alternative")
+    @Macro
+    private String accessTokenSecret;
+
+    @Description("The message to post with the Tweet, do you need any more explanation?")
+    @Macro
+    @Nullable
+    private String tweet;
+
+    public Config() {
+      tweet = "Just finished running a #BigData pipeline with #CaskHydrator.";
+    }
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/TweetAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/TweetAction.java
@@ -70,7 +70,7 @@ public class TweetAction extends PostAction {
       WebDriver webDriver = new FirefoxDriver();
       String pipelineURL = "http://localhost:9999/ns/" + config.namespace + "/hydrator/view/" + config.pipelineName;
       webDriver.get(pipelineURL);
-      File screenshot = ((TakesScreenshot)webDriver).getScreenshotAs(OutputType.FILE);
+      File screenshot = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.FILE);
       status.setMedia(screenshot);
     }
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/TweetAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/TweetAction.java
@@ -23,10 +23,16 @@ import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.etl.api.batch.BatchActionContext;
 import co.cask.cdap.etl.api.batch.PostAction;
 import co.cask.hydrator.common.batch.action.ConditionConfig;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import twitter4j.StatusUpdate;
 import twitter4j.Twitter;
 import twitter4j.TwitterFactory;
 import twitter4j.auth.AccessToken;
 
+import java.io.File;
 import javax.annotation.Nullable;
 
 /**
@@ -51,13 +57,25 @@ public class TweetAction extends PostAction {
     // Cask Data does not support sweat shops.
     Twitter twitter = new TwitterFactory().getInstance();
 
-    // Do some fancy stuff with authorization, because not just ANYBODY can post to your account (You're special).
+    // Do some fancy stuff with authorization, because not just ANYBODY can post to your account (you're special).
     twitter.setOAuthConsumer(config.consumerKey, config.consumerSecret);
     AccessToken accessToken = new AccessToken(config.accessToken, config.accessTokenSecret);
     twitter.setOAuthAccessToken(accessToken);
 
+    // Begin creating the status to end all statuses
+    StatusUpdate status = new StatusUpdate(config.tweet);
+
+    // Take that fancy screenshot to make all your friends jealous at your big data prowess
+    if (config.namespace != null && config.pipelineName != null) {
+      WebDriver webDriver = new FirefoxDriver();
+      String pipelineURL = "http://localhost:9999/ns/" + config.namespace + "/hydrator/view/" + config.pipelineName;
+      webDriver.get(pipelineURL);
+      File screenshot = ((TakesScreenshot)webDriver).getScreenshotAs(OutputType.FILE);
+      status.setMedia(screenshot);
+    }
+
     // Just do it.
-    twitter.updateStatus(config.tweet);
+    twitter.updateStatus(status);
   }
 
   /**
@@ -84,10 +102,23 @@ public class TweetAction extends PostAction {
     @Macro
     private String accessTokenSecret;
 
+    @Name("Tweet")
     @Description("The message to post with the Tweet, do you need any more explanation?")
     @Macro
     @Nullable
     private String tweet;
+
+    @Name("Namespace")
+    @Description("The namespace this pipeline will be run in.")
+    @Macro
+    @Nullable
+    private String namespace;
+
+    @Name("PipelineName")
+    @Description("The name of the pipeline.")
+    @Macro
+    @Nullable
+    private String pipelineName;
 
     public Config() {
       tweet = "Just finished running a #BigData pipeline with #CaskHydrator.";

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.TestConfiguration;
 import co.cask.hydrator.plugin.batch.action.EmailAction;
 import co.cask.hydrator.plugin.batch.action.SSHAction;
+import co.cask.hydrator.plugin.batch.action.TweetAction;
 import co.cask.hydrator.plugin.batch.aggregator.DedupAggregator;
 import co.cask.hydrator.plugin.batch.aggregator.GroupByAggregator;
 import co.cask.hydrator.plugin.batch.joiner.Joiner;
@@ -138,7 +139,8 @@ public class ETLBatchTestBase extends HydratorTestBase {
                       DedupAggregator.class,
                       Joiner.class,
                       EmailAction.class,
-                      SSHAction.class);
+                      SSHAction.class,
+                      TweetAction.class);
   }
 
   protected List<GenericRecord> readOutput(TimePartitionedFileSet fileSet, Schema schema) throws IOException {

--- a/core-plugins/widgets/Tweet-postaction.json
+++ b/core-plugins/widgets/Tweet-postaction.json
@@ -60,6 +60,21 @@
           "name": "ConsumerSecret"
         }
       ]
+    },
+    {
+      "label": "Pipeline Screenshot Settings",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Namespace",
+          "name": "namespace"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Pipeline Name",
+          "name": "pipelineName"
+        }
+      ]
     }
   ],
   "outputs": []

--- a/core-plugins/widgets/Tweet-postaction.json
+++ b/core-plugins/widgets/Tweet-postaction.json
@@ -73,6 +73,11 @@
           "widget-type": "textbox",
           "label": "Pipeline Name",
           "name": "pipelineName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Gecko Driver Path",
+          "name": "geckoDriverPath"
         }
       ]
     }

--- a/core-plugins/widgets/Tweet-postaction.json
+++ b/core-plugins/widgets/Tweet-postaction.json
@@ -1,0 +1,66 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "Tweet Properties",
+      "properties": [
+        {
+          "widget-type": "select",
+          "label": "Run Condition",
+          "name": "runCondition",
+          "widget-attributes": {
+            "values": [
+              "completion",
+              "success",
+              "failure"
+            ],
+            "default": "completion"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Tweet",
+          "name": "tweet"
+        }
+      ]
+    },
+    {
+      "label": "OAuth Access Tokens",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Access Token",
+          "name": "AccessToken"
+        },
+        {
+          "widget-type": "password",
+          "label": "Access Token Secret",
+          "name": "AccessTokenSecret"
+        }
+      ]
+    },
+    {
+      "label": "OAuth Consumer Settings",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Consumer Key",
+          "name": "ConsumerKey"
+        },
+        {
+          "widget-type": "password",
+          "label": "Consumer Secret",
+          "name": "ConsumerSecret"
+        }
+      ]
+    }
+  ],
+  "outputs": []
+}

--- a/pom.xml
+++ b/pom.xml
@@ -614,6 +614,11 @@
         <artifactId>spark-streaming-twitter_2.10</artifactId>
         <version>1.6.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.seleniumhq.selenium</groupId>
+        <artifactId>selenium-firefox-driver</artifactId>
+        <version>3.0.0-beta2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
# Tweet Post Action Plugin

Cask Hydrator allows data scientists to create ETL pipelines through a simple drag-and-drop interface. However, is that really good enough?

The world of big data is indeed very, very big. The face of the field is evolving almost on a monthly basis. In this ever-changing world, the question is: how can a data scientist simultaneously do work while reminding those around them that they are, in fact, doing work? The answer is social media, which often goes hand-in-hand with big data. 

Now, with the Tweet post-action, pipeline operators can post a Tweet conditionally based on the result of an ETL pipeline. Here are some examples:
- On completion:
  `Just finished a run of an ETL Pipeline with #CaskHydrator! Boy, that was a lot of fun, y'all should try it out.`
- On success:
  `Successfully finished my very own ETL Pipeline with #CaskHydrator! Happy to throw more money at @CaskData.`
- On failure:
  `My f****** pipeline failed... thanks a lot @CaskData #FML`

As a company, Cask Data is committed to growing and evolving with the needs of its users. We believe that this Tweet post action is a testament to how hip, far out, and down with the kids we are.

> “If Paul Revere had been a modern day citizen, he wouldn't have ridden down Main Street. He would have tweeted." - @AlecJRoss

ᵀʰᶦˢ ᵐᵃʸ ᵒʳ ᵐᵃʸ ᶰᵒᵗ ᵇᵉ ᵃ ʲᵒᵏᵉ
