### PR TITLE
Making Ignore Non-Existing Folders optional in all file batch batch sources

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AzureBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AzureBatchSource.java
@@ -89,7 +89,7 @@ public class AzureBatchSource extends FileBatchSource {
     public AzureBatchConfig(String referenceName, String path, String account, String container, String storageKey,
                             @Nullable String regex, @Nullable String timeTable, @Nullable String inputFormatClass,
                             @Nullable String fileSystemProperties, @Nullable Long maxSplitSize,
-                            Boolean ignoreNonExistingFolders) {
+                            @Nullable Boolean ignoreNonExistingFolders) {
       super(referenceName, path, regex, timeTable, inputFormatClass,
             updateFileSystemProperties(fileSystemProperties, account, container, storageKey),
             maxSplitSize, ignoreNonExistingFolders);
@@ -97,7 +97,7 @@ public class AzureBatchSource extends FileBatchSource {
       this.container = container;
       this.storageKey = storageKey;
       this.path = path;
-      this.ignoreNonExistingFolders = ignoreNonExistingFolders;
+      this.ignoreNonExistingFolders = ignoreNonExistingFolders == null ? false : ignoreNonExistingFolders;
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
@@ -89,19 +89,20 @@ public class FTPBatchSource extends FileBatchSource {
     @Macro
     public String inputFormatClassName;
 
+    @Nullable
     @Description("Identify if path needs to be ignored or not, for case when directory or file does not exists. If " +
       "set to true it will treat the not present folder as zero input and log a warning. Default is false.")
     public Boolean ignoreNonExistingFolders;
 
     public FTPBatchSourceConfig(String referenceName, String path, @Nullable String fileSystemProperties,
                                 @Nullable String fileRegex, @Nullable String inputFormatClassName,
-                                Boolean ignoreNonExistingFolders) {
+                                @Nullable Boolean ignoreNonExistingFolders) {
       super(referenceName);
       this.path = path;
       this.fileSystemProperties = fileSystemProperties;
       this.fileRegex = fileRegex;
       this.inputFormatClassName = inputFormatClassName;
-      this.ignoreNonExistingFolders = ignoreNonExistingFolders;
+      this.ignoreNonExistingFolders = ignoreNonExistingFolders == null ? false : ignoreNonExistingFolders;
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
@@ -264,6 +264,7 @@ public class FileBatchSource extends ReferenceBatchSource<LongWritable, Object, 
     @Macro
     public Long maxSplitSize;
 
+    @Nullable
     @Description("Identify if path needs to be ignored or not, for case when directory or file does not exists. If " +
       "set to true it will treat the not present folder as zero input and log a warning. Default is false.")
     public Boolean ignoreNonExistingFolders;
@@ -279,7 +280,7 @@ public class FileBatchSource extends ReferenceBatchSource<LongWritable, Object, 
 
     public FileBatchConfig(String referenceName, String path, @Nullable String fileRegex, @Nullable String timeTable,
                            @Nullable String inputFormatClass, @Nullable String fileSystemProperties,
-                           @Nullable Long maxSplitSize, Boolean ignoreNonExistingFolders) {
+                           @Nullable Long maxSplitSize, @Nullable Boolean ignoreNonExistingFolders) {
       super(referenceName);
       this.path = path;
       this.fileSystemProperties = fileSystemProperties == null ? GSON.toJson(ImmutableMap.<String, String>of()) :
@@ -289,7 +290,7 @@ public class FileBatchSource extends ReferenceBatchSource<LongWritable, Object, 
       this.timeTable = timeTable;
       this.inputFormatClass = inputFormatClass == null ? CombineTextInputFormat.class.getName() : inputFormatClass;
       this.maxSplitSize = maxSplitSize == null ? DEFAULT_MAX_SPLIT_SIZE : maxSplitSize;
-      this.ignoreNonExistingFolders = ignoreNonExistingFolders;
+      this.ignoreNonExistingFolders = ignoreNonExistingFolders == null ? false : ignoreNonExistingFolders;
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/S3BatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/S3BatchSource.java
@@ -85,7 +85,7 @@ public class S3BatchSource extends FileBatchSource {
     public S3BatchConfig(String referenceName, String accessID, String accessKey, String path, @Nullable String regex,
                          @Nullable String timeTable, @Nullable String inputFormatClass,
                          @Nullable String fileSystemProperties, @Nullable Long maxSplitSize,
-                         Boolean ignoreNonExistingFolders) {
+                         @Nullable Boolean ignoreNonExistingFolders) {
       super(referenceName, path, regex, timeTable, inputFormatClass,
             updateFileSystemProperties(fileSystemProperties, accessID, accessKey), maxSplitSize,
             ignoreNonExistingFolders);


### PR DESCRIPTION
The Ignore Non-Existing Folders was not optional config parameter, this might break the older pipelines