### PR TITLE
HYDRATOR-1384 fix json parser doc

### DIFF
--- a/transform-plugins/docs/JSONParser-transform.md
+++ b/transform-plugins/docs/JSONParser-transform.md
@@ -106,7 +106,7 @@ The mappings in the plugin will be:
 
 The "root member object" for parsing any JSON is referred to as ```$```, regardless of
 whether it's an array or an object. It also uses either dot notation or bracket notation for
-defining the levels of parsing. For example: ```$.employee.name``` or ```$[employee][name]```.
+defining the levels of parsing. For example: ```$.employee.name``` or ```$['employee']['name']```.
 
 #### Supported Operators
 

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/JSONParserTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/JSONParserTest.java
@@ -230,5 +230,27 @@ public class JSONParserTest {
     Assert.assertEquals("red", emitter.getEmitted().get(0).get("bicycle_color"));
     Assert.assertEquals(19.95, emitter.getEmitted().get(0).get("bicycle_price"));
     Assert.assertEquals(null, emitter.getEmitted().get(0).get("window"));
+
+    final String[] jsonPaths2 = {
+      "expensive:$['expensive']",
+      "bicycle_color:$['store']['bicycle']['color']",
+      "bicycle_price:$['store']['bicycle']['price']",
+      "window:$['store']['window']"
+    };
+
+    emitter.clear();
+    config = new JSONParser.Config("body", Joiner.on(",").join(jsonPaths2), OUTPUT5.toString());
+    transform = new JSONParser(config);
+
+    mockPipelineConfigurer = new MockPipelineConfigurer(INPUT1);
+    transform.configurePipeline(mockPipelineConfigurer);
+    transform.initialize(null);
+    transform.transform(StructuredRecord.builder(INPUT1)
+                          .set("body", json)
+                          .build(), emitter);
+    Assert.assertEquals(10, emitter.getEmitted().get(0).get("expensive"));
+    Assert.assertEquals("red", emitter.getEmitted().get(0).get("bicycle_color"));
+    Assert.assertEquals(19.95, emitter.getEmitted().get(0).get("bicycle_price"));
+    Assert.assertEquals(null, emitter.getEmitted().get(0).get("window"));
   }
 }


### PR DESCRIPTION
When specifying paths with brackets, elements in the bracket
need to be enclosed in single quotes.