### PR TITLE
HYDRATOR-699 remove use of etlbatch from tests

### DIFF
--- a/cassandra-plugins/pom.xml
+++ b/cassandra-plugins/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/copybookreader-plugins/pom.xml
+++ b/copybookreader-plugins/pom.xml
@@ -95,10 +95,6 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -55,10 +55,6 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLBatchTestBase.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.datapipeline.DataPipelineApp;
-import co.cask.cdap.etl.batch.ETLBatchApplication;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
@@ -89,10 +88,8 @@ public class ETLBatchTestBase extends HydratorTestBase {
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", true);
 
-  protected static final ArtifactId ETLBATCH_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("etlbatch", "3.2.0");
   protected static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "3.2.0");
-  protected static final ArtifactSummary ETLBATCH_ARTIFACT = new ArtifactSummary("etlbatch", "3.2.0");
   protected static final ArtifactSummary DATAPIPELINE_ARTIFACT = new ArtifactSummary("data-pipeline", "3.2.0");
 
   private static int startCount;
@@ -103,13 +100,9 @@ public class ETLBatchTestBase extends HydratorTestBase {
       return;
     }
 
-    setupBatchArtifacts(ETLBATCH_ARTIFACT_ID, ETLBatchApplication.class);
     setupBatchArtifacts(DATAPIPELINE_ARTIFACT_ID, DataPipelineApp.class);
 
     Set<ArtifactRange> parents = ImmutableSet.of(
-      new ArtifactRange(Id.Namespace.DEFAULT, ETLBATCH_ARTIFACT_ID.getArtifact(),
-                        new ArtifactVersion(ETLBATCH_ARTIFACT_ID.getVersion()), true,
-                        new ArtifactVersion(ETLBATCH_ARTIFACT_ID.getVersion()), true),
       new ArtifactRange(Id.Namespace.DEFAULT, DATAPIPELINE_ARTIFACT_ID.getArtifact(),
                         new ArtifactVersion(DATAPIPELINE_ARTIFACT_ID.getVersion()), true,
                         new ArtifactVersion(DATAPIPELINE_ARTIFACT_ID.getVersion()), true)

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLFTPTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLFTPTestRun.java
@@ -18,17 +18,18 @@ package co.cask.hydrator.plugin.batch;
 
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.plugin.batch.source.FileBatchSource;
 import co.cask.hydrator.plugin.common.Properties;
 import com.google.common.collect.ImmutableMap;
@@ -123,13 +124,13 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "FTPToTPFS");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("FTPToTPFS");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(2, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("fileSink");
     try (TimePartitionedFileSet fileSet = fileSetManager.get()) {

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLMapReduceTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLMapReduceTestRun.java
@@ -23,18 +23,19 @@ import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.common.Constants;
 import co.cask.hydrator.plugin.batch.source.FileBatchSource;
 import co.cask.hydrator.plugin.common.Properties;
@@ -84,8 +85,8 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection("transform", "sink")
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "KVToKV");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("KVToKV");
     try {
       deployApplication(appId, appRequest);
       Assert.fail();
@@ -114,8 +115,8 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "KVToKV");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("KVToKV");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // add some data to the input table
@@ -126,9 +127,9 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
     }
     table1.flush();
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<KeyValueTable> table2 = getDataset("kvTable2");
     try (KeyValueTable outputTable = table2.get()) {
@@ -193,8 +194,8 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection(transform.getName(), sink2.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "DagApp");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("DagApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // add some data to the input table
@@ -216,9 +217,9 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
     }
 
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     // all records are passed to this table (validation not performed)
     DataSetManager<Table> outputManager1 = getDataset("dagOutputTable1");
@@ -295,8 +296,8 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "TableToTable");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("TableToTable");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // add some data to the input table
@@ -321,9 +322,9 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
     inputTable.put(put);
     inputManager.flush();
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset("outputTable");
     Table outputTable = outputManager.get();
