### PR TITLE
Update information on Git Submodules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,7 @@ You get started with Hydrator plugins by building directly from the latest sourc
 
   git clone https://github.com/caskdata/hydrator-plugins.git
   cd hydrator-plugins
-  git submodule init
-  git submodule update
+  git submodule update --init --recursive --remote
   mvn clean package
 
 After the build completes, you will have a JAR for each plugin under each


### PR DESCRIPTION
Update the information on Git Submodules to make it more succinct and to include `--remote` which will update the submodule to the latest HEAD on the configured branch.