### PR TITLE
Fixing [HYDRATOR-995] test case failure in DecisionTreeConfigTest

### DIFF
--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/SparkUtils.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/SparkUtils.java
@@ -26,6 +26,7 @@ import joptsimple.internal.Strings;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,7 +85,7 @@ final class SparkUtils {
       throw new IllegalArgumentException("Cannot specify values for both featuresToInclude and featuresToExclude. " +
                                            "Please specify fields for one.");
     }
-    Map<String, Integer> fields = new HashMap<>();
+    Map<String, Integer> fields = new LinkedHashMap<>();
 
     if (!Strings.isNullOrEmpty(featuresToInclude)) {
       Iterable<String> tokens = Splitter.on(',').trimResults().split(featuresToInclude);

--- a/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/DecisionTreeConfigTest.java
+++ b/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/DecisionTreeConfigTest.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.hydrator.plugin.spark.DecisionTreePredictor;
 import co.cask.hydrator.plugin.spark.DecisionTreeTrainer;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class DecisionTreeConfigTest {
@@ -72,8 +71,6 @@ public class DecisionTreeConfigTest {
   }
 
   @Test
-  @Ignore
-  // Ignoring this test temporarily. Enable this test once HYDRATOR-995 is fixed.
   public void testIncludeAllFeatures() throws Exception {
     DecisionTreeTrainer.DecisionTreeTrainerConfig config =
       new DecisionTreeTrainer.DecisionTreeTrainerConfig("decision-tree-regression-model", "decisionTreeRegression",


### PR DESCRIPTION
Changed map type in getFeatureList() in SparkUtils.java from HashMap() to LinkedHashMap() to maintain the insertion order of fields from schema for different reducers, and avoid inconsistent test behavior.
