### PR TITLE
Fixed flaky tests.

### DIFF
--- a/cassandra-plugins/src/test/java/co/cask/hydrator/plugin/test/ETLCassandraTest.java
+++ b/cassandra-plugins/src/test/java/co/cask/hydrator/plugin/test/ETLCassandraTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.etl.proto.v2.ETLRealtimeConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.realtime.ETLRealtimeApplication;
 import co.cask.cdap.etl.realtime.ETLWorker;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
@@ -229,7 +230,7 @@ public class ETLCassandraTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     CqlResult result = client.execute_cql3_query(ByteBufferUtil.bytes("SELECT * from testtablebatch"),
                                                  Compression.NONE, ConsistencyLevel.ALL);
@@ -284,7 +285,7 @@ public class ETLCassandraTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> output = MockSink.readOutput(outputManager);

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLFTPTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLFTPTestRun.java
@@ -24,6 +24,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -131,7 +132,7 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 2, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("fileSink");
     try (TimePartitionedFileSet fileSet = fileSetManager.get()) {

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLMapReduceTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLMapReduceTestRun.java
@@ -30,6 +30,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -129,7 +130,7 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<KeyValueTable> table2 = getDataset("kvTable2");
     try (KeyValueTable outputTable = table2.get()) {
@@ -219,7 +220,7 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     // all records are passed to this table (validation not performed)
     DataSetManager<Table> outputManager1 = getDataset("dagOutputTable1");
@@ -324,7 +325,7 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset("outputTable");
     Table outputTable = outputManager.get();
@@ -404,7 +405,7 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 2, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("TPFSsink");
     try (TimePartitionedFileSet fileSet = fileSetManager.get()) {
@@ -466,7 +467,7 @@ public class ETLMapReduceTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 2, TimeUnit.MINUTES);
 
     for (String sinkName : new String[] { "fileSink1", "fileSink2" }) {
       DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(sinkName);

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLSnapshotTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLSnapshotTestRun.java
@@ -26,6 +26,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -108,7 +109,7 @@ public class ETLSnapshotTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("snapshotSinkTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("snapshotSinkTest-multisnapshot");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // run the pipeline once with some state in the table
@@ -122,7 +123,7 @@ public class ETLSnapshotTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     Map<String, Integer> expected = new HashMap<>();
     expected.put("id123", 777);
@@ -141,7 +142,7 @@ public class ETLSnapshotTestRun extends ETLBatchTestBase {
     inputManager.flush();
 
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 2, 5, TimeUnit.MINUTES);
     expected.clear();
     expected.put("id456", 100);
 
@@ -187,7 +188,7 @@ public class ETLSnapshotTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("snapshotSinkTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("snapshotSinkTest-snapshottext");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // run the pipeline once with some state in the table
@@ -202,7 +203,7 @@ public class ETLSnapshotTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     Set<String> expected = new HashSet<>();
     expected.add("id123\t777");
@@ -247,13 +248,13 @@ public class ETLSnapshotTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("snapshotSinkTest2");
+    ApplicationId appId = NamespaceId.DEFAULT.app(String.format("snapshotSinkTest_%s_%s", sourceETLPlugin, sourceName));
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     // run the pipeline, should see the 2nd state of the table
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<PartitionedFileSet> output = getDataset(outputName);
     Location partitionLocation = new SnapshotFileSet(output.get()).getLocation();

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLStreamConversionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLStreamConversionTestRun.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.proto.Engine;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -90,12 +91,12 @@ public class ETLStreamConversionTestRun extends ETLBatchTestBase {
     ETLBatchConfig etlConfig = constructETLBatchConfig(engine, streamName, filesetName, sinkType);
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app(String.format("app_%s", sinkType));
+    ApplicationId appId = NamespaceId.DEFAULT.app(String.format("app_%s_%s", engine, sinkType));
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     final WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(4, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 4, TimeUnit.MINUTES);
 
     // get the output fileset, and read the parquet/avro files it output.
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
@@ -24,6 +24,7 @@ import co.cask.cdap.etl.api.batch.PostAction;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -86,7 +87,7 @@ public class EmailActionTestRun extends ETLBatchTestBase {
 
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start(ImmutableMap.of("logical.start.time", "0"));
-    manager.waitForFinish(5, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     server.stop();
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/HDFSActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/HDFSActionTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -104,11 +105,11 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsFailedActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.FAILED, 1, 3, TimeUnit.MINUTES);
 
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/source/test.txt")));
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/source/test.json")));
@@ -146,11 +147,11 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsSuccessActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 3, TimeUnit.MINUTES);
 
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/dest/test.txt")));
     Assert.assertFalse(fileSystem.exists(new Path(outputDir.toUri().toString() + "/dest/test.json")));
@@ -190,11 +191,11 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsInvalidActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.FAILED, 1, 3, TimeUnit.MINUTES);
 
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/source/test.txt")));
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/source/test2.txt")));
@@ -239,7 +240,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 3, TimeUnit.MINUTES);
 
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/basicDir/test.json")));
     Assert.assertFalse(fileSystem.exists(new Path(outputDir.toUri().toString() + "/basicDir/test.txt")));
@@ -276,11 +277,11 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsDeleteActionTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("hdfsDeleteSingleFileNoRegexActionTest");
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     Assert.assertFalse(fileSystem.exists(new Path(outputDir.toUri().toString() + "/dir/test.txt")));
   }
@@ -320,7 +321,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 3, TimeUnit.MINUTES);
 
     Assert.assertFalse(fileSystem.exists(new Path(outputDir.toUri().toString() + "/singleDir/test.txt")));
     Assert.assertTrue(fileSystem.exists(new Path(outputDir.toUri().toString() + "/singleDir/test2.txt")));
@@ -363,7 +364,7 @@ public class HDFSActionTestRun extends ETLBatchTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(3, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 3, TimeUnit.MINUTES);
 
     Assert.assertFalse(fileSystem.isDirectory(new Path(outputDir.toUri().toString() + "/dir1/source")));
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/DedupTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/DedupTestRun.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -125,7 +126,7 @@ public class DedupTestRun extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> sinkManager = getDataset(sinkDatasetName);
     try (Table sinkTable = sinkManager.get()) {

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/GroupByTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/GroupByTestRun.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -180,7 +181,7 @@ public class GroupByTestRun extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> usersManager = getDataset(usersDatasetName);
     Table usersTable = usersManager.get();

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/RowDenormalizerAggregatorTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/RowDenormalizerAggregatorTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -143,7 +144,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> outputManager = getDataset(outputDatasetName);
     TimePartitionedFileSet fileSet = outputManager.get();
@@ -206,7 +207,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
       .addConnection(aggregateStage.getName(), sinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test-with-null");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data
@@ -263,7 +264,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> outputManager = getDataset(outputDatasetName);
     TimePartitionedFileSet fileSet = outputManager.get();
@@ -329,7 +330,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
       .addConnection(aggregateStage.getName(), sinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("denormalize-test-with-wrong-output");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // write input data
@@ -355,7 +356,7 @@ public class RowDenormalizerAggregatorTest extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> outputManager = getDataset(outputDatasetName);
     TimePartitionedFileSet fileSet = outputManager.get();

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/joiner/JoinerTestRun.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -152,7 +153,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
       .addConnection(joinStage.getName(), joinSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    ApplicationId appId = NamespaceId.DEFAULT.app("joiner-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("inner-joiner-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // ingest data
@@ -163,7 +164,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> outputManager = getDataset(joinedDatasetName);
     TimePartitionedFileSet fileSet = outputManager.get();
@@ -252,7 +253,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
       .addConnection(joinStage.getName(), joinSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    ApplicationId appId = NamespaceId.DEFAULT.app("joiner-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("outer-joiner-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // ingest data
@@ -263,7 +264,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> outputManager = getDataset(joinedDatasetName);
     TimePartitionedFileSet fileSet = outputManager.get();
@@ -352,7 +353,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
       .addConnection(joinStage.getName(), joinSinkStage.getName())
       .build();
     AppRequest<ETLBatchConfig> request = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
-    ApplicationId appId = NamespaceId.DEFAULT.app("joiner-test");
+    ApplicationId appId = NamespaceId.DEFAULT.app("outer-joiner-without-required-inputs-test");
     ApplicationManager appManager = deployApplication(appId, request);
 
     // ingest data
@@ -363,7 +364,7 @@ public class JoinerTestRun extends ETLBatchTestBase {
     // run the pipeline
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<TimePartitionedFileSet> outputManager = getDataset(joinedDatasetName);
     TimePartitionedFileSet fileSet = outputManager.get();

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/BatchCubeSinkTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/BatchCubeSinkTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -134,7 +135,7 @@ public class BatchCubeSinkTest extends ETLBatchTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     long endTs = System.currentTimeMillis() / 1000;
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/TableSinkTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/TableSinkTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -258,7 +259,7 @@ public class TableSinkTest extends ETLBatchTestBase {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.setRuntimeArgs(runTimeProperties);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
     // verify
     DataSetManager<Table> tableManager = getDataset("tableSinkName");
     Table table = tableManager.get();

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/FileBatchSourceTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -109,7 +110,7 @@ public class FileBatchSourceTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> output = MockSink.readOutput(outputManager);
@@ -137,13 +138,12 @@ public class FileBatchSourceTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("FileTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("InvalidFileTest");
 
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
-    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
+    workflowManager.waitForRuns(ProgramRunStatus.FAILED, 1, 5, TimeUnit.MINUTES);
   }
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSourceTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSourceTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -194,10 +195,10 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     return deployApplication(appId.toId(), appRequest);
   }
 
-  private void startMapReduceJob(ApplicationManager appManager) throws Exception {
+  private void startWorkflow(ApplicationManager appManager, ProgramRunStatus status) throws Exception {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(status, 1, 5, TimeUnit.MINUTES);
   }
 
   @Test
@@ -230,7 +231,7 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     createPreProcessedRecord(processedFileTable, preProcessedDate);
     createExpiredRecord(processedFileTable);
 
-    startMapReduceJob(appManager);
+    startWorkflow(appManager, ProgramRunStatus.COMPLETED);
 
     //Nmber of files processed
     List<String> processedFileList = getProcessedFileList(processedFileTable, preProcessedDate);
@@ -273,7 +274,7 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     Date preProcessedDate = new Date();
     createPreProcessedRecord(processedFileTable, preProcessedDate);
 
-    startMapReduceJob(appManager);
+    startWorkflow(appManager, ProgramRunStatus.COMPLETED);
 
     List<String> processedFileList = getProcessedFileList(processedFileTable, preProcessedDate);
     Assert.assertEquals(2, processedFileList.size());
@@ -301,7 +302,7 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     String outputDatasetName = "output-batchsink-test-invalid-node-path-archived-files";
     ApplicationManager appManager = deployApplication(sourceProperties, outputDatasetName,
                                                       "XMLReaderInvalidNodePathArchiveFilesTest");
-    startMapReduceJob(appManager);
+    startWorkflow(appManager, ProgramRunStatus.COMPLETED);
 
     //No records for invalid node path
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
@@ -336,7 +337,7 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     String outputDatasetName = "output-batchsink-test-pattern-move-files";
     ApplicationManager appManager = deployApplication(sourceProperties, outputDatasetName,
                                                       "XMLReaderWithPatternAndMoveFilesTest");
-    startMapReduceJob(appManager);
+    startWorkflow(appManager, ProgramRunStatus.COMPLETED);
 
     //Number of record derived from XML.
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
@@ -371,7 +372,7 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     String outputDatasetName = "output-batchsink-test-invalid-pattern-delete-files";
     ApplicationManager appManager = deployApplication(sourceProperties, outputDatasetName,
                                                       "XMLReaderInvalidPatternDeleteFilesTest");
-    startMapReduceJob(appManager);
+    startWorkflow(appManager, ProgramRunStatus.COMPLETED);
 
     //No record fetched as no pattern matching file
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBActionTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBActionTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -81,7 +82,7 @@ public class DBActionTestRun extends DatabasePluginTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start(ImmutableMap.of("logical.start.time", "0"));
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     try (Connection connection = getConnection()) {
       try (Statement statement = connection.createStatement()) {

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBQueryActionTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/action/DBQueryActionTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -82,7 +83,7 @@ public class DBQueryActionTestRun extends DatabasePluginTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start(ImmutableMap.of("logical.start.time", "0"));
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     try (Connection connection = getConnection()) {
       try (Statement statement = connection.createStatement()) {

--- a/elasticsearch-plugins/src/test/java/co/cask/hydrator/plugin/test/ETLESTest.java
+++ b/elasticsearch-plugins/src/test/java/co/cask/hydrator/plugin/test/ETLESTest.java
@@ -36,6 +36,7 @@ import co.cask.cdap.etl.proto.v2.ETLRealtimeConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.realtime.ETLRealtimeApplication;
 import co.cask.cdap.etl.realtime.ETLWorker;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
@@ -199,7 +200,7 @@ public class ETLESTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     SearchResponse searchResponse = client.prepareSearch("batch").execute().actionGet();
     Assert.assertEquals(2, searchResponse.getHits().getTotalHits());
@@ -243,7 +244,7 @@ public class ETLESTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/hbase-plugins/src/test/java/co/cask/hydrator/plugin/HBaseTest.java
+++ b/hbase-plugins/src/test/java/co/cask/hydrator/plugin/HBaseTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -183,7 +184,7 @@ public class HBaseTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     ResultScanner resultScanner = htable.getScanner(HBASE_FAMILY_COLUMN.getBytes());
     Result result;
@@ -227,7 +228,7 @@ public class HBaseTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/hdfs-plugins/src/test/java/co/cask/hydrator/plugin/HDFSSinkTest.java
+++ b/hdfs-plugins/src/test/java/co/cask/hydrator/plugin/HDFSSinkTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -156,7 +157,7 @@ public class HDFSSinkTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     Path[] outputFiles = FileUtil.stat2Paths(dfsCluster.getFileSystem().listStatus(
       outputDir, new Utils.OutputFileUtils.OutputFilesFilter()));
@@ -211,7 +212,7 @@ public class HDFSSinkTest extends HydratorTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("HDFSTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("HDFSTest-adding-jobproperties");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
@@ -223,7 +224,7 @@ public class HDFSSinkTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     Path[] outputFiles = FileUtil.stat2Paths(dfsCluster.getFileSystem().listStatus(
       outputDir, new Utils.OutputFileUtils.OutputFilesFilter()));

--- a/http-plugins/src/test/java/co/cask/hydrator/plugin/batch/HttpCallbackActionTest.java
+++ b/http-plugins/src/test/java/co/cask/hydrator/plugin/batch/HttpCallbackActionTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.realtime.ETLRealtimeApplication;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
@@ -156,7 +157,7 @@ public class HttpCallbackActionTest extends HydratorTestBase {
 
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     manager.start();
-    manager.waitForFinish(5, TimeUnit.MINUTES);
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     Assert.assertEquals(body, getFeedContent("users"));
   }

--- a/mongodb-plugins/src/test/java/co/cask/hydrator/plugin/test/MongoDBTest.java
+++ b/mongodb-plugins/src/test/java/co/cask/hydrator/plugin/test/MongoDBTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.etl.proto.v2.ETLRealtimeConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.realtime.ETLRealtimeApplication;
 import co.cask.cdap.etl.realtime.ETLWorker;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
@@ -231,7 +232,7 @@ public class MongoDBTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     MongoClient mongoClient = factory.newMongo();
     MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
@@ -287,7 +288,7 @@ public class MongoDBTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     MongoClient mongoClient = factory.newMongo();
     MongoDatabase mongoDatabase = mongoClient.getDatabase(MONGO_DB);
@@ -339,7 +340,7 @@ public class MongoDBTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/solrsearch-plugins/src/test/java/co/cask/hydrator/plugin/SolrSearchSinkTest.java
+++ b/solrsearch-plugins/src/test/java/co/cask/hydrator/plugin/SolrSearchSinkTest.java
@@ -33,6 +33,7 @@ import co.cask.cdap.etl.proto.v2.ETLRealtimeConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.realtime.ETLRealtimeApplication;
 import co.cask.cdap.etl.realtime.ETLWorker;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
@@ -429,7 +430,7 @@ public class SolrSearchSinkTest extends HydratorTestBase {
       .addConnection(source.getName(), sink.getName())
       .build();
 
-    ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrSink");
+    ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrSinkWrongHost");
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
@@ -444,9 +445,7 @@ public class SolrSearchSinkTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
-
-    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
+    workflowManager.waitForRuns(ProgramRunStatus.FAILED, 1, 5, TimeUnit.MINUTES);
   }
 
   @Test
@@ -488,9 +487,7 @@ public class SolrSearchSinkTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
-
-    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
+    workflowManager.waitForRuns(ProgramRunStatus.FAILED, 1, 5, TimeUnit.MINUTES);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/NormalizeTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/NormalizeTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -124,10 +125,10 @@ public class NormalizeTest extends TransformPluginsTestBase {
     return deployApplication(appId.toId(), appRequest);
   }
 
-  private void startMapReduceJob(ApplicationManager appManager) throws Exception {
+  private void startWorkflow(ApplicationManager appManager, ProgramRunStatus status) throws Exception {
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(status, 1, 5, TimeUnit.MINUTES);
   }
 
   @Test
@@ -261,7 +262,7 @@ public class NormalizeTest extends TransformPluginsTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    startMapReduceJob(applicationManager);
+    startWorkflow(applicationManager, ProgramRunStatus.COMPLETED);
 
     DataSetManager<Table> outputManager = getDataset(outputTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -299,7 +300,7 @@ public class NormalizeTest extends TransformPluginsTestBase {
     );
     MockSource.writeInput(inputManager, input);
 
-    startMapReduceJob(applicationManager);
+    startWorkflow(applicationManager, ProgramRunStatus.COMPLETED);
 
     DataSetManager<Table> outputManager = getDataset(outputTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/ValueMapperTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/ValueMapperTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -117,7 +118,7 @@ public class ValueMapperTest extends TransformPluginsTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -189,7 +190,7 @@ public class ValueMapperTest extends TransformPluginsTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -283,7 +284,7 @@ public class ValueMapperTest extends TransformPluginsTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/XMLParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/XMLParserTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.etl.mock.transform.MockTransformContext;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -110,7 +111,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -147,7 +148,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTestWithMultipleElements");
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
     DataSetManager<Table> inputManager = getDataset(inputTable);
@@ -172,7 +173,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+    workflowManager.waitForRuns(ProgramRunStatus.COMPLETED, 1, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(sinkTable);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -297,7 +298,7 @@ public class XMLParserTest extends TransformPluginsTestBase {
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(BATCH_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTest");
+    ApplicationId appId = NamespaceId.DEFAULT.app("XMLReaderTestError");
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
     DataSetManager<Table> inputManager = getDataset(inputTable);
@@ -312,7 +313,6 @@ public class XMLParserTest extends TransformPluginsTestBase {
     MockSource.writeInput(inputManager, input);
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     workflowManager.start();
-    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
-    Assert.assertEquals("FAILED", workflowManager.getHistory().get(0).getStatus().name());
+    workflowManager.waitForRuns(ProgramRunStatus.FAILED, 1, 5, TimeUnit.MINUTES);
   }
 }


### PR DESCRIPTION
`ProgramManager.waitForFinish()` methods calls the `status` endpoint to figure out if program is running. `status` endpoint checks if runtime info is available in the in-memory map. The runtime info for the program is added asynchronously through the listener mechanism, so it is possible that when program is started, status endpoint gets called before its runtime info is added to the in-memory map. Then the `ProgramManager.waitForFinish()` return immediately without running the program causing test case failures. 

This issue is more evident now since we added new listener for the Workflow(https://issues.cask.co/browse/CDAP-6008) which gets executed before the listener which adds runtime info to in-memory map.  