### PR TITLE
[HYDRATOR-282] - Changing option names to "Tab Delimited" and "Pipe Delimited"

### DIFF
--- a/transform-plugins/docs/CSVParser-transform.md
+++ b/transform-plugins/docs/CSVParser-transform.md
@@ -5,7 +5,8 @@ Description
 -----------
 Parses an input field as a CSV Record into a Structured Record. Supports multi-line CSV Record parsing
 into multiple Structured Records. Different formats of CSV Record can be parsed using this plugin.
-Supports these CSV Record types: ``DEFAULT``, ``EXCEL``, ``MYSQL``, ``RFC4180``, ``TDF`` and ``Custom``.
+Supports these CSV Record types: ``DEFAULT``, ``EXCEL``, ``MYSQL``, ``RFC4180``, ``Tab Delimited``, ``Pipe Delimited``
+and ``Custom``.
 
 
 Configuration

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/CSVParser.java
@@ -47,8 +47,8 @@ import javax.annotation.Nullable;
  *   <li>EXCEL</li>
  *   <li>RFC4180</li>
  *   <li>MYSQL</li>
- *   <li>TDF and</li>
- *   <li>PDL</li>
+ *   <li>Tab Delimited and</li>
+ *   <li>Pipe Delimited</li>
  *   <li>Custom</li>
  * </ul>
  * </p>
@@ -160,11 +160,11 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
         csvFormat = CSVFormat.RFC4180;
         break;
 
-      case "tdf":
+      case "tab delimited":
         csvFormat = CSVFormat.TDF;
         break;
 
-      case "pdl":
+      case "pipe delimited":
         csvFormat = PDL;
         break;
 
@@ -176,7 +176,8 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
 
       default:
         throw new IllegalArgumentException("Format {} specified is not one of the allowed format. Allowed formats are" +
-                                             "DEFAULT, EXCEL, MYSQL, RFC4180, PDL and TDF or Custom");
+                                             "DEFAULT, EXCEL, MYSQL, RFC4180, Pipe Delimited and Tab Delimited or " +
+                                             "Custom");
     }
 
     try {
@@ -253,8 +254,8 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
   public static class Config extends PluginConfig {
 
     @Name("format")
-    @Description("Specify one of the predefined formats. DEFAULT, EXCEL, MYSQL, RFC4180, PDL, TDF and Custom " +
-      "are supported formats.")
+    @Description("Specify one of the predefined formats. DEFAULT, EXCEL, MYSQL, RFC4180, Pipe Delimited, Tab " +
+      "Delimited and Custom are supported formats.")
     private final String format;
 
     @Nullable
@@ -282,15 +283,16 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
       // Check if the format specified is valid.
       if (format == null || format.isEmpty()) {
         throw new IllegalArgumentException("Format is not specified. Allowed values are DEFAULT, EXCEL, MYSQL," +
-                                             " RFC4180, PDL, TDF or Custom");
+                                             " RFC4180, Pipe Delimited, Tab Delimited or Custom");
       }
 
       // Check if format is one of the allowed types.
       if (!format.equalsIgnoreCase("DEFAULT") && !format.equalsIgnoreCase("EXCEL") &&
         !format.equalsIgnoreCase("MYSQL") && !format.equalsIgnoreCase("RFC4180") &&
-        !format.equalsIgnoreCase("TDF") && !format.equalsIgnoreCase("PDL") && !format.equalsIgnoreCase("Custom")) {
+        !format.equalsIgnoreCase("Tab Delimited") && !format.equalsIgnoreCase("Pipe Delimited")
+        && !format.equalsIgnoreCase("Custom")) {
         throw new IllegalArgumentException("Format specified is not one of the allowed values. Allowed values are " +
-                                             "DEFAULT, EXCEL, MYSQL, RFC4180, PDL, TDF or Custom");
+                                             "DEFAULT, EXCEL, MYSQL, RFC4180, Pipe Delimited, Tab Delimited or Custom");
       }
 
       if (format.equalsIgnoreCase("Custom") && (delimiter == null || delimiter == 0)) {

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/CSVParserTest.java
@@ -197,7 +197,7 @@ public class CSVParserTest {
 
   @Test
   public void testPDL() throws Exception {
-    CSVParser.Config config = new CSVParser.Config("PDL", null, "body", OUTPUT1.toString());
+    CSVParser.Config config = new CSVParser.Config("Pipe Delimited", null, "body", OUTPUT1.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new CSVParser(config);
     transform.initialize(null);
 

--- a/transform-plugins/widgets/CSVParser-transform.json
+++ b/transform-plugins/widgets/CSVParser-transform.json
@@ -23,9 +23,9 @@
               "DEFAULT",
               "EXCEL",
               "MYSQL",
-              "PDL",
+              "Pipe Delimited",
               "RFC4180",
-              "TDF",
+              "Tab Delimited",
               "Custom"
             ],
             "default": "DEFAULT"


### PR DESCRIPTION
Changing the option name from TDF to "Tab Delimited" and PDL to "Pipe Delimited"  - https://issues.cask.co/browse/HYDRATOR-282