### PR TITLE
Bump twill.version to 0.8.0, since 0.8.0-SNAPSHOT is no longer available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <mockftp.version>2.6</mockftp.version>
     <snappy.version>1.1.2</snappy.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <twill.version>0.8.0-SNAPSHOT</twill.version>
+    <twill.version>0.8.0</twill.version>
     <twitter4j.version>4.0.3</twitter4j.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <jython.version>2.5.2</jython.version>


### PR DESCRIPTION
Bump twill.version to 0.8.0, since 0.8.0-SNAPSHOT is no longer available.
