### PR TITLE
Fixing realtime elasticsearch sink to work with spark streaming

### DIFF
--- a/elasticsearch-plugins/pom.xml
+++ b/elasticsearch-plugins/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-hadoop-mr</artifactId>
+      <artifactId>elasticsearch-hadoop</artifactId>
     </dependency>
     <!-- elasticsearch-hadoop-mr includes a class, StringUtils, which requires commons-httpclient-->
     <dependency>

--- a/elasticsearch-plugins/src/test/java/co/cask/hydrator/plugin/test/ETLESTest.java
+++ b/elasticsearch-plugins/src/test/java/co/cask/hydrator/plugin/test/ETLESTest.java
@@ -61,7 +61,7 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.search.SearchHit;
 import org.junit.After;
@@ -141,12 +141,12 @@ public class ETLESTest extends HydratorTestBase {
   public void beforeTest() throws Exception {
     httpPort = Networks.getRandomPort();
     transportPort = Networks.getRandomPort();
-    ImmutableSettings.Builder elasticsearchSettings = ImmutableSettings.settingsBuilder()
+    Settings elasticsearchSettings = Settings.settingsBuilder()
       .put("path.data", tmpFolder.newFolder("data"))
       .put("cluster.name", "testcluster")
       .put("http.port", httpPort)
-      .put("transport.tcp.port", transportPort);
-    node = nodeBuilder().settings(elasticsearchSettings.build()).client(false).node();
+      .put("transport.tcp.port", transportPort).build();
+    node = nodeBuilder().settings(elasticsearchSettings).client(false).node();
     client = node.client();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
     <cdap.version>4.0.0-SNAPSHOT</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
-    <es.version>1.6.0</es.version>
-    <es-hadoop.version>2.1.0</es-hadoop.version>
+    <es.version>2.4.0</es.version>
+    <es-hadoop.version>2.4.0</es-hadoop.version>
     <fastutil.version>6.6.1</fastutil.version>
     <geronimo-jms.version>1.1.1</geronimo-jms.version>
     <guava.version>13.0.1</guava.version>
@@ -467,7 +467,7 @@
       </dependency>
       <dependency>
         <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-hadoop-mr</artifactId>
+        <artifactId>elasticsearch-hadoop</artifactId>
         <version>${es-hadoop.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Build: http://builds.cask.co/browse/HYP-BAD136-1

Changes:
- version incompatibility 
- changing artifact from `elasticsearch-hadoop-mr` to `elasticsearch-hadoop`
- Fixing config inconsistencies with UI and backend
