### PR TITLE
HYDRATOR-973 add http poll streaming source

### DIFF
--- a/http-plugins/pom.xml
+++ b/http-plugins/pom.xml
@@ -68,7 +68,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <_exportcontents>co.cask.hydrator.plugin.*</_exportcontents>
+            <_exportcontents>co.cask.hydrator.plugin.*;co.cask.hydrator.common.http</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/http-plugins/src/main/java/co/cask/hydrator/plugin/batch/HTTPCallbackAction.java
+++ b/http-plugins/src/main/java/co/cask/hydrator/plugin/batch/HTTPCallbackAction.java
@@ -25,7 +25,7 @@ import co.cask.cdap.etl.api.batch.BatchActionContext;
 import co.cask.cdap.etl.api.batch.PostAction;
 import co.cask.hydrator.common.batch.action.Condition;
 import co.cask.hydrator.common.batch.action.ConditionConfig;
-import co.cask.hydrator.plugin.config.HTTPConfig;
+import co.cask.hydrator.common.http.HTTPConfig;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
@@ -143,10 +143,6 @@ public class HTTPCallbackAction extends PostAction {
       super();
       numRetries = 0;
       runCondition = Condition.COMPLETION.name();
-    }
-
-    public HttpRequestConf(String url) {
-      super(url);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/http-plugins/src/main/java/co/cask/hydrator/plugin/realtime/HTTPPollerRealtimeSource.java
+++ b/http-plugins/src/main/java/co/cask/hydrator/plugin/realtime/HTTPPollerRealtimeSource.java
@@ -21,25 +21,16 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.format.StructuredRecord;
-import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.etl.api.realtime.SourceState;
 import co.cask.hydrator.common.ReferencePluginConfig;
 import co.cask.hydrator.common.ReferenceRealtimeSource;
-import co.cask.hydrator.plugin.realtime.config.HTTPPollConfig;
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
-import com.google.common.io.CharStreams;
+import co.cask.hydrator.common.http.HTTPPollConfig;
+import co.cask.hydrator.common.http.HTTPRequestor;
 
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -50,18 +41,10 @@ import javax.annotation.Nullable;
 @Name("HTTPPoller")
 @Description("Fetch data by performing an HTTP request at a regular interval.")
 public class HTTPPollerRealtimeSource extends ReferenceRealtimeSource<StructuredRecord> {
-  private static final String METHOD = "GET";
   private static final String POLL_TIME_STATE_KEY = "lastPollTime";
-  private static final Schema SCHEMA = Schema.recordOf(
-    "event",
-    Schema.Field.of("ts", Schema.of(Schema.Type.LONG)),
-    Schema.Field.of("url", Schema.of(Schema.Type.STRING)),
-    Schema.Field.of("responseCode", Schema.of(Schema.Type.INT)),
-    Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))),
-    Schema.Field.of("body", Schema.of(Schema.Type.STRING))
-  );
 
   private final HTTPPollConfig config;
+  private HTTPRequestor httpRequestor;
 
   public HTTPPollerRealtimeSource(HTTPPollConfig config) {
     super(new ReferencePluginConfig(config.referenceName));
@@ -69,9 +52,16 @@ public class HTTPPollerRealtimeSource extends ReferenceRealtimeSource<Structured
   }
 
   @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(HTTPRequestor.SCHEMA);
+  }
+
+  @Override
   public void initialize(RealtimeContext context) throws Exception {
     super.initialize(context);
     config.validate();
+    httpRequestor = new HTTPRequestor(config);
   }
 
   @Nullable
