### PR TITLE
Fixing generic fields visible on UI - Decision Tree Regression[HYDRATOR-1060]

### DIFF
--- a/spark-plugins/docs/DecisionTreePredictor-sparkcompute.md
+++ b/spark-plugins/docs/DecisionTreePredictor-sparkcompute.md
@@ -16,13 +16,14 @@ Properties
 
 **path:** Path of the FileSet to load the model from.
 
-**featuresToInclude:** A comma-separated sequence of fields to be used for prediction. If both featuresToInclude and
-featuresToExclude are empty, all fields will be used for prediction. Features to be used, must be from one of the
-following types: int, long, float or double. Both *featuresToInclude* and *featuresToExclude* fields cannot be specified.
+**featureFieldsToInclude:** A comma-separated sequence of fields to be used for prediction. If both
+featureFieldsToInclude and featureFieldsToExclude are empty, all fields will be used for prediction. Features to be
+used, must be from one of the following types: int, long, float or double. Both *featureFieldsToInclude* and
+*featureFieldsToExclude* fields cannot be specified.
 
-**featuresToExclude:** A comma-separated sequence of fields to be excluded for prediction. If both featuresToInclude and
-featuresToExclude are empty, all fields will be used for prediction. Both *featuresToInclude* and *featuresToExclude*
-fields cannot be specified.
+**featureFieldsToExclude:** A comma-separated sequence of fields to be excluded for prediction. If both
+featureFieldsToInclude and featureFieldsToExclude are empty, all fields will be used for prediction. Both
+*featureFieldsToInclude* and *featureFieldsToExclude* fields cannot be specified.
 
 **predictionField:** The field on which to set the prediction. It will be of type double.
 

--- a/spark-plugins/docs/DecisionTreeTrainer-sparksink.md
+++ b/spark-plugins/docs/DecisionTreeTrainer-sparksink.md
@@ -15,14 +15,14 @@ Properties
 
 **path:** Path of the FileSet to save the model to.
 
-**featuresToInclude:** A comma-separated sequence of fields to use for training. If both featuresToInclude and 
-featuresToExclude are empty, all fields except the label will be used for training. Features to be used, must be from 
-one of the following types: int, long, float or double. Both *featuresToInclude* and *featuresToExclude* fields cannot 
-be specified.
+**featureFieldsToInclude:** A comma-separated sequence of fields to use for training. If both featureFieldsToInclude and
+featureFieldsToExclude are empty, all fields except the label will be used for training. Features to be used, must be 
+from one of the following types: int, long, float or double. Both *featureFieldsToInclude* and *featureFieldsToExclude* 
+fields cannot be specified.
 
-**featuresToExclude:** A comma-separated sequence of fields to be excluded when training. If both featuresToInclude and 
-featuresToExclude are empty, all fields except the label will be used for training. Both *featuresToInclude* and 
-*featuresToExclude* fields cannot be specified.
+**featureFieldsToExclude:** A comma-separated sequence of fields to be excluded when training. If both 
+featureFieldsToInclude and featureFieldsToExclude are empty, all fields except the label will be used for training. Both
+ *featureFieldsToInclude* and *featureFieldsToExclude* fields cannot be specified.
 
 **cardinalityMapping:** Mapping of the feature to the cardinality of that feature; required for categorical features.
 
@@ -31,8 +31,8 @@ featuresToExclude are empty, all fields except the label will be used for traini
 **maxDepth:** Maximum depth of the tree.
 For example, depth 0 means 1 leaf node; depth 1 means 1 internal node + 2 leaf nodes. Default is 10.
 
-**maxBins:** Maximum number of bins used for splitting when discretizing continuous featuresToInclude. DecisionTree
-requires maxBins to be at least as large as the number of values in each categorical feature. Default is 100.
+**maxBins:** Maximum number of bins used for splitting when discretizing continuous features. DecisionTree requires 
+maxBins to be at least as large as the number of values in each categorical feature. Default is 100.
 
 
 Example

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/DecisionTreeTrainer.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/DecisionTreeTrainer.java
@@ -72,7 +72,7 @@ public class DecisionTreeTrainer extends SparkMLTrainer {
     private Integer maxDepth;
 
     @Nullable
-    @Description("Maximum number of bins used for splitting when discretizing continuous featuresToInclude. " +
+    @Description("Maximum number of bins used for splitting when discretizing continuous features. " +
       "DecisionTree requires maxBins to be at least as large as the number of values in each categorical feature. " +
       "Default is 100.")
     private Integer maxBins;

--- a/spark-plugins/widgets/DecisionTreePredictor-sparkcompute.json
+++ b/spark-plugins/widgets/DecisionTreePredictor-sparkcompute.json
@@ -19,7 +19,7 @@
         {
           "widget-type": "csv",
           "label": "Features to Include for Prediction",
-          "name": "featuresToInclude",
+          "name": "featureFieldsToInclude",
           "widget-attributes": {
             "delimiter": ",",
             "value-placeholder": "Field Name"
@@ -28,7 +28,7 @@
         {
           "widget-type": "csv",
           "label": "Features to Exclude while Prediction",
-          "name": "featuresToExclude",
+          "name": "featureFieldsToExclude",
           "widget-attributes": {
             "delimiter": ",",
             "value-placeholder": "Field Name"

--- a/spark-plugins/widgets/DecisionTreeTrainer-sparksink.json
+++ b/spark-plugins/widgets/DecisionTreeTrainer-sparksink.json
@@ -19,7 +19,7 @@
         {
           "widget-type": "csv",
           "label": "Features to Include for training",
-          "name": "featuresToInclude",
+          "name": "featureFieldsToInclude",
           "widget-attributes": {
             "delimiter": ",",
             "value-placeholder": "Field Name"
@@ -28,7 +28,7 @@
         {
           "widget-type": "csv",
           "label": "Features to Exclude while training",
-          "name": "featuresToExclude",
+          "name": "featureFieldsToExclude",
           "widget-attributes": {
             "delimiter": ",",
             "value-placeholder": "Field Name"


### PR DESCRIPTION
Replacing all occurrences of `featuresToInclude` and `featuresToExclude` with`featureFieldsToInclude` and `featureFieldsToExclude` (field names as present in the common spark ml base class). 
Changed the field values in widget jsons, docs and in description in the classes.
