### PR TITLE
HYDRATOR 471 - conditions clause is excluded from the query in get schema request in database source

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -141,12 +141,13 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
   }
 
   private static String removeConditionsClause(String importQuerySring) {
-    if (importQuerySring.toUpperCase().contains("WHERE $CONDITIONS AND")) {
-      importQuerySring = importQuerySring.toUpperCase().replace(" $CONDITIONS AND", "");
-    } else if (importQuerySring.toUpperCase().contains("WHERE $CONDITIONS")) {
-      importQuerySring = importQuerySring.toUpperCase().replace(" WHERE $CONDITIONS", "");
-    } else if (importQuerySring.toUpperCase().contains("AND $CONDITIONS")) {
-      importQuerySring = importQuerySring.toUpperCase().replace(" AND $CONDITIONS", "");
+    importQuerySring = importQuerySring.replaceAll("\\s{2,}", " ").toUpperCase();
+    if (importQuerySring.contains("WHERE $CONDITIONS AND")) {
+      importQuerySring = importQuerySring.replace("$CONDITIONS AND", "");
+    } else if (importQuerySring.contains("WHERE $CONDITIONS")) {
+      importQuerySring = importQuerySring.replace("WHERE $CONDITIONS", "");
+    } else if (importQuerySring.contains("AND $CONDITIONS")) {
+      importQuerySring = importQuerySring.replace("AND $CONDITIONS", "");
     }
     return importQuerySring;
   }


### PR DESCRIPTION
Tested from UI. No ITN for DbSource.
If use enters $CONDITIONS in the query,though it would be visible in the UI,internally back end logic would exclude the $CONDITIONS clause and execute the manipulated query.