### PR TITLE
Add hydrator/wrangler-transform as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,21 @@
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Add Git submodule definitions below. Always include "branch" name to follow.
+
+[submodule "wrangler-transform"]
+	path = wrangler-transform
+	url = https://github.com/hydrator/wrangler-transform.git
+	branch = develop

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,10 @@
     <module>http-plugins</module>
     <module>kafka-plugins</module>
     <module>mongodb-plugins</module>
+    <module>solrsearch-plugins</module>
     <module>spark-plugins</module>
     <module>transform-plugins</module>
-    <module>solrsearch-plugins</module>
+    <module>wrangler-transform</module>
   </modules>
 
   <licenses>


### PR DESCRIPTION
This adds `hydrator/wrangler-transform` as a submodule, which will be fetched with Git and built along with the rest of this repository when creating CDAP artifacts.

Build: http://builds.cask.co/browse/HYP-BAD191-2

(This is just including it, so build should include it... other failures unrelated)