### PR TITLE
Update docs for ignoreNonExistingFolders. It is not nullable.

### DIFF
--- a/core-plugins/docs/AzureBlobStore-batchsource.md
+++ b/core-plugins/docs/AzureBlobStore-batchsource.md
@@ -28,7 +28,7 @@ Azure Storage account name. (Macro-enabled)
 Must be a valid base64 encoded storage key provided by Microsoft Azure. (Macro-enabled)
 
 **ignoreNonExistingFolders:** Identify if path needs to be ignored or not, for case when directory or file does not
-exists. If set to true it will treat the not present folder as 0 input and log a warning. Default is false.
+exists. If set to true it will treat the not present folder as 0 input and log a warning.
 
 Example
 -------

--- a/core-plugins/docs/FTP-batchsource.md
+++ b/core-plugins/docs/FTP-batchsource.md
@@ -27,7 +27,7 @@ needed for the distributed file system. (Macro-enabled)
 Defaults to CombineTextInputFormat. (Macro-enabled)
 
 **ignoreNonExistingFolders:** Identify if path needs to be ignored or not, for case when directory or file does not
-exists. If set to true it will treat the not present folder as 0 input and log a warning. Default is false.
+exists. If set to true it will treat the not present folder as 0 input and log a warning.
 
 
 Example

--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -44,7 +44,7 @@ subclass of FileInputFormat. Defaults to CombineTextInputFormat. (Macro-enabled)
 **maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB. (Macro-enabled)
 
 **ignoreNonExistingFolders:** Identify if path needs to be ignored or not, for case when directory or file does not
-exists. If set to true it will treat the not present folder as 0 input and log a warning. Default is false.
+exists. If set to true it will treat the not present folder as 0 input and log a warning.
 
 Example
 -------

--- a/core-plugins/docs/S3-batchsource.md
+++ b/core-plugins/docs/S3-batchsource.md
@@ -41,7 +41,7 @@ subclass of FileInputFormat. Defaults to TextInputFormat. (Macro-enabled)
 **maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB. (Macro-enabled)
 
 **ignoreNonExistingFolders:** Identify if path needs to be ignored or not, for case when directory or file does not
-exists. If set to true it will treat the not present folder as 0 input and log a warning. Default is false.
+exists. If set to true it will treat the not present folder as 0 input and log a warning.
 
 
 Example


### PR DESCRIPTION
Update docs for ignoreNonExistingFolders. It is not nullable/default-able from the plugin perspective. The default is in the UI widget, actually.