### PR TITLE
HYDRATOR-703 exception if diver class is not loaded and its null

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -158,6 +158,12 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
       pluginContext.loadPluginClass(request.getJDBCPluginType(),
                                     request.jdbcPluginName, PluginProperties.builder().build());
 
+    if (driverClass == null) {
+      throw new InstantiationException(
+        String.format("Unable to load Driver class with plugin type %s and plugin name %s",
+                      request.getJDBCPluginType(), request.jdbcPluginName));
+    }
+
     try {
       return DBUtils.ensureJDBCDriverIsAvailable(driverClass, request.connectionString,
                                                  request.getJDBCPluginType(), request.jdbcPluginName);


### PR DESCRIPTION
currently when we can't load the driver class (null), we still try to ensure it exists and throw NPE during the process. rather we should do null check earlier.
https://issues.cask.co/browse/HYDRATOR-703