### PR TITLE
[HYDRATOR-1326 and HYDRATOR-1373] Added support for IAM authentication to S3batchsource and S3batchsink.Added support for server side encryption in S3 batchsink

### DIFF
--- a/core-plugins/docs/S3-batchsource.md
+++ b/core-plugins/docs/S3-batchsource.md
@@ -17,9 +17,13 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**accessID:** Access ID of the Amazon S3 instance to connect to. (Macro-enabled)
+**authenticationMethod:** Authentication method to access S3. Defaults to Access Credentials.
+ User need to have AWS environment only to use IAM role based authentication.
+ For IAM, URI scheme should be s3a://. (Macro-enabled)
 
-**accessKey:** Access Key of the Amazon S3 instance to connect to. (Macro-enabled)
+**accessID:** Access ID of the Amazon S3 instance to connect to. Mandatory if authentication method is Access credentials. (Macro-enabled)
+
+**accessKey:** Access Key of the Amazon S3 instance to connect to. Mandatory if authentication method is Access credentials. (Macro-enabled)
 
 **path:** Path to file(s) to be read. If a directory is specified,
 terminate the path name with a '/'. The path uses filename expansion (globbing) to read files. (Macro-enabled)
@@ -49,7 +53,7 @@ exists. If set to true it will treat the not present folder as 0 input and log a
 
 Example
 -------
-This example connects to Amazon S3 and reads in files found in the specified directory while
+This example connects to Amazon S3 using Access Credentials and reads in files found in the specified directory while
 using the stateful ``timefilter``, which ensures that each file is read only once. The ``timefilter``
 requires that files be named with either the convention "yy-MM-dd-HH..." (S3) or "...'.'yy-MM-dd-HH..."
 (Cloudfront). The stateful metadata is stored in a table named 'timeTable'. With the maxSplitSize