@@ -396,13 +397,13 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "S3ToTPFS");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("S3ToTPFS");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(2, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("TPFSsink");
     try (TimePartitionedFileSet fileSet = fileSetManager.get()) {
@@ -457,13 +458,13 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink2.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "FileToTPFS");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("FileToTPFS");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(2, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
 
     for (String sinkName : new String[] { "fileSink1", "fileSink2" }) {
       DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(sinkName);
@@ -508,8 +509,8 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink2.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "FileToTPFS");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("FileToTPFS");
 
     // deploying would thrown an excpetion
     deployApplication(appId, appRequest);

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLTPFSTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLTPFSTestRun.java
@@ -28,13 +28,13 @@ import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import co.cask.cdap.etl.batch.ETLWorkflow;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -101,8 +101,8 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "offsetCleanupTest");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("offsetCleanupTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // write input to read
@@ -138,7 +138,7 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
     inputManager.flush();
 
     // run the pipeline
-    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(runtime)));
     workflowManager.waitForFinish(4, TimeUnit.MINUTES);
 
@@ -214,7 +214,7 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "TPFSOrcSinkTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("TPFSOrcSinkTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
 
@@ -318,11 +318,11 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
     String newFilesetName = filesetName + "_op";
     ETLBatchConfig etlBatchConfig = constructTPFSETLConfig(filesetName, newFilesetName, eventSchema);
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlBatchConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "sconversion1");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlBatchConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("sconversion1");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     // add a minute to the end time to make sure the newly added partition is included in the run.
     workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis + 60 * 1000)));
     workflowManager.waitForFinish(4, TimeUnit.MINUTES);
