### PR TITLE
HYDRATOR-971 adding a file streaming source

### DIFF
--- a/spark-plugins/docs/File-streamingsource.md
+++ b/spark-plugins/docs/File-streamingsource.md
@@ -1,0 +1,57 @@
+# File Streaming Source
+
+
+Description
+-----------
+File streaming source. Watches a directory and streams file contents of any new files added to the directory.
+Files must be atomically moved or renamed.
+
+
+Use Case
+--------
+This source is used whenever you want to read files from a directory in a streaming context.
+For example, you may want to read access logs as they are moved into an archive directory.
+
+
+Properties
+----------
+**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+
+**path:** The path of the directory to monitor. Files must be written to the monitored directory by
+"moving" them from another location within the same file system. File names starting with . are ignored. (Macro-enabled)
+
+**format:** Format of files in the directory. Supported formats are 'text', 'csv', 'tsv', 'clf', 'grok', and 'syslog'.
+The default format is 'text'. (Macro-enabled)
+
+**schema:** Schema of files in the directory.
+
+**extensions:** Comma separated list of file extensions to accept. If not specified, all files in the directory
+will be read. Otherwise, only files with an extension in this list will be read. (Macro-enabled)
+
+**ignoreThreshold:** Ignore files that are older than this many seconds. Defaults to 60. (Macro-enabled)
+
+
+Example
+-------
+This example reads from the '/data/events' directory on an hdfs cluster whose namenode
+is running on namenode.example.com. The source will monitor the directory for any
+new files that are added. It will parse those files as comma separated files with three
+columns: timestamp, user, and action.
+
+    {
+        "name": "File",
+        "type": "streamingsource",
+        "properties": {
+            "path": "hdfs://namenode.example.com/data/events",
+            "format": "csv",
+            "schema": "{
+                \"type\":\"record\",
+                \"name\":\"event\",
+                \"fields\":[
+                    {\"name\":\"timestamp\",\"type\":\"long\"},
+                    {\"name\":\"user\",\"type\":\"string\"},
+                    {\"name\":\"action\",\"type\":\"string\"}
+                ]
+            }"
+        }
+    }

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/FileStreamingSource.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/FileStreamingSource.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.spark;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.data.format.RecordFormat;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.format.RecordFormats;
+import co.cask.hydrator.common.ReferencePluginConfig;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Source that monitors a directory and reads files from it.
+ */
+@Plugin(type = StreamingSource.PLUGIN_TYPE)
+@Name("File")
+@Description("File streaming source. Streams data from files that are atomically moved into a specified directory.")
+public class FileStreamingSource extends ReferenceStreamingSource<StructuredRecord> {
+  private final Conf conf;
+
+  public FileStreamingSource(Conf conf) {
+    super(conf);
+    this.conf = conf;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    super.configurePipeline(pipelineConfigurer);
+    conf.validate();
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(conf.getSchema());
+  }
+
+  @Override
+  public JavaDStream<StructuredRecord> getStream(StreamingContext context) throws Exception {
+    conf.validate();
+    registerUsage(context);
+
+    JavaStreamingContext jsc = context.getSparkStreamingContext();
+
+    Function<Path, Boolean> filter =
+      conf.extensions == null ? new NoFilter() : new ExtensionFilter(conf.getExtensions());
+
+    jsc.ssc().conf().set("spark.streaming.fileStream.minRememberDuration", conf.ignoreThreshold + "s");
+    return jsc.fileStream(conf.path, LongWritable.class, Text.class,
+                          TextInputFormat.class, filter, false)
+      .flatMap(new FormatFunction(conf.format, conf.schema));
+  }
+
+  /**
+   * Doesn't filter any files.
+   */
+  private static class NoFilter implements Function<Path, Boolean> {
+    @Override
+    public Boolean call(Path path) throws Exception {
+      return true;
+    }
+  }
+
+  /**
+   * Filters out files that don't have one of the supported extensions.
+   */
+  private static class ExtensionFilter implements Function<Path, Boolean> {
+    private final Set<String> extensions;
+
+    ExtensionFilter(Set<String> extensions) {
+      this.extensions = extensions;
+    }
+
+    @Override
+    public Boolean call(Path path) throws Exception {
+      String extension = Files.getFileExtension(path.getName());
+      return extensions.contains(extension);
+    }
+  }
+
+  /**
+   * Transforms kafka key and message into a structured record when message format and schema are given.
+   * Everything here should be serializable, as Spark Streaming will serialize all functions.
+   */
+  private static class FormatFunction implements FlatMapFunction<Tuple2<LongWritable, Text>, StructuredRecord> {
+    private final String format;
+    private final String schemaStr;
+    private transient Schema schema;
+    private transient RecordFormat<StreamEvent, StructuredRecord> recordFormat;
+
+    FormatFunction(String format, String schemaStr) {
+      this.format = format;
+      this.schemaStr = schemaStr;
+    }
+
+    @Override
+    public Iterable<StructuredRecord> call(Tuple2<LongWritable, Text> in) throws Exception {
+      // first time this was called, initialize schema and time, key, and message fields.
+      if (recordFormat == null) {
+        schema = Schema.parseJson(schemaStr);
+        FormatSpecification spec = new FormatSpecification(format, schema, new HashMap<String, String>());
+        recordFormat = RecordFormats.createInitializedFormat(spec);
+      }
+
+      StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+      StructuredRecord messageRecord = recordFormat.read(new StreamEvent(ByteBuffer.wrap(in._2().getBytes())));
+      for (Schema.Field messageField : messageRecord.getSchema().getFields()) {
+        String fieldName = messageField.getName();
+        builder.set(fieldName, messageRecord.get(fieldName));
+      }
+      List<StructuredRecord> output = new ArrayList<>(1);
+      output.add(builder.build());
+      return output;
+    }
+  }
+
+  /**
+   * Configuration for the source.
+   */
+  public static class Conf extends ReferencePluginConfig {
+    private static final Set<String> FORMATS = ImmutableSet.of("text", "csv", "tsv", "clf", "grok", "syslog");
+
+    @Macro
+    @Description("The format of the source files. Must be text, csv, tsv, clf, grok, or syslog. Defaults to text.")
+    @Nullable
+    private String format;
+
+    @Description("The schema of the source files.")
+    @Nullable
+    private String schema;
+
+    @Macro
+    @Description("The path to the directory containing source files to stream.")
+    private String path;
+
+    @Macro
+    @Description("Ignore files after they are older than this many seconds. Defaults to 60.")
+    @Nullable
+    private Integer ignoreThreshold;
+
+    @Macro
+    @Description("Comma separated list of file extensions to accept. If not specified, all files in the directory " +
+      "will be read. Otherwise, only files with an extension in this list will be read.")
+    @Nullable
+    private String extensions;
+
+    public Conf() {
+      super(null);
+      this.path = "";
+      this.format = "text";
+      this.schema = null;
+      this.ignoreThreshold = 60;
+      this.extensions = null;
+    }
+
+    private void validate() {
+      if (!containsMacro(format) && !FORMATS.contains(format)) {
+        throw new IllegalArgumentException(
+          String.format("Invalid format '%s'. Must be one of %s", format, Joiner.on(',').join(FORMATS)));
+      }
+      if (schema != null) {
+        getSchema();
+      }
+    }
+
+    private Schema getSchema() {
+      try {
+        return Schema.parseJson(schema);
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Unable to parse schema. Reason: " + e.getMessage());
+      }
+    }
+
+    private Set<String> getExtensions() {
+      Set<String> extensionsSet = new HashSet<>();
+      if (extensions == null) {
+        return extensionsSet;
+      }
+      for (String extension : Splitter.on(',').trimResults().split(extensions)) {
+        extensionsSet.add(extension);
+      }
+      return extensionsSet;
+    }
+  }
+
+}

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/FileStreamingSource.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/FileStreamingSource.java
@@ -142,7 +142,7 @@ public class FileStreamingSource extends ReferenceStreamingSource<StructuredReco
       }
 
       StructuredRecord.Builder builder = StructuredRecord.builder(schema);
