### PR TITLE
Export apache http packages, for use by S3 sources/sinks.

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -64,30 +64,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
-      <version>2.3.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>
@@ -284,7 +260,9 @@
               co.cask.hydrator.plugin.validator.*;
               org.apache.avro.mapreduce;
               parquet.avro.*;
-              org.apache.orc.*
+              org.apache.orc.*;
+              <!-- Used by S3 source/sink -->
+              org.apache.http.*
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,28 @@
         <artifactId>hadoop-minicluster</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>asm</groupId>
+            <artifactId>asm</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Export apache http packages, for use by S3 sources/sinks.
It was previously packaged with cdap, until CDAP-7648.
Moved exclusions to dependency-management (best practices).

Note: the fix is tested by Mao on SDK and Cluster.

http://builds.cask.co/browse/HYP-BAD189-2

Helps avoid this error:
```
2016-12-09 16:29:34,491 - WARN  [HiveServer2-Background-Pool: Thread-353:c.c.c.c.l.RedirectedPrintStream@91] - OK
Exception in thread "MapReduceRunner-phase-1" java.lang.NoClassDefFoundError: org/apache/http/HttpEntity
        at org.apache.hadoop.fs.s3native.Jets3tNativeFileSystemStore.initialize(Jets3tNativeFileSystemStore.java:66)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:186)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)
        at org.apache.hadoop.fs.s3native.$Proxy64.initialize(Unknown Source)
        at org.apache.hadoop.fs.s3native.NativeS3FileSystem.initialize(NativeS3FileSystem.java:272)
        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2316)
        at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:90)
        at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2350)
        at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2332)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:369)
        at org.apache.hadoop.fs.Path.getFileSystem(Path.java:296)
        at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.addInputPath(FileInputFormat.java:466)
        at co.cask.hydrator.plugin.batch.source.FileBatchSource.prepareRun(FileBatchSource.java:172)
        at co.cask.hydrator.plugin.batch.source.FileBatchSource.prepareRun(FileBatchSource.java:65)
        at co.cask.cdap.etl.batch.LoggedBatchConfigurable$1.call(LoggedBatchConfigurable.java:44)
        at co.cask.cdap.etl.batch.LoggedBatchConfigurable$1.call(LoggedBatchConfigurable.java:41)
        at co.cask.cdap.etl.log.LogContext.run(LogContext.java:59)
        at co.cask.cdap.etl.batch.LoggedBatchConfigurable.prepareRun(LoggedBatchConfigurable.java:41)
        at co.cask.cdap.etl.batch.mapreduce.ETLMapReduce.initialize(ETLMapReduce.java:183)
        at co.cask.cdap.api.mapreduce.AbstractMapReduce.initialize(AbstractMapReduce.java:122)
        at co.cask.cdap.api.mapreduce.AbstractMapReduce.initialize(AbstractMapReduce.java:33)
        at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService.doInitialize(MapReduceRuntimeService.java:561)
        at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService.access$100(MapReduceRuntimeService.java:143)
        at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService$2.run(MapReduceRuntimeService.java:539)
        at co.cask.cdap.data2.transaction.Transactions$CacheBasedTransactional.finishExecute(Transactions.java:242)
        at co.cask.cdap.data2.transaction.Transactions$CacheBasedTransactional.execute(Transactions.java:230)
        at co.cask.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:385)
        at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService.beforeSubmit(MapReduceRuntimeService.java:536)
        at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService.startUp(MapReduceRuntimeService.java:225)
        at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47)
        at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService$1$1.run(MapReduceRuntimeService.java:440)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: org.apache.http.HttpEntity
        at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
        at co.cask.cdap.common.lang.InterceptableClassLoade
```