### PR TITLE
HYDRATOR-922 remove usage of BadRequestException

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/DedupAggregator.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/DedupAggregator.java
@@ -31,7 +31,6 @@ import co.cask.hydrator.plugin.batch.aggregator.function.SelectionFunction;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Path;
 
 /**
@@ -129,11 +128,7 @@ public class DedupAggregator extends RecordAggregator {
 
   @Path("outputSchema")
   public Schema getOutputSchema(GetSchemaRequest request) {
-    try {
-      return getOutputSchema(request.inputSchema);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e.getMessage(), e);
-    }
+    return getOutputSchema(request.inputSchema);
   }
 
   private Schema getGroupKeySchema(Schema inputSchema) {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/GroupByAggregator.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/GroupByAggregator.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Path;
 
 /**
@@ -117,11 +116,7 @@ public class GroupByAggregator extends RecordAggregator {
 
   @Path("outputSchema")
   public Schema getOutputSchema(GetSchemaRequest request) {
-    try {
-      return getOutputSchema(request.inputSchema, request.getGroupByFields(), request.getAggregates());
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e.getMessage());
-    }
+    return getOutputSchema(request.inputSchema, request.getGroupByFields(), request.getAggregates());
   }
 
   private Schema getOutputSchema(Schema inputSchema, List<String> groupByFields,

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/Joiner.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/Joiner.java
@@ -39,7 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Path;
 
 /**
@@ -181,15 +180,11 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
 
   @Path("outputSchema")
   public Schema getOutputSchema(GetSchemaRequest request) {
-    try {
-      validateJoinKeySchemas(request.inputSchemas, request.getPerStageJoinKeys());
-      requiredInputs = request.getInputs();
-      perStageSelectedFields = request.getPerStageSelectedFields();
-      duplicateFields = ArrayListMultimap.create();
-      return getOutputSchema(request.inputSchemas);
-    } catch (IllegalArgumentException e) {
-        throw new BadRequestException(e.getMessage());
-    }
+    validateJoinKeySchemas(request.inputSchemas, request.getPerStageJoinKeys());
+    requiredInputs = request.getInputs();
+    perStageSelectedFields = request.getPerStageSelectedFields();
+    duplicateFields = ArrayListMultimap.create();
+    return getOutputSchema(request.inputSchemas);
   }
 
   /**

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -55,10 +55,8 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import javax.annotation.Nullable;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Path;
 
 /**
@@ -116,13 +114,11 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
    * @throws SQLException
    * @throws InstantiationException
    * @throws IllegalAccessException
-   * @throws BadRequestException If executing the query threw {@link SQLSyntaxErrorException}
-   * we get the message and throw it as BadRequestException
    */
   @Path("getSchema")
   public Schema getSchema(GetSchemaRequest request,
                           EndpointPluginContext pluginContext) throws IllegalAccessException,
-    SQLException, InstantiationException, BadRequestException {
+    SQLException, InstantiationException {
     DriverCleanup driverCleanup;
     try {
       driverCleanup = loadPluginClassAndGetDriver(request, pluginContext);
@@ -131,8 +127,6 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
         statement.setMaxRows(1);
         ResultSet resultSet = statement.executeQuery(request.query);
         return Schema.recordOf("outputSchema", DBUtils.getSchemaFields(resultSet));
-      } catch (SQLSyntaxErrorException e) {
-        throw new BadRequestException(e.getMessage());
       } finally {
         driverCleanup.destroy();
       }


### PR DESCRIPTION
The class causes problems with some versions of spark that bundle
jersey classes in the spark-assembly jar. In those situations,
the javax.ws.rs classes visible to the program are the jersey
classes (which dont include BadRequestException) and not the
rs-api-2.0 classes (which do include BadRequestException). Since
that package seems to exist in multiple dependencies, just removing
usage of BadRequestException for simplicity.