@@ -90,57 +80,10 @@ public class HTTPPollerRealtimeSource extends ReferenceRealtimeSource<Structured
       }
     }
     try {
-      URL url = new URL(config.getUrl());
-      String response = "";
-      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-      connection.setRequestMethod(METHOD);
-      connection.setConnectTimeout(config.getConnectTimeout());
-      connection.setReadTimeout(config.getReadTimeout());
-      connection.setInstanceFollowRedirects(config.shouldFollowRedirects());
-      // Set additional request headers
-      for (Map.Entry<String, String> requestHeader : config.getRequestHeadersMap().entrySet()) {
-        connection.setRequestProperty(requestHeader.getKey(), requestHeader.getValue());
-      }
-      int responseCode = connection.getResponseCode();
-      try {
-        if (connection.getErrorStream() != null) {
-          try (Reader reader = new InputStreamReader(connection.getErrorStream(), config.getCharset())) {
-            response = CharStreams.toString(reader);
-          }
-        } else if (connection.getInputStream() != null) {
-          try (Reader reader = new InputStreamReader(connection.getInputStream(), config.getCharset())) {
-            response = CharStreams.toString(reader);
-          }
-        }
-      } finally {
-        connection.disconnect();
-      }
-
-      Map<String, List<String>> headers = connection.getHeaderFields();
-      Map<String, String> flattenedHeaders = new HashMap<>();
-      for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
-        if (!Strings.isNullOrEmpty(entry.getKey())) {
-          // If multiple values for the same header exist, concatenate them
-          flattenedHeaders.put(entry.getKey(), Joiner.on(',').skipNulls().join(entry.getValue()));
-        }
-      }
-      writer.emit(createStructuredRecord(response, flattenedHeaders, responseCode));
+      writer.emit(httpRequestor.get());
     } finally {
       currentState.setState(POLL_TIME_STATE_KEY, Bytes.toBytes(System.currentTimeMillis()));
     }
     return currentState;
-  }
-
-  private StructuredRecord createStructuredRecord(String response,
-                                                  Map<String, String> headerFields,
-                                                  int responseCode) {
-    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(SCHEMA);
-    recordBuilder
-      .set("ts", System.currentTimeMillis())
-      .set("url", config.getUrl())
-      .set("responseCode", responseCode)
-      .set("headers", headerFields)
-      .set("body", response);
-    return recordBuilder.build();
   }
 }

--- a/http-plugins/src/test/java/co/cask/hydrator/plugin/realtime/HTTPPollTest.java
+++ b/http-plugins/src/test/java/co/cask/hydrator/plugin/realtime/HTTPPollTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.test.TestBase;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import co.cask.http.NettyHttpService;
-import co.cask.hydrator.plugin.realtime.config.HTTPPollConfig;
+import co.cask.hydrator.common.http.HTTPPollConfig;
 import com.google.common.collect.ImmutableList;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/http/HTTPConfig.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/http/HTTPConfig.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.hydrator.plugin.config;