@@ -366,8 +366,8 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "parquetTest");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("parquetTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // write input to read
@@ -390,7 +390,7 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
     inputManager.flush();
 
     // run the pipeline
-    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     // add a minute to the end time to make sure the newly added partition is included in the run.
     workflowManager.start(ImmutableMap.of("logical.start.time", String.valueOf(timeInMillis + 60 * 1000)));
     workflowManager.waitForFinish(4, TimeUnit.MINUTES);

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
@@ -17,14 +17,16 @@
 package co.cask.hydrator.plugin.batch.action;
 
 import co.cask.cdap.common.utils.Networks;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.PostAction;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.plugin.batch.ETLBatchTestBase;
@@ -78,11 +80,11 @@ public class EmailActionTestRun extends ETLBatchTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "actionTest");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("actionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    WorkflowManager manager = appManager.getWorkflowManager("ETLWorkflow");
+    WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start(ImmutableMap.of("logical.start.time", "0"));
     manager.waitForFinish(5, TimeUnit.MINUTES);
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/HDFSActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/HDFSActionTestRun.java
@@ -23,8 +23,9 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.plugin.batch.ETLBatchTestBase;
@@ -43,7 +44,7 @@ import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Test for {@link HDFSAction}
+ * Test for HDFSAction.
  */
 public class HDFSActionTestRun extends ETLBatchTestBase {
   @ClassRule
@@ -103,7 +104,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
@@ -145,7 +146,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
@@ -189,7 +190,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
@@ -234,7 +235,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsDeleteActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsDeleteActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
@@ -275,7 +276,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsDeleteActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsDeleteActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
@@ -315,7 +316,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsDeleteSingleFileActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsDeleteSingleFileActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
@@ -358,7 +359,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "hdfsDeleteDirectoryActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsDeleteDirectoryActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/DedupTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/DedupTestRun.java
@@ -27,8 +27,9 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -84,7 +85,7 @@ public class DedupTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "dedup-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("dedup-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/DistinctTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/DistinctTestRun.java
@@ -28,8 +28,9 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -93,7 +94,7 @@ public class DistinctTestRun extends ETLBatchTestBase {
       .addConnection(distinctStage.getName(), sinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "distinct-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("distinct-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/GroupByTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/GroupByTestRun.java
@@ -28,8 +28,9 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -132,7 +133,7 @@ public class GroupByTestRun extends ETLBatchTestBase {
       .addConnection(itemGroupStage.getName(), itemSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "groupby-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("groupby-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/RowDenormalizerAggregatorTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/RowDenormalizerAggregatorTest.java
@@ -28,8 +28,9 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -100,7 +101,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
       .addConnection(aggregateStage.getName(), sinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "denormalize-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data
@@ -205,7 +206,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
       .addConnection(aggregateStage.getName(), sinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "denormalize-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data
@@ -328,7 +329,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
       .addConnection(aggregateStage.getName(), sinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "denormalize-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerTestRun.java
@@ -28,8 +28,9 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.WorkflowManager;
@@ -151,7 +152,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
       .addConnection(joinStage.getName(), joinSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "joiner-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("joiner-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // ingest data
@@ -251,7 +252,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
       .addConnection(joinStage.getName(), joinSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "joiner-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("joiner-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // ingest data
@@ -351,7 +352,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
       .addConnection(joinStage.getName(), joinSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "joiner-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("joiner-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // ingest data

--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -45,14 +45,6 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>co.cask.hydrator</groupId>

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBActionTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBActionTestRun.java
@@ -23,8 +23,9 @@ import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.plugin.DatabasePluginTestBase;
@@ -75,7 +76,7 @@ public class DBActionTestRun extends DatabasePluginTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "actionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("actionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBQueryActionTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBQueryActionTestRun.java
@@ -16,15 +16,16 @@
 
 package co.cask.hydrator.plugin.db.batch.action;
 
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.PostAction;
-import co.cask.cdap.etl.batch.ETLWorkflow;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.plugin.DatabasePluginTestBase;
@@ -75,11 +76,11 @@ public class DBQueryActionTestRun extends DatabasePluginTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, config);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "postActionTest");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app("postActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start(ImmutableMap.of("logical.start.time", "0"));
     workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
@@ -24,8 +24,9 @@ import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.hydrator.common.Constants;
@@ -276,7 +277,7 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .put(Constants.Reference.REFERENCE_NAME, "UserPassDBTest")
       .build();
 
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "dbTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("dbTest");
 
     // null user name, null password. Should succeed.
     // as source
@@ -288,7 +289,7 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .addStage(table)
       .addConnection(database.getName(), table.getName())
       .build();
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
     deployApplication(appId, appRequest);
 
     // null user name, non-null password. Should fail.
@@ -315,7 +316,7 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .addStage(table)
       .addConnection(database.getName(), table.getName())
       .build();
-    appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
     deployApplication(appId, appRequest);
   }
 
@@ -347,7 +348,7 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .addStage(sink)
       .addConnection(sourceBadName.getName(), sink.getName())
       .build();
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "dbSourceNonExistingTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("dbSourceNonExistingTest");
     assertRuntimeFailure(appId, etlConfig, "ETL Application with DB Source should have failed because of a " +
       "non-existent source table.");
 

--- a/elasticsearch-plugins/pom.xml
+++ b/elasticsearch-plugins/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.hydrator</groupId>

--- a/hbase-plugins/src/test/java/co/cask/hydrator/plugin/HBaseTest.java
+++ b/hbase-plugins/src/test/java/co/cask/hydrator/plugin/HBaseTest.java
@@ -21,25 +21,25 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import co.cask.cdap.etl.batch.ETLBatchApplication;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.TestConfiguration;
+import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.common.Constants;
 import co.cask.hydrator.plugin.sink.HBaseSink;
 import co.cask.hydrator.plugin.source.HBaseSource;
@@ -97,8 +97,8 @@ public class HBaseTest extends HydratorTestBase {
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion("3.2.0");
 
   private static final ArtifactId BATCH_APP_ARTIFACT_ID =
-    NamespaceId.DEFAULT.artifact("etlbatch", CURRENT_VERSION.getVersion());
-  private static final ArtifactSummary ETLBATCH_ARTIFACT =
+    NamespaceId.DEFAULT.artifact("data-pipeline", CURRENT_VERSION.getVersion());
+  private static final ArtifactSummary BATCH_ARTIFACT =
     new ArtifactSummary(BATCH_APP_ARTIFACT_ID.getArtifact(), BATCH_APP_ARTIFACT_ID.getVersion());
 
   private static HBaseTestingUtility testUtil;
@@ -108,7 +108,7 @@ public class HBaseTest extends HydratorTestBase {
   @BeforeClass
   public static void setupTest() throws Exception {
     // add the artifact for etl batch app
-    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, ETLBatchApplication.class);
+    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, DataPipelineApp.class);
 
     // add artifact for batch sources and sinks
     addPluginArtifact(NamespaceId.DEFAULT.artifact("batch-plugins", "1.0.0"), BATCH_APP_ARTIFACT_ID,
@@ -170,8 +170,8 @@ public class HBaseTest extends HydratorTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "HBaseSinkTest");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("HBaseSinkTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
@@ -181,9 +181,9 @@ public class HBaseTest extends HydratorTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     ResultScanner resultScanner = htable.getScanner(HBASE_FAMILY_COLUMN.getBytes());
     Result result;
@@ -221,13 +221,13 @@ public class HBaseTest extends HydratorTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "HBaseSourceTest");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("HBaseSourceTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/hdfs-plugins/pom.xml
+++ b/hdfs-plugins/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.hydrator</groupId>

--- a/http-plugins/pom.xml
+++ b/http-plugins/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.hydrator</groupId>

--- a/http-plugins/src/test/java/co/cask/hydrator/plugin/batch/HttpCallbackActionTest.java
+++ b/http-plugins/src/test/java/co/cask/hydrator/plugin/batch/HttpCallbackActionTest.java
@@ -17,8 +17,9 @@
 package co.cask.hydrator.plugin.batch;
 
 import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.PostAction;
-import co.cask.cdap.etl.batch.ETLBatchApplication;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
@@ -30,6 +31,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
@@ -69,8 +71,8 @@ public class HttpCallbackActionTest extends HydratorTestBase {
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
-  protected static final ArtifactId BATCH_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("etlbatch", "3.2.0");
-  protected static final ArtifactSummary BATCH_ARTIFACT = new ArtifactSummary("etlbatch", "3.2.0");
+  protected static final ArtifactId BATCH_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("data-pipeline", "3.2.0");
+  protected static final ArtifactSummary BATCH_ARTIFACT = new ArtifactSummary("data-pipeline", "3.2.0");
   protected static final ArtifactId REALTIME_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("etlrealtime", "3.2.0");
   protected static final ArtifactSummary REALTIME_ARTIFACT = new ArtifactSummary("etlrealtime", "3.2.0");
 
@@ -84,7 +86,7 @@ public class HttpCallbackActionTest extends HydratorTestBase {
       return;
     }
 
-    setupBatchArtifacts(BATCH_ARTIFACT_ID, ETLBatchApplication.class);
+    setupBatchArtifacts(BATCH_ARTIFACT_ID, DataPipelineApp.class);
     setupRealtimeArtifacts(REALTIME_ARTIFACT_ID, ETLRealtimeApplication.class);
 
     Set<ArtifactRange> parents = new HashSet<>();
@@ -150,10 +152,10 @@ public class HttpCallbackActionTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "actionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("actionTest");
     ApplicationManager appManager = TestBase.deployApplication(appId, appRequest);
 
-    WorkflowManager manager = appManager.getWorkflowManager("ETLWorkflow");
+    WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
     manager.waitForFinish(5, TimeUnit.MINUTES);
 

--- a/kafka-plugins/src/test/java/co/cask/hydrator/sinks/KafkaPipelineTest.java
+++ b/kafka-plugins/src/test/java/co/cask/hydrator/sinks/KafkaPipelineTest.java
@@ -27,9 +27,9 @@ import co.cask.cdap.etl.proto.v2.ETLRealtimeConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.realtime.ETLRealtimeApplication;
 import co.cask.cdap.etl.realtime.ETLWorker;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
@@ -140,7 +140,7 @@ public class KafkaPipelineTest extends HydratorTestBase {
       .addConnection("source", "sink")
       .build();
 
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "kafkaSourceTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("kafkaSourceTest");
     AppRequest<ETLRealtimeConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
     ApplicationManager appManager = deployApplication(appId, appRequest);
 

--- a/kafka-plugins/src/test/java/co/cask/hydrator/sinks/KafkaProducerTest.java
+++ b/kafka-plugins/src/test/java/co/cask/hydrator/sinks/KafkaProducerTest.java
@@ -107,7 +107,7 @@ public class KafkaProducerTest {
     kafkaproducer.write(input, null);
     
     final CountDownLatch latch = new CountDownLatch(input.size());
-    final List<String> consumedMessages = new ArrayList<String>(input.size());
+    final List<String> consumedMessages = new ArrayList<>(input.size());
       kafkaClient.getConsumer().prepare()
         .addFromBeginning(testTopic, 0)
         .addFromBeginning(testTopic, 1)
@@ -158,7 +158,7 @@ public class KafkaProducerTest {
     kafkaproducer.write(input, null);
 
     final CountDownLatch latch = new CountDownLatch(input.size());
-    final List<String> consumedMessages = new ArrayList<String>(input.size());
+    final List<String> consumedMessages = new ArrayList<>(input.size());
     kafkaClient.getConsumer().prepare()
       .addFromBeginning(testTopic, 0)
       .addFromBeginning(testTopic, 1)
@@ -209,7 +209,7 @@ public class KafkaProducerTest {
     kafkaproducer.write(input, null);
 
     final CountDownLatch latch = new CountDownLatch(input.size());
-    final List<String> consumedMessages = new ArrayList<String>(input.size());
+    final List<String> consumedMessages = new ArrayList<>(input.size());
     kafkaClient.getConsumer().prepare()
       .addFromBeginning(testTopic, 0)
       .addFromBeginning(testTopic, 1)
@@ -260,7 +260,7 @@ public class KafkaProducerTest {
     kafkaproducer.write(input, null);
 
     final CountDownLatch latch = new CountDownLatch(input.size());
-    final List<String> consumedMessages = new ArrayList<String>(input.size());
+    final List<String> consumedMessages = new ArrayList<>(input.size());
     kafkaClient.getConsumer().prepare()
       .addFromBeginning(testTopic, 0)
       .addFromBeginning(testTopic, 1)
@@ -311,7 +311,7 @@ public class KafkaProducerTest {
     kafkaproducer.write(input, null);
 
     final CountDownLatch latch = new CountDownLatch(input.size());
-    final List<String> consumedMessages = new ArrayList<String>(input.size());
+    final List<String> consumedMessages = new ArrayList<>(input.size());
     kafkaClient.getConsumer().prepare()
       .addFromBeginning(testTopic, 0)
       .addFromBeginning(testTopic, 1)
@@ -363,7 +363,7 @@ public class KafkaProducerTest {
     kafkaproducer.write(input, null);
 
     final CountDownLatch latch = new CountDownLatch(input.size());
-    final List<String> consumedMessages = new ArrayList<String>(input.size());
+    final List<String> consumedMessages = new ArrayList<>(input.size());
     kafkaClient.getConsumer().prepare()
       .addFromBeginning(testTopic, 0)
       .addFromBeginning(testTopic, 1)

--- a/mongodb-plugins/pom.xml
+++ b/mongodb-plugins/pom.xml
@@ -38,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/mongodb-plugins/src/test/java/co/cask/hydrator/plugin/test/MongoDBTest.java
+++ b/mongodb-plugins/src/test/java/co/cask/hydrator/plugin/test/MongoDBTest.java
@@ -21,11 +21,11 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.realtime.RealtimeSink;
-import co.cask.cdap.etl.batch.ETLBatchApplication;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
@@ -39,12 +39,13 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.WorkerManager;
+import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.common.Constants;
 import co.cask.hydrator.plugin.batch.sink.MongoDBBatchSink;
 import co.cask.hydrator.plugin.batch.source.MongoDBBatchSource;
@@ -86,7 +87,7 @@ public class MongoDBTest extends HydratorTestBase {
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion("3.2.0");
 
   private static final ArtifactId BATCH_APP_ARTIFACT_ID =
-    NamespaceId.DEFAULT.artifact("etlbatch", CURRENT_VERSION.getVersion());
+    NamespaceId.DEFAULT.artifact("data-pipeline", CURRENT_VERSION.getVersion());
   private static final ArtifactSummary ETLBATCH_ARTIFACT =
     new ArtifactSummary(BATCH_APP_ARTIFACT_ID.getArtifact(), BATCH_APP_ARTIFACT_ID.getVersion());
 
@@ -98,7 +99,7 @@ public class MongoDBTest extends HydratorTestBase {
   private static final ArtifactRange REALTIME_ARTIFACT_RANGE = new ArtifactRange(Id.Namespace.DEFAULT, "etlrealtime",
                                                                                  CURRENT_VERSION, true,
                                                                                  CURRENT_VERSION, true);
-  private static final ArtifactRange BATCH_ARTIFACT_RANGE = new ArtifactRange(Id.Namespace.DEFAULT, "etlbatch",
+  private static final ArtifactRange BATCH_ARTIFACT_RANGE = new ArtifactRange(Id.Namespace.DEFAULT, "data-pipeline",
                                                                               CURRENT_VERSION, true,
                                                                               CURRENT_VERSION, true);
 
@@ -124,7 +125,7 @@ public class MongoDBTest extends HydratorTestBase {
 
   @BeforeClass
   public static void setup() throws Exception {
-    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, ETLBatchApplication.class);
+    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, DataPipelineApp.class);
     setupRealtimeArtifacts(REALTIME_APP_ARTIFACT_ID, ETLRealtimeApplication.class);
 
     Set<ArtifactRange> parents = ImmutableSet.of(REALTIME_ARTIFACT_RANGE, BATCH_ARTIFACT_RANGE);
@@ -184,7 +185,7 @@ public class MongoDBTest extends HydratorTestBase {
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
       .build();
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "MongoDBRealtimeSinkTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("MongoDBRealtimeSinkTest");
     AppRequest<ETLRealtimeConfig> appRequest = new AppRequest<>(REALTIME_APP_ARTIFACT, etlConfig);
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkerManager workerManager = appManager.getWorkerManager(ETLWorker.class.getSimpleName());
@@ -222,7 +223,7 @@ public class MongoDBTest extends HydratorTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "MongoSinkTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("MongoSinkTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     List<StructuredRecord> inputRecords = ImmutableList.of(
@@ -232,9 +233,9 @@ public class MongoDBTest extends HydratorTestBase {
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
     MockSource.writeInput(inputManager, inputRecords);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     MongoClient mongoClient = factory.newMongo();
     MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
@@ -285,12 +286,12 @@ public class MongoDBTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "MongoToMongoTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("MongoToMongoTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     MongoClient mongoClient = factory.newMongo();
     MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
@@ -337,12 +338,12 @@ public class MongoDBTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "MongoSourceTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("MongoSourceTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,6 @@
       </dependency>
       <dependency>
         <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-etl-batch</artifactId>
-        <version>${cdap.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-data-pipeline</artifactId>
         <version>${cdap.version}</version>
         <scope>test</scope>

--- a/solrsearch-plugins/pom.xml
+++ b/solrsearch-plugins/pom.xml
@@ -82,10 +82,6 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-realtime</artifactId>
     </dependency>
     <dependency>

--- a/solrsearch-plugins/src/test/java/co/cask/hydrator/plugin/SolrSearchSinkTest.java
+++ b/solrsearch-plugins/src/test/java/co/cask/hydrator/plugin/SolrSearchSinkTest.java
@@ -20,10 +20,10 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.realtime.RealtimeSink;
-import co.cask.cdap.etl.batch.ETLBatchApplication;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
@@ -42,9 +42,9 @@ import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.WorkerManager;
+import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.common.Constants;
 import co.cask.hydrator.plugin.batch.SolrSearchSink;
 import co.cask.hydrator.plugin.common.SolrSearchSinkConfig;
@@ -88,7 +88,7 @@ public class SolrSearchSinkTest extends HydratorTestBase {
 
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion("3.2.0");
   private static final ArtifactId BATCH_APP_ARTIFACT_ID =
-    NamespaceId.DEFAULT.artifact("etlbatch", CURRENT_VERSION.getVersion());
+    NamespaceId.DEFAULT.artifact("data-pipeline", CURRENT_VERSION.getVersion());
   private static final ArtifactSummary ETLBATCH_ARTIFACT =
     new ArtifactSummary(BATCH_APP_ARTIFACT_ID.getArtifact(), BATCH_APP_ARTIFACT_ID.getVersion());
   private static final ArtifactId REALTIME_APP_ARTIFACT_ID =
@@ -98,7 +98,7 @@ public class SolrSearchSinkTest extends HydratorTestBase {
   private static final ArtifactRange REALTIME_ARTIFACT_RANGE = new ArtifactRange(Id.Namespace.DEFAULT, "etlrealtime",
                                                                                  CURRENT_VERSION, true,
                                                                                  CURRENT_VERSION, true);
-  private static final ArtifactRange BATCH_ARTIFACT_RANGE = new ArtifactRange(Id.Namespace.DEFAULT, "etlbatch",
+  private static final ArtifactRange BATCH_ARTIFACT_RANGE = new ArtifactRange(Id.Namespace.DEFAULT, "data-pipeline",
                                                                               CURRENT_VERSION, true,
                                                                               CURRENT_VERSION, true);
 
@@ -109,7 +109,7 @@ public class SolrSearchSinkTest extends HydratorTestBase {
 
   @BeforeClass
   public static void setupTest() throws Exception {
-    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, ETLBatchApplication.class);
+    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, DataPipelineApp.class);
 
     setupRealtimeArtifacts(REALTIME_APP_ARTIFACT_ID, ETLRealtimeApplication.class);
 
@@ -158,9 +158,9 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     QueryResponse queryResponse = client.query(new SolrQuery("*:*"));
     SolrDocumentList resultList = queryResponse.getResults();
@@ -293,9 +293,9 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     QueryResponse queryResponse = cloudClient.query(new SolrQuery("*:*"));
     SolrDocumentList resultList = queryResponse.getResults();
@@ -371,9 +371,9 @@ public class SolrSearchSinkTest extends HydratorTestBase {
         .set("office address", "WE Lake Side").set("pincode", 480005).build());
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     QueryResponse queryResponse = client.query(new SolrQuery("*:*"));
     SolrDocumentList resultList = queryResponse.getResults();
@@ -444,11 +444,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
-    Assert.assertEquals("FAILED", mrManager.getHistory().get(0).getStatus().name());
+    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
   }
 
   @Test
@@ -488,11 +488,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
-    Assert.assertEquals("FAILED", mrManager.getHistory().get(0).getStatus().name());
+    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/SparkPluginTest.java
+++ b/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/SparkPluginTest.java
@@ -41,6 +41,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
@@ -210,7 +211,7 @@ public class SparkPluginTest extends HydratorTestBase {
       .setBatchInterval("1s")
       .build();
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(DATASTREAMS_ARTIFACT, pipelineConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "HTTPSourceApp");
+    ApplicationId appId = NamespaceId.DEFAULT.app("HTTPSourceApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
@@ -275,7 +276,7 @@ public class SparkPluginTest extends HydratorTestBase {
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(DATASTREAMS_ARTIFACT, pipelineCfg);
 
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "FileSourceApp");
+    ApplicationId appId = NamespaceId.DEFAULT.app("FileSourceApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
@@ -368,7 +369,7 @@ public class SparkPluginTest extends HydratorTestBase {
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(DATASTREAMS_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "KafkaSourceApp");
+    ApplicationId appId = NamespaceId.DEFAULT.app("KafkaSourceApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // write some messages to kafka
@@ -475,7 +476,7 @@ public class SparkPluginTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SinglePhaseApp");
+    ApplicationId appId = NamespaceId.DEFAULT.app("SinglePhaseApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
 
@@ -523,7 +524,7 @@ public class SparkPluginTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SinglePhaseApp");
+    ApplicationId appId = NamespaceId.DEFAULT.app("SinglePhaseApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
 

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.hydrator</groupId>

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/NormalizeTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/NormalizeTest.java
@@ -19,8 +19,8 @@ package co.cask.hydrator.plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
@@ -32,7 +32,7 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.WorkflowManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
@@ -67,7 +67,7 @@ public class NormalizeTest extends TransformPluginsTestBase {
   private static final double ITEM_COST_ROW1 = 245.67;
   private static final double ITEM_COST_ROW2 = 67.90;
   private static final double ITEM_COST_ROW3 = 14.15;
-  private static final Map<String, Object> dataMap = new HashMap<String, Object>();
+  private static final Map<String, Object> dataMap = new HashMap<>();
   private static final Schema INPUT_SCHEMA =
     Schema.recordOf("inputSchema",
                     Schema.Field.of(CUSTOMER_ID, Schema.of(Schema.Type.STRING)),
@@ -119,15 +119,15 @@ public class NormalizeTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
     ApplicationId appId = NamespaceId.DEFAULT.app(applicationName);
     return deployApplication(appId.toId(), appRequest);
   }
 
   private void startMapReduceJob(ApplicationManager appManager) throws Exception {
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
   }
 
   @Test

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/TransformPluginsTestBase.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/TransformPluginsTestBase.java
@@ -17,7 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.artifact.ArtifactVersion;
-import co.cask.cdap.etl.batch.ETLBatchApplication;
+import co.cask.cdap.datapipeline.DataPipelineApp;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ArtifactId;
@@ -44,14 +44,14 @@ public class TransformPluginsTestBase extends HydratorTestBase {
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion("3.2.0");
 
   private static final ArtifactId BATCH_APP_ARTIFACT_ID =
-    NamespaceId.DEFAULT.artifact("etlbatch", CURRENT_VERSION.getVersion());
-  protected static final ArtifactSummary ETLBATCH_ARTIFACT =
+    NamespaceId.DEFAULT.artifact("data-pipeline", CURRENT_VERSION.getVersion());
+  protected static final ArtifactSummary BATCH_ARTIFACT =
     new ArtifactSummary(BATCH_APP_ARTIFACT_ID.getArtifact(), BATCH_APP_ARTIFACT_ID.getVersion());
 
   @BeforeClass
   public static void setupTestClass() throws Exception {
     // Add the ETL batch artifact and mock plugins.
-    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, ETLBatchApplication.class);
+    setupBatchArtifacts(BATCH_APP_ARTIFACT_ID, DataPipelineApp.class);
 
     // Add our plugins artifact with the ETL batch artifact as its parent.
     // This will make our plugins available to the ETL batch.

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/ValueMapperTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/ValueMapperTest.java
@@ -20,8 +20,8 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
@@ -30,9 +30,11 @@ import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.WorkflowManager;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -88,8 +90,8 @@ public class ValueMapperTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "valuemappertest_test_Empty_Null");
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("valuemappertest_test_Empty_Null");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     addDatasetInstance(KeyValueTable.class.getName(), "designation_lookup_table_test_Empty_Null");
@@ -114,9 +116,9 @@ public class ValueMapperTest extends TransformPluginsTestBase {
 
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -161,7 +163,7 @@ public class ValueMapperTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "valuemappertest_without_defaults");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
@@ -186,9 +188,9 @@ public class ValueMapperTest extends TransformPluginsTestBase {
         .set(DESIGNATIONID, "4").build());
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -249,7 +251,7 @@ public class ValueMapperTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "valuemappertest_with_multi_mapping");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
@@ -280,9 +282,9 @@ public class ValueMapperTest extends TransformPluginsTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/XMLParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/XMLParserTest.java
@@ -19,9 +19,9 @@ package co.cask.hydrator.plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.mock.batch.MockSink;
 import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.common.MockEmitter;
@@ -35,7 +35,7 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.WorkflowManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
@@ -95,7 +95,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
     ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
@@ -107,9 +107,10 @@ public class XMLParserTest extends TransformPluginsTestBase {
           "<author>Giada De Laurentiis</author><year>2005</year><price>30.00</price></book>").build()
     );
     MockSource.writeInput(inputManager, input);
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -145,7 +146,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
     ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
@@ -168,9 +169,10 @@ public class XMLParserTest extends TransformPluginsTestBase {
           "</book></bookstore>").build()
     );
     MockSource.writeInput(inputManager, input);
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -294,7 +296,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
       .addConnection(transform.getName(), sink.getName())
       .build();
 
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
     ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
@@ -308,9 +310,9 @@ public class XMLParserTest extends TransformPluginsTestBase {
           "<year>2005</year><price>29.99</price></book></bookstore>").build()
     );
     MockSource.writeInput(inputManager, input);
-    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
-    mrManager.start();
-    mrManager.waitForFinish(5, TimeUnit.MINUTES);
-    Assert.assertEquals("FAILED", mrManager.getHistory().get(0).getStatus().name());
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
   }
 }


### PR DESCRIPTION
Replace all usages of old etlbatch app with datapipeline app in
unit tests. Also replacing deprecated Id.Application with new
ApplicationId.