### PR TITLE
[HYDRATOR-1085]Fixed TPFS Parquet Sink failure while writing byte[]

### DIFF
--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/StructuredtoAvroTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/StructuredtoAvroTest.java
@@ -23,6 +23,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+
 public class StructuredtoAvroTest {
 
   @Test
@@ -70,6 +72,32 @@ public class StructuredtoAvroTest {
     Assert.assertEquals(123L, result.get("id"));
     Assert.assertEquals("ABC", result.get("name"));
     Assert.assertNull(result.get("age"));
+  }
+
+  @Test
+  public void testByteArrayConversionToByteBuffer() throws Exception {
+    Schema outputSchema = Schema.recordOf("output",
+                                          Schema.Field.of("testForBytes", Schema.of(Schema.Type.BYTES)));
+    Schema inputSchema = Schema.recordOf("input",
+                                         Schema.Field.of("testForBytes", Schema.of(Schema.Type.BYTES)));
+    StructuredRecord record = StructuredRecord.builder(inputSchema).set("testForBytes", new byte[1234]).build();
+    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(outputSchema.toString());
+    GenericRecord result = avroTransformer.transform(record);
+    Assert.assertEquals(ByteBuffer.wrap(new byte[1234]), result.get("testForBytes"));
+  }
+
+  @Test
+  public void testByteArrayConversionToByteBufferForNullableField() throws Exception {
+    Schema outputSchema = Schema.recordOf("output",
+                                          Schema.Field.of("testForBytes",
+                                                          Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
+    Schema inputSchema = Schema.recordOf("input",
+                                         Schema.Field.of("testForBytes",
+                                                         Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
+    StructuredRecord record = StructuredRecord.builder(inputSchema).set("testForBytes", new byte[1234]).build();
+    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(outputSchema.toString());
+    GenericRecord result = avroTransformer.transform(record);
+    Assert.assertEquals(ByteBuffer.wrap(new byte[1234]), result.get("testForBytes"));
   }
 
 }


### PR DESCRIPTION
https://issues.cask.co/browse/HYDRATOR-1085

Verified for TPFS Parquet and Avro.TPFS Avro sink didnt have issue while writing byte[].
Tried to put the fix in RecordConverted.convertField but was not working/reflecting.