@@ -60,6 +64,7 @@ configure Hadoop to use one mapper per MB:
         "name": "S3",
         "type": "batchsource",
         "properties": {
+            "authenticationMethod": "Access Credentials",
             "accessKey": "key",
             "accessID": "ID",
             "path": "s3n://path/to/logs/",

--- a/core-plugins/docs/S3Avro-batchsink.md
+++ b/core-plugins/docs/S3Avro-batchsink.md
@@ -19,6 +19,10 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
+**authenticationMethod:** Authentication method to access S3. Defaults to Access Credentials.
+ User need to have AWS environment only to use IAM role based authentication.
+ For IAM, URI scheme should be s3a://. (Macro-enabled)
+
 **accessID:** Access ID of the Amazon S3 instance to connect to. (Macro-enabled)
 
 **accessKey:** Access Key of the Amazon S3 instance to connect to. (Macro-enabled)
@@ -41,7 +45,7 @@ Valid values are None, Snappy, and Deflate.
 
 Example
 -------
-This example will write to an S3 output located at ``s3n://logs``. It will write data in
+This example will use Access Credentials authentication and write to an S3 output located at ``s3n://logs``. It will write data in
 Avro format compressed using Snappy format and using the given schema. Every time the pipeline 
 runs, a new output directory from the base path (``s3n://logs``) will be created which 
 will have the directory name corresponding to the start time in ``yyyy-MM-dd-HH-mm`` format:
@@ -50,6 +54,7 @@ will have the directory name corresponding to the start time in ``yyyy-MM-dd-HH-
         "name": "S3Avro",
         "type": "batchsink",
         "properties": {
+            "authenticationMethod": "Access Credentials",
             "accessKey": "key",
             "accessID": "ID",
             "basePath": "s3n://logs",

--- a/core-plugins/docs/S3Avro-batchsink.md
+++ b/core-plugins/docs/S3Avro-batchsink.md
@@ -29,6 +29,8 @@ Properties
 
 **basePath:** The S3 path where the data is stored. Example: 's3n://logs'. (Macro-enabled)
 
+**enableEncryption:** Server side encryption. Defaults to True. Sole supported algorithm is AES256. (Macro-enabled)
+
 **fileSystemProperties:** A JSON string representing a map of properties needed for the
 distributed file system. The property names needed for S3 (*accessID* and *accessKey*)
 will be included as ``'fs.s3n.awsSecretAccessKey'`` and ``'fs.s3n.awsAccessKeyId'``. (Macro-enabled)

--- a/core-plugins/docs/S3Parquet-batchsink.md
+++ b/core-plugins/docs/S3Parquet-batchsink.md
@@ -19,6 +19,10 @@ Properties
 ----------
 **referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
 
+**authenticationMethod:** Authentication method to access S3. Defaults to Access Credentials.
+ User need to have AWS environment only to use IAM role based authentication.
+ For IAM, URI scheme should be s3a://. (Macro-enabled)
+
 **accessID:** Access ID of the Amazon S3 instance to connect to. (Macro-enabled)
 
 **accessKey:** Access Key of the Amazon S3 instance to connect to. (Macro-enabled)

--- a/core-plugins/docs/S3Parquet-batchsink.md
+++ b/core-plugins/docs/S3Parquet-batchsink.md
@@ -29,6 +29,8 @@ Properties
 
 **basePath:** The S3 path where the data is stored. Example: 's3n://logs'. (Macro-enabled)
 
+**enableEncryption:** Server side encryption. Defaults to True. Sole supported algorithm is AES256. (Macro-enabled)
+
 **fileSystemProperties:** A JSON string representing a map of properties needed for the
 distributed file system. The property names needed for S3 (*accessID* and *accessKey*)
 will be included as ``'fs.s3n.awsSecretAccessKey'`` and ``'fs.s3n.awsAccessKeyId'``. (Macro-enabled)

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3AvroBatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3AvroBatchSink.java
@@ -98,8 +98,9 @@ public class S3AvroBatchSink extends S3BatchSink<AvroKey<GenericRecord>, NullWri
     @SuppressWarnings("unused")
     public S3AvroSinkConfig(String referenceName, String basePath, String schema, String accessID, String accessKey,
                             String pathFormat, String filesystemProperties, @Nullable String compressionCodec,
-                            String authenticationMethod) {
-      super(referenceName, basePath, accessID, accessKey, pathFormat, filesystemProperties, authenticationMethod);
+                            String authenticationMethod, String enableEncryption) {
+      super(referenceName, basePath, accessID, accessKey, pathFormat, filesystemProperties, authenticationMethod,
+            enableEncryption);
       this.schema = schema;
       this.compressionCodec = compressionCodec;
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3AvroBatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3AvroBatchSink.java
@@ -97,8 +97,9 @@ public class S3AvroBatchSink extends S3BatchSink<AvroKey<GenericRecord>, NullWri
 
     @SuppressWarnings("unused")
     public S3AvroSinkConfig(String referenceName, String basePath, String schema, String accessID, String accessKey,
-                            String pathFormat, String filesystemProperties, @Nullable String compressionCodec) {
-      super(referenceName, basePath, accessID, accessKey, pathFormat, filesystemProperties);
+                            String pathFormat, String filesystemProperties, @Nullable String compressionCodec,
+                            String authenticationMethod) {
+      super(referenceName, basePath, accessID, accessKey, pathFormat, filesystemProperties, authenticationMethod);
       this.schema = schema;
       this.compressionCodec = compressionCodec;
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3ParquetBatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3ParquetBatchSink.java
@@ -93,8 +93,9 @@ public class S3ParquetBatchSink extends S3BatchSink<Void, GenericRecord> {
     @SuppressWarnings("unused")
     public S3ParquetSinkConfig(String referenceName, String basePath, String schema, String accessID, String accessKey,
                                String pathFormat, String fileSystemProperties, String compressionCodec,
-                               String authenticationMethod) {
-      super(referenceName, basePath, accessID, accessKey, pathFormat, fileSystemProperties, authenticationMethod);
+                               String authenticationMethod, String enableEncryption) {
+      super(referenceName, basePath, accessID, accessKey, pathFormat, fileSystemProperties, authenticationMethod,
+            enableEncryption);
       this.schema = schema;
       this.compressionCodec = compressionCodec;
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3ParquetBatchSink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/S3ParquetBatchSink.java
@@ -49,6 +49,7 @@ public class S3ParquetBatchSink extends S3BatchSink<Void, GenericRecord> {
 
   private static final String SCHEMA_DESC = "The Parquet schema of the record being written to the sink as a JSON " +
     "object.";
+  private static final String PARQUET_AVRO_SCHEMA = "parquet.avro.schema";
 
   public S3ParquetBatchSink(S3ParquetSinkConfig config) {
     super(config);
@@ -91,8 +92,9 @@ public class S3ParquetBatchSink extends S3BatchSink<Void, GenericRecord> {
 
     @SuppressWarnings("unused")
     public S3ParquetSinkConfig(String referenceName, String basePath, String schema, String accessID, String accessKey,
-                               String pathFormat, String fileSystemProperties, String compressionCodec) {
-      super(referenceName, basePath, accessID, accessKey, pathFormat, fileSystemProperties);
+                               String pathFormat, String fileSystemProperties, String compressionCodec,
+                               String authenticationMethod) {
+      super(referenceName, basePath, accessID, accessKey, pathFormat, fileSystemProperties, authenticationMethod);
       this.schema = schema;
       this.compressionCodec = compressionCodec;
     }
@@ -110,6 +112,7 @@ public class S3ParquetBatchSink extends S3BatchSink<Void, GenericRecord> {
       SimpleDateFormat format = new SimpleDateFormat(config.pathFormat);
 
       conf = Maps.newHashMap();
+      conf.put(PARQUET_AVRO_SCHEMA, config.schema);
       conf.putAll(FileSetUtil.getParquetCompressionConfiguration(config.compressionCodec, config.schema, true));
       conf.put(FileOutputFormat.OUTDIR,
                String.format("%s/%s", config.basePath, format.format(context.getLogicalStartTime())));

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/S3BatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/S3BatchSource.java
@@ -41,6 +41,10 @@ public class S3BatchSource extends FileBatchSource {
   private static final String ACCESS_KEY_DESCRIPTION = "Access Key of the Amazon S3 instance to connect to.";
   private static final String AUTHENTICATION_METHOD = "Authentication method to access S3. " +
     "Defaults to Access Credentials. For IAM, URI scheme should be s3a://. (Macro-enabled)";
+  private static final String ACCESS_KEY = "fs.s3n.awsAccessKeyId";
+  private static final String SECRET_KEY = "fs.s3n.awsSecretAccessKey";
+  private static final String ACCESS_CREDENTIALS = "Access Credentials";
+  private static final String IAM = "IAM";
   private static final Gson GSON = new Gson();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() {
   }.getType();
@@ -71,9 +75,9 @@ public class S3BatchSource extends FileBatchSource {
     } else {
       providedProperties = GSON.fromJson(fileSystemProperties, MAP_STRING_STRING_TYPE);
     }
-    if (authenticationMethod.equalsIgnoreCase("Access Credentials")) {
-      providedProperties.put("fs.s3n.awsAccessKeyId", accessID);
-      providedProperties.put("fs.s3n.awsSecretAccessKey", accessKey);
+    if (authenticationMethod.equalsIgnoreCase(ACCESS_CREDENTIALS)) {
+      providedProperties.put(ACCESS_KEY, accessID);
+      providedProperties.put(SECRET_KEY, accessKey);
     }
     return GSON.toJson(providedProperties);
   }
@@ -115,7 +119,7 @@ public class S3BatchSource extends FileBatchSource {
     }
 
     private void validate(String authenticationMethod) {
-      if (authenticationMethod.equalsIgnoreCase("Access Credentials")) {
+      if (authenticationMethod.equalsIgnoreCase(ACCESS_CREDENTIALS)) {
         if (!containsMacro("accessID") && (accessID == null || accessID.isEmpty())) {
           throw new IllegalArgumentException("The Access ID must be specified if " +
                                                "authentication method is Access Credentials.");
@@ -123,6 +127,10 @@ public class S3BatchSource extends FileBatchSource {
         if (!containsMacro("accessKey") && (accessKey == null || accessKey.isEmpty())) {
           throw new IllegalArgumentException("The Access Key must be specified if " +
                                                "authentication method is Access Credentials.");
+        }
+      } else if (authenticationMethod.equalsIgnoreCase(IAM)) {
+        if (!path.startsWith("s3a://")) {
+          throw new IllegalArgumentException("Path must start with s3a:// for IAM based authentication.");
         }
       }
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/Properties.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/Properties.java
@@ -170,6 +170,7 @@ public final class Properties {
     public static final String SCHEMA = "schema";
     public static final String PATH_FORMAT = "pathFormat";
     public static final String AUTHENTICATION_METHOD = "authenticationMethod";
+    public static final String ENABLE_ENCRYPTION = "enableEncryption";
   }
 
   /**

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/Properties.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/Properties.java
@@ -169,6 +169,7 @@ public final class Properties {
     public static final String BASE_PATH = "basePath";
     public static final String SCHEMA = "schema";
     public static final String PATH_FORMAT = "pathFormat";
+    public static final String AUTHENTICATION_METHOD = "authenticationMethod";
   }
 
   /**

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/S3BatchSinkTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/S3BatchSinkTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 public class S3BatchSinkTest {
   private static final Gson GSON = new Gson();
-  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() {
+  }.getType();
 
   @Test
   public void testFileSystemProperties() {
@@ -37,9 +38,11 @@ public class S3BatchSinkTest {
     String accessKey = "accessKey";
     String path = "/path";
     String schema = "schema";
+    String authenticationMethod = "Access Credentials";
     // Test default properties
     S3AvroBatchSink.S3AvroSinkConfig s3AvroSinkConfig =
-      new S3AvroBatchSink.S3AvroSinkConfig("s3test", path, schema, accessID, accessKey, null, null, null);
+      new S3AvroBatchSink.S3AvroSinkConfig("s3test", path, schema, accessID, accessKey, null, null, null,
+                                           authenticationMethod);
     S3AvroBatchSink s3AvroBatchSink = new S3AvroBatchSink(s3AvroSinkConfig);
     S3BatchSink.S3BatchSinkConfig s3BatchSinkConfig = s3AvroBatchSink.getConfig();
     Map<String, String> fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
@@ -49,4 +52,19 @@ public class S3BatchSinkTest {
     Assert.assertEquals(accessKey, fsProperties.get("fs.s3n.awsSecretAccessKey"));
   }
 
+  @Test
+  public void testFileSystemPropertiesForIAM() {
+    String accessID = null;
+    String accessKey = null;
+    String path = "/path";
+    String schema = "schema";
+    String authenticationMethod = "IAM";
+    S3AvroBatchSink.S3AvroSinkConfig s3AvroSinkConfig =
+      new S3AvroBatchSink.S3AvroSinkConfig("s3iamtest", path, schema, accessID, accessKey, null, null, null,
+                                           authenticationMethod);
+    S3AvroBatchSink s3AvroBatchSink = new S3AvroBatchSink(s3AvroSinkConfig);
+    S3BatchSink.S3BatchSinkConfig s3BatchSinkConfig = s3AvroBatchSink.getConfig();
+    Map<String, String> fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    Assert.assertEquals(0, fsProperties.size());
+  }
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/S3BatchSinkTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/S3BatchSinkTest.java
@@ -39,29 +39,52 @@ public class S3BatchSinkTest {
     String path = "/path";
     String schema = "schema";
     String authenticationMethod = "Access Credentials";
+    String enableEncryption = "True";
+    String encryptionValue = "AES256";
     // Test default properties
     S3AvroBatchSink.S3AvroSinkConfig s3AvroSinkConfig =
       new S3AvroBatchSink.S3AvroSinkConfig("s3test", path, schema, accessID, accessKey, null, null, null,
-                                           authenticationMethod);
+                                           authenticationMethod, enableEncryption);
     S3AvroBatchSink s3AvroBatchSink = new S3AvroBatchSink(s3AvroSinkConfig);
     S3BatchSink.S3BatchSinkConfig s3BatchSinkConfig = s3AvroBatchSink.getConfig();
     Map<String, String> fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
     Assert.assertNotNull(fsProperties);
-    Assert.assertEquals(2, fsProperties.size());
+    Assert.assertEquals(3, fsProperties.size());
     Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
     Assert.assertEquals(accessKey, fsProperties.get("fs.s3n.awsSecretAccessKey"));
+    Assert.assertEquals(encryptionValue, fsProperties.get("fs.s3n.server-side-encryption-algorithm"));
   }
 
   @Test
-  public void testFileSystemPropertiesForIAM() {
+  public void testFileSystemPropertiesForIAMWithEncryption() {
     String accessID = null;
     String accessKey = null;
     String path = "/path";
     String schema = "schema";
     String authenticationMethod = "IAM";
+    String enableEncryption = "True";
+    String encryptionValue = "AES256";
     S3AvroBatchSink.S3AvroSinkConfig s3AvroSinkConfig =
       new S3AvroBatchSink.S3AvroSinkConfig("s3iamtest", path, schema, accessID, accessKey, null, null, null,
-                                           authenticationMethod);
+                                           authenticationMethod, enableEncryption);
+    S3AvroBatchSink s3AvroBatchSink = new S3AvroBatchSink(s3AvroSinkConfig);
+    S3BatchSink.S3BatchSinkConfig s3BatchSinkConfig = s3AvroBatchSink.getConfig();
+    Map<String, String> fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    Assert.assertEquals(1, fsProperties.size());
+    Assert.assertEquals(encryptionValue, fsProperties.get("fs.s3a.server-side-encryption-algorithm"));
+  }
+
+  @Test
+  public void testFileSystemPropertiesForIAMWithoutEncryption() {
+    String accessID = null;
+    String accessKey = null;
+    String path = "/path";
+    String schema = "schema";
+    String authenticationMethod = "IAM";
+    String enableEncryption = "False";
+    S3AvroBatchSink.S3AvroSinkConfig s3AvroSinkConfig =
+      new S3AvroBatchSink.S3AvroSinkConfig("s3iamtest", path, schema, accessID, accessKey, null, null, null,
+                                           authenticationMethod, enableEncryption);
     S3AvroBatchSink s3AvroBatchSink = new S3AvroBatchSink(s3AvroSinkConfig);
     S3BatchSink.S3BatchSinkConfig s3BatchSinkConfig = s3AvroBatchSink.getConfig();
     Map<String, String> fsProperties = GSON.fromJson(s3BatchSinkConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);

--- a/core-plugins/widgets/S3-batchsource.json
+++ b/core-plugins/widgets/S3-batchsource.json
@@ -12,6 +12,18 @@
           "name": "referenceName"
         },
         {
+          "widget-type": "select",
+          "label": "Authentication Method",
+          "name": "authenticationMethod",
+          "widget-attributes": {
+            "values": [
+              "Access Credentials",
+              "IAM"
+            ],
+            "default": "Access Credentials"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Access ID",
           "name": "accessID"

--- a/core-plugins/widgets/S3Avro-batchsink.json
+++ b/core-plugins/widgets/S3Avro-batchsink.json
@@ -13,6 +13,18 @@
           "name": "referenceName"
         },
         {
+          "widget-type": "select",
+          "label": "Authentication Method",
+          "name": "authenticationMethod",
+          "widget-attributes": {
+            "values": [
+              "Access Credentials",
+              "IAM"
+            ],
+            "default": "Access Credentials"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Access ID",
           "name": "accessID"

--- a/core-plugins/widgets/S3Avro-batchsink.json
+++ b/core-plugins/widgets/S3Avro-batchsink.json
@@ -46,6 +46,18 @@
         },
         {
           "widget-type": "select",
+          "label": "Server Side Encryption",
+          "name": "enableEncryption",
+          "widget-attributes": {
+            "values": [
+              "True",
+              "False"
+            ],
+            "default": "True"
+          }
+        },
+        {
+          "widget-type": "select",
           "label": "Compression Codec",
           "name": "compressionCodec",
           "widget-attributes": {

--- a/core-plugins/widgets/S3Parquet-batchsink.json
+++ b/core-plugins/widgets/S3Parquet-batchsink.json
@@ -13,6 +13,18 @@
           "name": "referenceName"
         },
         {
+          "widget-type": "select",
+          "label": "Authentication Method",
+          "name": "authenticationMethod",
+          "widget-attributes": {
+            "values": [
+              "Access Credentials",
+              "IAM"
+            ],
+            "default": "Access Credentials"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Access ID",
           "name": "accessID"

--- a/core-plugins/widgets/S3Parquet-batchsink.json
+++ b/core-plugins/widgets/S3Parquet-batchsink.json
@@ -46,6 +46,18 @@
         },
         {
           "widget-type": "select",
+          "label": "Server Side Encryption",
+          "name": "enableEncryption",
+          "widget-attributes": {
+            "values": [
+              "True",
+              "False"
+            ],
+            "default": "True"
+          }
+        },
+        {
+          "widget-type": "select",
           "label": "Compression Codec",
           "name": "compressionCodec",
           "widget-attributes": {


### PR DESCRIPTION
Design wiki: https://wiki.cask.co/display/CE/S3+IAM+Roles+Authentication+and+server+side+encryption
JIRA:https://issues.cask.co/browse/HYDRATOR-1326