### PR TITLE
Kafka streaming source enhancements

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/JoinerConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/joiner/JoinerConfig.java
@@ -19,7 +19,7 @@ package co.cask.hydrator.plugin.batch.joiner;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.plugin.PluginConfig;
-import co.cask.hydrator.plugin.common.KeyValueListParser;
+import co.cask.hydrator.common.KeyValueListParser;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ProjectionTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ProjectionTransform.java
@@ -28,7 +28,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
-import co.cask.hydrator.plugin.common.KeyValueListParser;
+import co.cask.hydrator.common.KeyValueListParser;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/KeyValueListParser.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/KeyValueListParser.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.hydrator.plugin.common;
+package co.cask.hydrator.common;
 
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import com.google.common.base.Splitter;
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 public class KeyValueListParser {
   private final Pattern pairDelimiter;
   private final Pattern keyValDelimiter;
+  public static final KeyValueListParser DEFAULT = new KeyValueListParser(",", ":");
 
   /**
    * Create a parser that uses the given regexes to parse a list of key value pairs.
@@ -67,7 +68,7 @@ public class KeyValueListParser {
     private final Iterator<String> pairIter;
 
     private KeyValueIterator(String kvList) {
-      pairIter = Splitter.on(pairDelimiter).split(kvList).iterator();
+      pairIter = Splitter.on(pairDelimiter).trimResults().split(kvList).iterator();
     }
 
     @Override
@@ -78,7 +79,7 @@ public class KeyValueListParser {
     @Override
     public KeyValue<String, String> next() {
       String pair = pairIter.next();
-      Iterator<String> keyValIter = Splitter.on(keyValDelimiter).split(pair).iterator();
+      Iterator<String> keyValIter = Splitter.on(keyValDelimiter).trimResults().split(pair).iterator();
       String key = keyValIter.next();
       if (!keyValIter.hasNext()) {
         throw new IllegalArgumentException("Invalid syntax for key-value pair in list: " + pair);

--- a/solrsearch-plugins/src/main/java/co/cask/hydrator/plugin/common/SolrSearchSinkConfig.java
+++ b/solrsearch-plugins/src/main/java/co/cask/hydrator/plugin/common/SolrSearchSinkConfig.java
@@ -18,6 +18,7 @@ package co.cask.hydrator.plugin.common;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.hydrator.common.KeyValueListParser;
 import co.cask.hydrator.common.ReferencePluginConfig;
 import com.google.common.base.Strings;
 import org.apache.solr.client.solrj.SolrClient;

--- a/spark-plugins/docs/Kafka-streamingsource.md
+++ b/spark-plugins/docs/Kafka-streamingsource.md
@@ -27,13 +27,13 @@ Properties
 **defaultInitialOffset:** The default initial offset for all topic partitions.
 An offset of -2 means the smallest offset. An offset of -1 means the latest offset. Defaults to -1.
 Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read.
-If you wish to set different initial offsets for different partitions, use the initialPartitionOffsets property.
+If you wish to set different initial offsets for different partitions, use the initialPartitionOffsets property. (Macro-enabled)
 
 **initialPartitionOffsets:** The initial offset for each topic partition. If this is not specified,
 all partitions will use the same initial offset, which is determined by the defaultInitialOffset property.
 Any partitions specified in the partitions property, but not in this property will use the defaultInitialOffset.
 An offset of -2 means the smallest offset. An offset of -1 means the latest offset.
-Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read.
+Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read. (Macro-enabled)
 
 **schema:** Output schema of the source. If you would like the output records to contain a field with the
 Kafka message key, the schema must include a field of type bytes or nullable bytes, and you must set the

--- a/spark-plugins/docs/Kafka-streamingsource.md
+++ b/spark-plugins/docs/Kafka-streamingsource.md
@@ -18,9 +18,22 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**brokers:** Comma-separated list of Kafka brokers specified in host1:port1,host2:port2 form. (Macro-enabled)
+**brokers:** List of Kafka brokers specified in host1:port1,host2:port2 form. (Macro-enabled)
 
-**topics:** Comma-separated list of Kafka topics to read from. (Macro-enabled)
+**topic:** The Kafka topic to read from. (Macro-enabled)
+
+**partitions:** List of topic partitions to read from. If not specified, all partitions will be read. (Macro-enabled)
+
+**defaultInitialOffset:** The default initial offset for all topic partitions.
+An offset of -2 means the smallest offset. An offset of -1 means the latest offset. Defaults to -1.
+Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read.
+If you wish to set different initial offsets for different partitions, use the initialPartitionOffsets property.
+
+**initialPartitionOffsets:** The initial offset for each topic partition. If this is not specified,
+all partitions will use the same initial offset, which is determined by the defaultInitialOffset property.
+Any partitions specified in the partitions property, but not in this property will use the defaultInitialOffset.
+An offset of -2 means the smallest offset. An offset of -1 means the latest offset.
+Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read.
 
 **schema:** Output schema of the source. If you would like the output records to contain a field with the
 Kafka message key, the schema must include a field of type bytes or nullable bytes, and you must set the
@@ -35,11 +48,19 @@ If no format is given, Kafka message payloads will be treated as bytes.
 
 **timeField:** Optional name of the field containing the read time of the batch.
 If this is not set, no time field will be added to output records.
-If set, this field must be present in the schema property.
+If set, this field must be present in the schema property and must be a long.
 
 **keyField:** Optional name of the field containing the message key.
 If this is not set, no key field will be added to output records.
-If set, this field must be present in the schema property.
+If set, this field must be present in the schema property and must be bytes.
+
+**partitionField:** Optional name of the field containing the partition the message was read from.
+If this is not set, no partition field will be added to output records.
+If set, this field must be present in the schema property and must be an int.
+
+**offsetField:** Optional name of the field containing the partition offset the message was read from.
+If this is not set, no offset field will be added to output records.
+If set, this field must be present in the schema property and must be a long.
 
 
 Example

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -177,7 +177,14 @@
         <configuration>
           <instructions>
             <_exportcontents>
-              co.cask.hydrator.plugin.spark.*;org.apache.spark.streaming.kafka.*;org.apache.spark.streaming.scheduler.*;kafka.serializer.*;org.apache.spark.streaming.twitter.*;twitter4j.*;;co.cask.hydrator.common.http
+              co.cask.hydrator.plugin.spark.*;
+              org.apache.spark.streaming.kafka.*;
+              kafka.common;
+              org.apache.spark.streaming.scheduler.*;
+              kafka.serializer.*;
+              org.apache.spark.streaming.twitter.*;
+              twitter4j.*;
+              co.cask.hydrator.common.http
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaConfig.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaConfig.java
@@ -20,12 +20,15 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.format.RecordFormats;
+import co.cask.hydrator.common.KeyValueListParser;
 import co.cask.hydrator.common.ReferencePluginConfig;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import kafka.common.TopicAndPartition;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -33,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -44,13 +48,35 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
 
   private static final long serialVersionUID = 8069169417140954175L;
 
-  @Description("Comma-separated list of Kafka brokers specified in host1:port1,host2:port2 form.")
+  @Description("List of Kafka brokers specified in host1:port1,host2:port2 form. For example, " +
+    "host1.example.com:9092,host2.example.com:9092.")
   @Macro
   private String brokers;
 
-  @Description("Comma-separated list of Kafka topics to read from.")
+  @Description("Kafka topic to read from.")
   @Macro
-  private String topics;
+  private String topic;
+
+  @Description("The topic partitions to read from. If not specified, all partitions will be read.")
+  @Nullable
+  @Macro
+  private String partitions;
+
+  @Description("The initial offset for each topic partition. If this is not specified, " +
+    "all partitions will have the same initial offset, which is determined by the defaultInitialOffset property. " +
+    "An offset of -2 means the smallest offset. An offset of -1 means the latest offset. " +
+    "Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read.")
+  @Nullable
+  @Macro
+  private String initialPartitionOffsets;
+
+  @Description("The default initial offset for all topic partitions. " +
+    "An offset of -2 means the smallest offset. An offset of -1 means the latest offset. Defaults to -1. " +
+    "Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will be read. " +
+    "If you wish to set different initial offsets for different partitions, use the initialPartitionOffsets property.")
+  @Nullable
+  @Macro
+  private Long defaultInitialOffset;
 
   @Description("Output schema of the source, including the timeField and keyField. " +
     "The fields excluding the timeField and keyField are used in conjunction with the format " +
@@ -65,40 +91,59 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
 
   @Description("Optional name of the field containing the read time of the batch. " +
     "If this is not set, no time field will be added to output records. " +
-    "If set, this field must be present in the schema property.")
+    "If set, this field must be present in the schema property and must be a long.")
   @Nullable
   private String timeField;
 
   @Description("Optional name of the field containing the message key. " +
     "If this is not set, no key field will be added to output records. " +
-    "If set, this field must be present in the schema property.")
+    "If set, this field must be present in the schema property and must be bytes.")
   @Nullable
   private String keyField;
 
+  @Description("Optional name of the field containing the kafka partition that was read from. " +
+    "If this is not set, no partition field will be added to output records. " +
+    "If set, this field must be present in the schema property and must be an integer.")
+  @Nullable
+  private String partitionField;
+
+  @Description("Optional name of the field containing the kafka offset that the message was read from. " +
+    "If this is not set, no offset field will be added to output records. " +
+    "If set, this field must be present in the schema property and must be a long.")
+  @Nullable
+  private String offsetField;
+
   public KafkaConfig() {
     super("");
-    timeField = null;
-    keyField = null;
+    defaultInitialOffset = -1L;
   }
 
   @VisibleForTesting
-  public KafkaConfig(String referenceName, String brokers, String topics, String schema, String format,
-                     String timeField, String keyField) {
+  public KafkaConfig(String referenceName, String brokers, String topic, String schema, String format,
+                     String timeField, String keyField, String partitionField, String offsetField) {
+    this(referenceName, brokers, topic, null, null, null, schema, format,
+         timeField, keyField, partitionField, offsetField);
+  }
+
+  public KafkaConfig(String referenceName, String brokers, String topic, String partitions,
+                     String initialPartitionOffsets, Long defaultInitialOffset, String schema, String format,
+                     String timeField, String keyField, String partitionField, String offsetField) {
     super(referenceName);
     this.brokers = brokers;
-    this.topics = topics;
+    this.topic = topic;
+    this.partitions = partitions;
+    this.initialPartitionOffsets = initialPartitionOffsets;
+    this.defaultInitialOffset = defaultInitialOffset;
     this.schema = schema;
     this.format = format;
     this.timeField = timeField;
     this.keyField = keyField;
+    this.partitionField = partitionField;
+    this.offsetField = offsetField;
   }
 
-  public Set<String> getTopics() {
-    Set<String> topicSet = new HashSet<>();
-    for (String topic : Splitter.on(',').trimResults().split(topics)) {
-      topicSet.add(topic);
-    }
-    return topicSet;
+  public String getTopic() {
+    return topic;
   }
 
   public String getBrokers() {
@@ -116,6 +161,16 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
   }
 
   @Nullable
+  public String getPartitionField() {
+    return partitionField;
+  }
+
+  @Nullable
+  public String getOffsetField() {
+    return offsetField;
+  }
+
+  @Nullable
   public String getFormat() {
     return Strings.isNullOrEmpty(format) ? null : format;
   }
@@ -128,31 +183,37 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
     }
   }
 
-  // gets the message schema from the schema field. If the time field and key field are in the configured
+  // gets the message schema from the schema field. If the time, key, partition, or offset fields are in the configured
   // schema, they will be removed.
   public Schema getMessageSchema() {
     Schema schema = getSchema();
     List<Schema.Field> messageFields = new ArrayList<>();
     boolean timeFieldExists = false;
     boolean keyFieldExists = false;
+    boolean partitionFieldExists = false;
+    boolean offsetFieldExists;
+
     for (Schema.Field field : schema.getFields()) {
       String fieldName = field.getName();
       Schema fieldSchema = field.getSchema();
+      Schema.Type fieldType = fieldSchema.isNullable() ? fieldSchema.getNonNullable().getType() : fieldSchema.getType();
       // if the field is not the time field and not the key field, it is a message field.
       if (fieldName.equals(timeField)) {
-        Schema.Type timeType = fieldSchema.isNullable() ?
-          fieldSchema.getNonNullable().getType() : fieldSchema.getType();
-        if (timeType != Schema.Type.LONG) {
+        if (fieldType != Schema.Type.LONG) {
           throw new IllegalArgumentException("The time field must be of type long or nullable long.");
         }
         timeFieldExists = true;
       } else if (fieldName.equals(keyField)) {
-        Schema.Type timeType = fieldSchema.isNullable() ?
-          fieldSchema.getNonNullable().getType() : fieldSchema.getType();
-        if (timeType != Schema.Type.BYTES) {
+        if (fieldType != Schema.Type.BYTES) {
           throw new IllegalArgumentException("The key field must be of type bytes or nullable bytes.");
         }
         keyFieldExists = true;
+      } else if (fieldName.equals(partitionField)) {
+        if (fieldType != Schema.Type.INT) {
+          throw new IllegalArgumentException("The partition field must be of type int.");
+        }
+        partitionFieldExists = true;
+      } else if (fieldName.equals(offsetField)) {
       } else {
         messageFields.add(field);
       }
@@ -171,7 +232,92 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
     return Schema.recordOf("kafka.message", messageFields);
   }
 
+  /**
+   * Get the initial partition offsets for the specified partitions. If an initial offset is specified in the
+   * initialPartitionOffsets property, that value will be used. Otherwise, the defaultInitialOffset will be used.
+   *
+   * @param partitionsToRead the partitions to read
+   * @return initial partition offsets.
+   */
+  public Map<TopicAndPartition, Long> getInitialPartitionOffsets(Set<Integer> partitionsToRead) {
+    Map<TopicAndPartition, Long> partitionOffsets = new HashMap<>();
+
+    // set default initial partitions
+    for (Integer partition : partitionsToRead) {
+      partitionOffsets.put(new TopicAndPartition(topic, partition), defaultInitialOffset);
+    }
+
+    // if initial partition offsets are specified, overwrite the defaults.
+    if (initialPartitionOffsets != null) {
+      for (KeyValue<String, String> partitionAndOffset : KeyValueListParser.DEFAULT.parse(initialPartitionOffsets)) {
+        String partitionStr = partitionAndOffset.getKey();
+        String offsetStr = partitionAndOffset.getValue();
+        int partition;
+        try {
+          partition = Integer.parseInt(partitionStr);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(String.format(
+            "Invalid partition '%s' in initialPartitionOffsets.", partitionStr));
+        }
+        long offset;
+        try {
+          offset = Long.parseLong(offsetStr);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(String.format(
+            "Invalid offset '%s' in initialPartitionOffsets for partition %d.", partitionStr, partition));
+        }
+        partitionOffsets.put(new TopicAndPartition(topic, partition), offset);
+      }
+    }
+
+    return partitionOffsets;
+  }
+
+  /**
+   * @return broker host to broker port mapping.
+   */
+  public Map<String, Integer> getBrokerMap() {
+    Map<String, Integer> brokerMap = new HashMap<>();
+    for (KeyValue<String, String> hostAndPort : KeyValueListParser.DEFAULT.parse(brokers)) {
+      String host = hostAndPort.getKey();
+      String portStr = hostAndPort.getValue();
+      try {
+        brokerMap.put(host, Integer.parseInt(portStr));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(String.format(
+          "Invalid port '%s' for host '%s'.", portStr, host));
+      }
+    }
+    if (brokerMap.isEmpty()) {
+      throw new IllegalArgumentException("Must specify kafka brokers.");
+    }
+    return brokerMap;
+  }
+
+  /**
+   * @return set of partitions to read from. Returns an empty list if no partitions were specified.
+   */
+  public Set<Integer> getPartitions() {
+    Set<Integer> partitionSet = new HashSet<>();
+    if (partitions == null) {
+      return partitionSet;
+    }
+    for (String partition : Splitter.on(',').trimResults().split(partitions)) {
+      try {
+        partitionSet.add(Integer.parseInt(partition));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+          String.format("Invalid partition '%s'. Partitions must be integers.", partition));
+      }
+    }
+    return partitionSet;
+  }
+
   public void validate() {
+    getBrokerMap();
+    getPartitions();
+    getInitialPartitionOffsets(getPartitions());
+
     if (!Strings.isNullOrEmpty(timeField) && !Strings.isNullOrEmpty(keyField) && timeField.equals(keyField)) {
       throw new IllegalArgumentException(String.format(
         "The timeField and keyField cannot both have the same name (%s).", timeField));

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaConfig.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaConfig.java
@@ -162,12 +162,12 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
 
   @Nullable
   public String getPartitionField() {
-    return partitionField;
+    return Strings.isNullOrEmpty(partitionField) ? null : partitionField;
   }
 
   @Nullable
   public String getOffsetField() {
-    return offsetField;
+    return Strings.isNullOrEmpty(offsetField) ? null : offsetField;
   }
 
   @Nullable
@@ -191,7 +191,7 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
     boolean timeFieldExists = false;
     boolean keyFieldExists = false;
     boolean partitionFieldExists = false;
-    boolean offsetFieldExists;
+    boolean offsetFieldExists = false;
 
     for (Schema.Field field : schema.getFields()) {
       String fieldName = field.getName();
@@ -214,6 +214,10 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
         }
         partitionFieldExists = true;
       } else if (fieldName.equals(offsetField)) {
+        if (fieldType != Schema.Type.LONG) {
+          throw new IllegalArgumentException("The offset field must be of type long.");
+        }
+        offsetFieldExists = true;
       } else {
         messageFields.add(field);
       }
@@ -224,10 +228,20 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
     }
 
     if (getTimeField() != null && !timeFieldExists) {
-      throw new IllegalArgumentException(String.format("timeField '%s' does not exist in the schema.", timeField));
+      throw new IllegalArgumentException(String.format(
+        "timeField '%s' does not exist in the schema. Please add it to the schema.", timeField));
     }
     if (getKeyField() != null && !keyFieldExists) {
-      throw new IllegalArgumentException(String.format("keyField '%s' does not exist in the schema.", keyField));
+      throw new IllegalArgumentException(String.format(
+        "keyField '%s' does not exist in the schema. Please add it to the schema.", keyField));
+    }
+    if (getPartitionField() != null && !partitionFieldExists) {
+      throw new IllegalArgumentException(String.format(
+        "partitionField '%s' does not exist in the schema. Please add it to the schema.", partitionField));
+    }
+    if (getOffsetField() != null && !offsetFieldExists) {
+      throw new IllegalArgumentException(String.format(
+        "offsetField '%s' does not exist in the schema. Please add it to the schema.", offsetFieldExists));
     }
     return Schema.recordOf("kafka.message", messageFields);
   }

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaStreamingSource.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaStreamingSource.java
@@ -28,20 +28,31 @@ import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.format.RecordFormats;
+import kafka.api.OffsetRequest;
+import kafka.api.PartitionOffsetRequestInfo;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.OffsetResponse;
+import kafka.javaapi.PartitionMetadata;
+import kafka.javaapi.TopicMetadata;
+import kafka.javaapi.TopicMetadataRequest;
+import kafka.javaapi.TopicMetadataResponse;
+import kafka.javaapi.consumer.SimpleConsumer;
+import kafka.message.MessageAndMetadata;
 import kafka.serializer.DefaultDecoder;