-      StructuredRecord messageRecord = recordFormat.read(new StreamEvent(ByteBuffer.wrap(in._2().getBytes())));
+      StructuredRecord messageRecord = recordFormat.read(new StreamEvent(ByteBuffer.wrap(in._2().copyBytes())));
       for (Schema.Field messageField : messageRecord.getSchema().getFields()) {
         String fieldName = messageField.getName();
         builder.set(fieldName, messageRecord.get(fieldName));
@@ -165,7 +165,6 @@ public class FileStreamingSource extends ReferenceStreamingSource<StructuredReco
     private String format;
 
     @Description("The schema of the source files.")
-    @Nullable
     private String schema;
 
     @Macro
@@ -197,9 +196,7 @@ public class FileStreamingSource extends ReferenceStreamingSource<StructuredReco
         throw new IllegalArgumentException(
           String.format("Invalid format '%s'. Must be one of %s", format, Joiner.on(',').join(FORMATS)));
       }
-      if (schema != null) {
-        getSchema();
-      }
+      getSchema();
     }
 
     private Schema getSchema() {

--- a/spark-plugins/widgets/File-streamingsource.json
+++ b/spark-plugins/widgets/File-streamingsource.json
@@ -1,0 +1,77 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "configuration-groups": [
+    {
+      "label": "File Configuration",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "File Path",
+          "name": "path"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Ignore Threshold",
+          "name": "ignoreThreshold"
+        },
+        {
+          "widget-type": "csv",
+          "label": "Extension Whitelist",
+          "name": "extensions",
+          "widget-attributes": {
+            "delimiter": ",",
+            "value-placeholder": "Extension"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Format",
+      "properties": [
+        {
+          "widget-type": "select",
+          "label": "Format",
+          "name": "format",
+          "widget-attributes": {
+            "values": [
+              "clf",
+              "csv",
+              "grok",
+              "syslog",
+              "text",
+              "tsv"
+            ],
+            "default": "text"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "schema",
+      "widget-type": "schema",
+      "widget-attributes": {
+        "default-schema": {
+          "name": "etlSchemaBody",
+          "type": "record",
+          "fields": [
+            {
+              "name": "body",
+              "type": "string"
+            }
+          ]
+        },
+        "schema-default-type": "string",
+        "property-watch": "format"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The source allows the user to configure a path, format, schema,
a whitelist of file extensions, and whether to ignore existing
files or not. It will then monitor the directory and read any
new files it finds.
