### PR TITLE
Feature/bump version

### DIFF
--- a/cassandra-plugins/pom.xml
+++ b/cassandra-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.hydrator</groupId>
     <artifactId>hydrator-plugins</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>Cassandra Plugins</name>

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>Hydrator Core Plugins</name>

--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/elasticsearch-plugins/pom.xml
+++ b/elasticsearch-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>Elasticsearch Plugins</name>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/hdfs-plugins/pom.xml
+++ b/hdfs-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>HDFS Plugins</name>

--- a/hive-plugins/pom.xml
+++ b/hive-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>Hive Hydrator Plugins</name>

--- a/http-plugins/pom.xml
+++ b/http-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>HTTP Plugins</name>

--- a/hydrator-common/pom.xml
+++ b/hydrator-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-plugins/pom.xml
+++ b/kafka-plugins/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mongodb-plugins/pom.xml
+++ b/mongodb-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>MongoDB Plugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>co.cask.hydrator</groupId>
   <artifactId>hydrator-plugins</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Hydrator Plugin Collection</name>
   <description>A collection of plugins for Cask Hydrator.</description>

--- a/solrsearch-plugins/pom.xml
+++ b/solrsearch-plugins/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>Solr Search Plugins</name>

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.hydrator</groupId>
     <artifactId>hydrator-plugins</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
 
   <name>Transform Plugins</name>


### PR DESCRIPTION
First commit is from: `mvn versions:set -DnewVersion=1.6.0-SNAPSHOT -DgenerateBackupPoms=false`
Second commit changes version ranges.

Depends on https://github.com/caskdata/cdap/pull/7261