+package co.cask.hydrator.common.http;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.plugin.PluginConfig;
@@ -52,10 +52,6 @@ public class HTTPConfig extends PluginConfig {
   private Integer connectTimeout;
 
   public HTTPConfig() {
-    this(null);
-  }
-
-  public HTTPConfig(String url) {
     this(null, null);
   }
 

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/http/HTTPPollConfig.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/http/HTTPPollConfig.java
@@ -14,12 +14,11 @@
  * the License.
  */
 
-package co.cask.hydrator.plugin.realtime.config;
+package co.cask.hydrator.common.http;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.hydrator.common.Constants;
-import co.cask.hydrator.plugin.config.HTTPConfig;
 import com.google.common.base.Charsets;
 
 import java.nio.charset.Charset;

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/http/HTTPRequestor.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/http/HTTPRequestor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.common.http;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.io.CharStreams;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility code for performing a get request and formatting it as a StructuredRecord.
+ */
+public class HTTPRequestor {
+  public static final Schema SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("ts", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("url", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("responseCode", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("body", Schema.of(Schema.Type.STRING))
+  );
+  private final HTTPPollConfig config;
+
+  public HTTPRequestor(HTTPPollConfig config) {
+    this.config = config;
+  }
+
+  public StructuredRecord get() throws IOException {
+    URL url = new URL(config.getUrl());
+    String response = "";
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("GET");
+    connection.setConnectTimeout(config.getConnectTimeout());
+    connection.setReadTimeout(config.getReadTimeout());
+    connection.setInstanceFollowRedirects(config.shouldFollowRedirects());
+    // Set additional request headers
+    for (Map.Entry<String, String> requestHeader : config.getRequestHeadersMap().entrySet()) {
+      connection.setRequestProperty(requestHeader.getKey(), requestHeader.getValue());
+    }
+    int responseCode = connection.getResponseCode();
+    try {
+      if (connection.getErrorStream() != null) {
+        try (Reader reader = new InputStreamReader(connection.getErrorStream(), config.getCharset())) {
+          response = CharStreams.toString(reader);
+        }
+      } else if (connection.getInputStream() != null) {
+        try (Reader reader = new InputStreamReader(connection.getInputStream(), config.getCharset())) {
+          response = CharStreams.toString(reader);
+        }
+      }
+    } finally {
+      connection.disconnect();
+    }
+
+    Map<String, List<String>> headers = connection.getHeaderFields();
+    Map<String, String> flattenedHeaders = new HashMap<>();
+    for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+      if (!Strings.isNullOrEmpty(entry.getKey())) {
+        // If multiple values for the same header exist, concatenate them
+        flattenedHeaders.put(entry.getKey(), Joiner.on(',').skipNulls().join(entry.getValue()));
+      }
+    }
+    return createStructuredRecord(response, flattenedHeaders, responseCode);
+  }
+
+  private StructuredRecord createStructuredRecord(String response,
+                                                  Map<String, String> headerFields,
+                                                  int responseCode) {
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(SCHEMA);
+    recordBuilder
+      .set("ts", System.currentTimeMillis())
+      .set("url", config.getUrl())
+      .set("responseCode", responseCode)
+      .set("headers", headerFields)
+      .set("body", response);
+    return recordBuilder.build();
+  }
+}

--- a/spark-plugins/docs/HTTPPoller-streamingsource.md
+++ b/spark-plugins/docs/HTTPPoller-streamingsource.md
@@ -1,0 +1,61 @@
+# HTTP Poller Streaming Source
+
+Description
+-----------
+This is a streaming source that will fetch data from a specified URL at a given interval and
+pass the results to the next plugin. This source will return one record for each request to
+the specified URL. The record will contain a timestamp, the URL that was requested, the response code
+of the response and the set of response headers in a map<string, string> format, and the body of the response.
+
+Use Case
+--------
+The source is used whenever you need to fetch data from a URL at a regular interval. It could be
+used to fetch Atom or RSS feeds regularly, or to fetch the status of an external system.
+
+
+Properties
+----------
+**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+
+**url:** Required The URL to fetch data from.
+
+**interval:** Required The time to wait between fetching data from the URL in seconds.
+
+**requestHeaders:** An optional string of header values to send in each request where the keys and values are
+delimited by a colon (":") and each pair is delimited by a newline ("\n").
+
+**charset:** The charset of the content returned by the URL. Defaults to UTF-8.
+
+**followRedirects:** Whether to automatically follow redirects. Defaults to true.
+
+**connectTimeout:** The time in milliseconds to wait for a connection. Set to 0 for infinite. Defaults to 60000 (1 minute).
+
+**readTimeout:** The time in milliseconds to wait for a read. Set to 0 for infinite. Defaults to 60000 (1 minute).
+
+Example
+-------
+This example fetches data from a URL every hour using a custom user agent:
+
+    {
+        "name": "HTTPPoller",
+        "type": "streamingsource",
+        "properties": {
+            "url": "http://example.com/sampleEndpoint",
+            "interval": "60",
+            "requestHeaders": "User-Agent:HydratorPipeline\nAccept:application/json"
+        }
+    }
+
+The contents will output records with this schema:
+
+    +======================================+
+    | field name     | type                |
+    +======================================+
+    | ts             | long                |
+    | url            | string              |
+    | responseCode   | int                 |
+    | headers        | map<string, string> |
+    | body           | string              |
+    +======================================+
+
+All fields will be always be included, but the body might be an empty string.

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -177,7 +177,7 @@
         <configuration>
           <instructions>
             <_exportcontents>
-              co.cask.hydrator.plugin.spark.*;org.apache.spark.streaming.kafka.*;org.apache.spark.streaming.scheduler.*;kafka.serializer.*;org.apache.spark.streaming.twitter.*;twitter4j.*;
+              co.cask.hydrator.plugin.spark.*;org.apache.spark.streaming.kafka.*;org.apache.spark.streaming.scheduler.*;kafka.serializer.*;org.apache.spark.streaming.twitter.*;twitter4j.*;;co.cask.hydrator.common.http
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/HTTPPollerSource.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/HTTPPollerSource.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.spark;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.hydrator.common.http.HTTPPollConfig;
+import co.cask.hydrator.common.http.HTTPRequestor;
+import org.apache.spark.storage.StorageLevel;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.receiver.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Polls a http endpoints and outputs a record for each url response.
+ */
+@Plugin(type = StreamingSource.PLUGIN_TYPE)
+@Name("HTTPPoller")
+@Description("Fetch data by performing an HTTP request at a regular interval.")
+public class HTTPPollerSource extends StreamingSource<StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(HTTPPollerSource.class);
+  private final HTTPPollConfig conf;
+
+  public HTTPPollerSource(HTTPPollConfig conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public JavaDStream<StructuredRecord> getStream(StreamingContext streamingContext) throws Exception {
+    return streamingContext.getSparkStreamingContext()
+      .receiverStream(new Receiver<StructuredRecord>(StorageLevel.MEMORY_ONLY()) {
+
+        @Override
+        public StorageLevel storageLevel() {
+          return StorageLevel.MEMORY_ONLY();
+        }
+
+        @Override
+        public void onStart() {
+          new Thread() {
+
+            @Override
+            public void run() {
+              HTTPRequestor httpRequestor = new HTTPRequestor(conf);
+              while (!isStopped()) {
+
+                try {
+                  store(httpRequestor.get());
+                } catch (Exception e) {
+                  LOG.error("Error getting content from {}.", conf.getUrl(), e);
+                }
+
+                try {
+                  TimeUnit.SECONDS.sleep(conf.getInterval());
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            }
+
+            @Override
+            public void interrupt() {
+              super.interrupt();
+            }
+          }.start();
+        }
+
+        @Override
+        public void onStop() {
+
+        }
+      });
+  }
+}

--- a/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/mock/MockFeedHandler.java
+++ b/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/mock/MockFeedHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.spark.mock;
+
+import co.cask.http.HandlerContext;
+import co.cask.http.HttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Http handler used for unit tests.
+ *
+ * Has endpoints to set feed content, as well as endpoints to get feed content.
+ *
+ * PUT /port sets the port for the GET /feeds call, since the handler doesn't know what port it was bound to.
+ * PUT /feeds/{feed-id} adds a feed. Feed content will be the request body.
+ * GET /feeds/{feed-id} gets the content for a feed.
+ * GET /feeds gets a list of all feeds.
+ * DELETE /feeds deletes all feeds.
+ */
+public class MockFeedHandler implements HttpHandler {
+  private Map<String, String> feeds;
+  private Integer port;
+
+  @Override
+  public void init(HandlerContext handlerContext) {
+    feeds = new HashMap<>();
+  }
+
+  @Override
+  public void destroy(HandlerContext handlerContext) {
+    // no-op
+  }
+
+  // the handler itself doesn't know the host and port that it will be bound to,
+  // so adding a method to set it.
+  @PUT
+  @Path("port")
+  public void setPort(HttpRequest request, HttpResponder responder) {
+    port = Integer.parseInt(request.getContent().toString(Charsets.UTF_8));
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  // the handler itself doesn't know the host and port that it will be bound to,
+  // so adding a method to set it.
+  @PUT
+  @Path("feeds/{feed-id}")
+  public void setBasePath(HttpRequest request, HttpResponder responder,
+                          @PathParam("feed-id") String feedId) {
+    String content = request.getContent().toString(Charsets.UTF_8);
+    feeds.put(feedId, content);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  // returns an xml of all feed urls
+  @GET
+  @Path("feeds")
+  public void getFeeds(HttpRequest request, HttpResponder responder) {
+    if (port == null) {
+      responder.sendStatus(HttpResponseStatus.CONFLICT);
+      return;
+    }
+    StringBuilder response = new StringBuilder("<xml><urls>");
+    for (Map.Entry<String, String> feedEntry : feeds.entrySet()) {
+      response.append("<url>http://localhost:")
+        .append(port)
+        .append("/feeds/")
+        .append(feedEntry.getKey())
+        .append("</url>");
+    }
+    response.append("</urls></xml>");
+    responder.sendString(HttpResponseStatus.OK, response.toString());
+  }
+
+  @DELETE
+  @Path("feeds")
+  public void deleteFeeds(HttpRequest request, HttpResponder responder) {
+    feeds.clear();
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @GET
+  @Path("feeds/{feed-id}")
+  public void getFeed(HttpRequest request, HttpResponder responder,
+                      @PathParam("feed-id") String feedId) {
+    if (!feeds.containsKey(feedId)) {
+      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      return;
+    }
+    responder.sendString(HttpResponseStatus.OK, feeds.get(feedId));
+  }
+}

--- a/spark-plugins/widgets/HTTPPoller-streamingsource.json
+++ b/spark-plugins/widgets/HTTPPoller-streamingsource.json
@@ -1,0 +1,120 @@
+{
+  "metadata": {
+    "spec-version": "1.0"
+  },
+  "configuration-groups": [
+    {
+      "label": "HTTP Poller Configuration",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "URL",
+          "name": "url"
+        },
+        {
+          "widget-type": "number",
+          "label": "Interval",
+          "name": "interval",
+          "widget-attributes" : {
+            "default": "60",
+            "min": "1"
+          }
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "Request Headers",
+          "name": "requestHeaders",
+          "widget-attributes" : {
+            "showDelimiter": "false",
+            "kv-delimiter" : ":",
+            "delimiter" : "\n"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Charset",
+          "name": "charset",
+          "widget-attributes" : {
+            "values": [
+              "ISO-8859-1",
+              "US-ASCII",
+              "UTF-8",
+              "UTF-16",
+              "UTF-16BE",
+              "UTF-16LE"
+            ],
+            "default": "UTF-8"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Should Follow Redirects",
+          "name": "followRedirects",
+          "widget-attributes" : {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "true"
+          }
+        },
+        {
+          "widget-type": "number",
+          "label": "Connect Timeout",
+          "name": "connectTimeout",
+          "widget-attributes" : {
+            "default": "60000",
+            "min": "0"
+          }
+        },
+        {
+          "widget-type": "number",
+          "label": "Read Timeout",
+          "name": "readTimeout",
+          "widget-attributes" : {
+            "default": "60000",
+            "min": "0"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [
+    {
+      "widget-type": "non-editable-schema-editor",
+      "schema": {
+        "name": "etlSchemaBody",
+        "type": "record",
+        "fields": [{
+            "name": "ts",
+            "type": "long"
+        },
+        {
+            "name": "url",
+            "type": "string"
+        },
+        {
+            "name": "responseCode",
+            "type": "int"
+        },
+        {
+            "name": "headers",
+            "type": {
+              "type": "map",
+              "keys": "string",
+              "values": "string"
+            }
+        },
+        {
+            "name": "body",
+            "type": "string"
+        }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding the equivalent of the HTTP Poller source from the old
realtime framework into the new streaming framework. The source
uses the exact same config properties.
