### PR TITLE
HYDRATOR-1061 Do not exceed Travis resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ language: java
 jdk:
   - oraclejdk7
 
-# memory values same as surefire plugin config
-before_install: echo "MAVEN_OPTS='-Xmx5000m -XX:MaxPermSize=1024m'" > ~/.mavenrc
+# Do not exceed Travis memory capacity
+before_install: echo "MAVEN_OPTS='-Xmx3g -XX:MaxPermSize=256m'" > ~/.mavenrc
 
 script: mvn -U clean test
 

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
         <configuration>
-          <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=1024m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -Djava.net.preferIPv4Stack=true</argLine>
+          <argLine>-Xmx3g -Djava.awt.headless=true -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true</argLine>
           <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
           <reuseForks>false</reuseForks>
           <reportFormat>plain</reportFormat>


### PR DESCRIPTION
Travis container infrastructure has 4G of memory. We're allocating 6G. Also, we're exiting on OOM using `kill -9` on the process, causing builds to fail in a way that hides the actual problem.

Fixes HYDRATOR-1061
