### PR TITLE
Fixing XMLRecordReader to avoid divide by zero exception

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLRecordReader.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLRecordReader.java
@@ -77,7 +77,7 @@ public class XMLRecordReader extends RecordReader<LongWritable, Map<String, Stri
     XMLInputFactory factory = XMLInputFactory.newInstance();
     FSDataInputStream fdDataInputStream = fs.open(file);
     inputStream = new TrackingInputStream(fdDataInputStream);
-    availableBytes = inputStream.available();
+    availableBytes = split.getLength();
     try {
       reader = factory.createXMLStreamReader(inputStream);
     } catch (XMLStreamException exception) {


### PR DESCRIPTION
XMLRecordReader was using `InputStream.available()` method which does not guarantee to return file size. The effect was causing `InputStream.available()` to return zero for MapR 4.1. This PR should fix this issue.