-import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.streaming.Time;
 import org.apache.spark.streaming.api.java.JavaDStream;
-import org.apache.spark.streaming.api.java.JavaPairInputDStream;
 import org.apache.spark.streaming.kafka.KafkaUtils;
-import scala.Tuple2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  */
@@ -49,6 +60,7 @@ import java.util.Map;
 @Name("Kafka")
 @Description("Kafka streaming source.")
 public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaStreamingSource.class);
   private final KafkaConfig conf;
 
   public KafkaStreamingSource(KafkaConfig conf) {
@@ -66,21 +78,80 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
   @Override
   public JavaDStream<StructuredRecord> getStream(StreamingContext context) throws Exception {
     registerUsage(context);
+
     Map<String, String> kafkaParams = new HashMap<>();
     kafkaParams.put("metadata.broker.list", conf.getBrokers());
 
-    JavaPairInputDStream<byte[], byte[]> kafkaStream = KafkaUtils.createDirectStream(
-      context.getSparkStreamingContext(), byte[].class, byte[].class, DefaultDecoder.class, DefaultDecoder.class,
-      kafkaParams, conf.getTopics());
+    Map.Entry<String, Integer> firstBroker = conf.getBrokerMap().entrySet().iterator().next();
+    String brokerHost = firstBroker.getKey();
+    Integer brokerPort = firstBroker.getValue();
+    SimpleConsumer consumer = new SimpleConsumer(brokerHost, brokerPort, 20 * 1000, 128 * 1024, "partitionLookup");
 
-    return kafkaStream.transform(new RecordTransform(conf));
+    try {
+      Map<TopicAndPartition, Long> offsets = conf.getInitialPartitionOffsets(getPartitions(consumer));
+      // KafkaUtils doesn't understand -1 and -2 as smallest offset and latest offset.
+      // so we have to replace them with the actual smallest and latest
+      Map<TopicAndPartition, Long> updates = new HashMap<>();
+      for (Map.Entry<TopicAndPartition, Long> entry : offsets.entrySet()) {
+        TopicAndPartition topicAndPartition = entry.getKey();
+        Long offset = entry.getValue();
+        if (offset == OffsetRequest.EarliestTime() || offset == OffsetRequest.LatestTime()) {
+          updates.put(topicAndPartition, getOffset(consumer, topicAndPartition, offset));
+        }
+      }
+      offsets.putAll(updates);
+      LOG.info("Using initial offsets {}", offsets);
+
+      return KafkaUtils.createDirectStream(
+        context.getSparkStreamingContext(), byte[].class, byte[].class, DefaultDecoder.class, DefaultDecoder.class,
+        MessageAndMetadata.class, kafkaParams, offsets,
+        new Function<MessageAndMetadata<byte[], byte[]>, MessageAndMetadata>() {
+          @Override
+          public MessageAndMetadata call(MessageAndMetadata<byte[], byte[]> in) throws Exception {
+            return in;
+          }
+        }).transform(new RecordTransform(conf));
+    } finally {
+      consumer.close();
+    }
+  }
+
+  private long getOffset(SimpleConsumer consumer, TopicAndPartition topicAndPartition, long before) {
+    Map<TopicAndPartition, PartitionOffsetRequestInfo> requestInfo = new HashMap<>();
+    requestInfo.put(topicAndPartition, new PartitionOffsetRequestInfo(before, 1));
+    kafka.javaapi.OffsetRequest offsetRequest =
+      new kafka.javaapi.OffsetRequest(requestInfo, OffsetRequest.CurrentVersion(), "offsetLookup");
+    OffsetResponse response = consumer.getOffsetsBefore(offsetRequest);
+    if (response.hasError()) {
+      throw new RuntimeException(String.format(
+        "Unable to get offset information for partition %d. Error Code: %d",
+        topicAndPartition.partition(), response.errorCode(topicAndPartition.topic(), topicAndPartition.partition())));
+    }
+    return response.offsets(topicAndPartition.topic(), topicAndPartition.partition())[0];
+  }
+
+  private Set<Integer> getPartitions(SimpleConsumer consumer) {
+    Set<Integer> partitions = conf.getPartitions();
+    if (!partitions.isEmpty()) {
+      return partitions;
+    }
+
+    TopicMetadataRequest topicMetadataRequest = new TopicMetadataRequest(Collections.singletonList(conf.getTopic()));
+    TopicMetadataResponse response = consumer.send(topicMetadataRequest);
+    for (TopicMetadata topicMetadata : response.topicsMetadata()) {
+      for (PartitionMetadata partitionMetadata : topicMetadata.partitionsMetadata()) {
+        partitions.add(partitionMetadata.partitionId());
+      }
+    }
+
+    return partitions;
   }
 
   /**
    * Applies the format function to each rdd.
    */
   private static class RecordTransform
-    implements Function2<JavaPairRDD<byte[], byte[]>, Time, JavaRDD<StructuredRecord>> {
+    implements Function2<JavaRDD<MessageAndMetadata>, Time, JavaRDD<StructuredRecord>> {
 
     private final KafkaConfig conf;
 
@@ -89,37 +160,41 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
     }
 
     @Override
-    public JavaRDD<StructuredRecord> call(JavaPairRDD<byte[], byte[]> input, Time batchTime) throws Exception {
-      Function<Tuple2<byte[], byte[]>, StructuredRecord> recordFunction = conf.getFormat() == null ?
+    public JavaRDD<StructuredRecord> call(JavaRDD<MessageAndMetadata> input, Time batchTime) throws Exception {
+      Function<MessageAndMetadata, StructuredRecord> recordFunction = conf.getFormat() == null ?
         new BytesFunction(batchTime.milliseconds(), conf) : new FormatFunction(batchTime.milliseconds(), conf);
       return input.map(recordFunction);
     }
   }
 
   /**
-   * Transforms kafka key and message into a structured record when message format is not given.
+   * Common logic for transforming kafka key, message, partition, and offset into a structured record.
    * Everything here should be serializable, as Spark Streaming will serialize all functions.
    */
-  private static class BytesFunction implements Function<Tuple2<byte[], byte[]>, StructuredRecord> {
+  private abstract static class BaseFunction implements Function<MessageAndMetadata, StructuredRecord> {
     private final long ts;
-    private final KafkaConfig conf;
+    protected final KafkaConfig conf;
     private transient String messageField;
     private transient String timeField;
     private transient String keyField;
+    private transient String partitionField;
+    private transient String offsetField;
     private transient Schema schema;
 
-    BytesFunction(long ts, KafkaConfig conf) {
+    BaseFunction(long ts, KafkaConfig conf) {
       this.ts = ts;
       this.conf = conf;
     }
 
     @Override
-    public StructuredRecord call(Tuple2<byte[], byte[]> in) throws Exception {
+    public StructuredRecord call(MessageAndMetadata in) throws Exception {
       // first time this was called, initialize schema and time, key, and message fields.
       if (schema == null) {
         schema = conf.getSchema();
         timeField = conf.getTimeField();
         keyField = conf.getKeyField();
+        partitionField = conf.getPartitionField();
+        offsetField = conf.getOffsetField();
         for (Schema.Field field : schema.getFields()) {
           String name = field.getName();
           if (!name.equals(timeField) && !name.equals(keyField)) {
@@ -134,10 +209,35 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
         builder.set(timeField, ts);
       }
       if (keyField != null) {
-        builder.set(keyField, in._1());
+        builder.set(keyField, in.key());
       }
-      builder.set(messageField, in._2());
+      if (partitionField != null) {
+        builder.set(partitionField, in.partition());
+      }
+      if (offsetField != null) {
+        builder.set(offsetField, in.offset());
+      }
+      addMessage(builder, messageField, (byte[]) in.message());
       return builder.build();
+    }
+
+    protected abstract void addMessage(StructuredRecord.Builder builder, String messageField,
+                                       byte[] message) throws Exception;
+  }
+
+  /**
+   * Transforms kafka key and message into a structured record when message format is not given.
+   * Everything here should be serializable, as Spark Streaming will serialize all functions.
+   */
+  private static class BytesFunction extends BaseFunction {
+
+    BytesFunction(long ts, KafkaConfig conf) {
+      super(ts, conf);
+    }
+
+    @Override
+    protected void addMessage(StructuredRecord.Builder builder, String messageField, byte[] message) {
+      builder.set(messageField, message);
     }
   }
 
@@ -145,45 +245,28 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
    * Transforms kafka key and message into a structured record when message format and schema are given.
    * Everything here should be serializable, as Spark Streaming will serialize all functions.
    */
-  private static class FormatFunction implements Function<Tuple2<byte[], byte[]>, StructuredRecord> {
-    private final long ts;
-    private final KafkaConfig conf;
-    private transient Schema outputSchema;
-    private transient String timeField;
-    private transient String keyField;
+  private static class FormatFunction extends BaseFunction {
     private transient RecordFormat<StreamEvent, StructuredRecord> recordFormat;
 
     FormatFunction(long ts, KafkaConfig conf) {
-      this.ts = ts;
-      this.conf = conf;
+      super(ts, conf);
     }
 
     @Override
-    public StructuredRecord call(Tuple2<byte[], byte[]> in) throws Exception {
-      // first time this was called, initialize schema and time, key, and message fields.
+    protected void addMessage(StructuredRecord.Builder builder, String messageField, byte[] message) throws Exception {
+      // first time this was called, initialize record format
       if (recordFormat == null) {
-        outputSchema = conf.getSchema();
-        timeField = conf.getTimeField();
-        keyField = conf.getKeyField();
         Schema messageSchema = conf.getMessageSchema();
         FormatSpecification spec =
           new FormatSpecification(conf.getFormat(), messageSchema, new HashMap<String, String>());
         recordFormat = RecordFormats.createInitializedFormat(spec);
       }
 
-      StructuredRecord.Builder builder = StructuredRecord.builder(outputSchema);
-      if (timeField != null) {
-        builder.set(timeField, ts);
-      }
-      if (keyField != null) {
-        builder.set(keyField, in._1());
-      }
-      StructuredRecord messageRecord = recordFormat.read(new StreamEvent(ByteBuffer.wrap(in._2())));
-      for (Schema.Field messageField : messageRecord.getSchema().getFields()) {
-        String fieldName = messageField.getName();
+      StructuredRecord messageRecord = recordFormat.read(new StreamEvent(ByteBuffer.wrap(message)));
+      for (Schema.Field field : messageRecord.getSchema().getFields()) {
+        String fieldName = field.getName();
         builder.set(fieldName, messageRecord.get(fieldName));
       }
-      return builder.build();
     }
   }
 

--- a/spark-plugins/widgets/Kafka-streamingsource.json
+++ b/spark-plugins/widgets/Kafka-streamingsource.json
@@ -20,11 +20,31 @@
           }
         },
         {
+          "widget-type": "textbox",
+          "label": "Kafka Topic",
+          "name": "topic"
+        },
+        {
           "widget-type": "csv",
-          "label": "Kafka Topics",
-          "name": "topics",
+          "label": "Topic Partitions",
+          "name": "partitions",
           "widget-attributes": {
             "delimiter": ","
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Default Initial Offset",
+          "name": "defaultInitialOffset"
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "Initial Partition Offsets",
+          "name": "initialPartitionOffsets",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "key-placeholder": "Partition",
+            "value-placeholder": "Offset"
           }
         },
         {
@@ -36,6 +56,16 @@
           "widget-type": "textbox",
           "label": "Key Field",
           "name": "keyField"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Partition Field",
+          "name": "partitionField"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Offset Field",
+          "name": "offsetField"
         }
       ]
     },


### PR DESCRIPTION
Added properties to support specifying the partitions to read
from, as well as initial offsets for each partition. Also changed
it to only read from a single topic to simplify configuration.
In addition, added optional fields to allow including the partition
and offset in the output records.
