### PR TITLE
Hydrator-1423 fix for getting messageField from schema

### DIFF
--- a/spark-plugins/docs/Kafka-streamingsource.md
+++ b/spark-plugins/docs/Kafka-streamingsource.md
@@ -39,8 +39,8 @@ Offsets are inclusive. If an offset of 5 is used, the message at offset 5 will b
 Kafka message key, the schema must include a field of type bytes or nullable bytes, and you must set the
 keyField property to that field's name. Similarly, if you would like the output records to contain a field with
 the timestamp of when the record was read, the schema must include a field of type long or nullable long, and you
-must set the timeField property to that field's name. Any field that is not the timeField or keyField will be used
-in conjuction with the format to parse Kafka message payloads.
+must set the timeField property to that field's name. Any field that is not the timeField, keyField, partitionField or 
+offsetField will be used in conjuction with the format to parse Kafka message payloads.
 
 **format:** Optional format of the Kafka event message. Any format supported by CDAP is supported.
 For example, a value of 'csv' will attempt to parse Kafka payloads as comma-separated values.

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaConfig.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaConfig.java
@@ -78,7 +78,7 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
   @Macro
   private Long defaultInitialOffset;
 
-  @Description("Output schema of the source, including the timeField and keyField. " +
+  @Description("Output schema of the source, including the timeField, keyField, partitionField and offsetField. " +
     "The fields excluding the timeField and keyField are used in conjunction with the format " +
     "to parse Kafka payloads.")
   private String schema;

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaStreamingSource.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/KafkaStreamingSource.java
@@ -207,7 +207,7 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
 
     @Override
     public StructuredRecord call(MessageAndMetadata in) throws Exception {
-      // first time this was called, initialize schema and time, key, and message fields.
+      // first time this was called, initialize schema and time, key, partition, offset and message fields.
       if (schema == null) {
         schema = conf.getSchema();
         timeField = conf.getTimeField();
@@ -216,7 +216,8 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
         offsetField = conf.getOffsetField();
         for (Schema.Field field : schema.getFields()) {
           String name = field.getName();
-          if (!name.equals(timeField) && !name.equals(keyField)) {
+          if (!name.equals(timeField) && !name.equals(keyField) && !name.equals(partitionField) &&
+            !name.equals(offsetField)) {
             messageField = name;
             break;
           }

--- a/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/SparkPluginTest.java
+++ b/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/SparkPluginTest.java
@@ -331,8 +331,6 @@ public class SparkPluginTest extends HydratorTestBase {
   }
 
   @Test
-  @Ignore
-  // TODO: https://issues.cask.co/browse/HYDRATOR-1194
   public void testKafkaStreamingSource() throws Exception {
     Schema schema = Schema.recordOf(
       "user",


### PR DESCRIPTION
Since Hydrator 1194 is fixed, unignore the test case for KafkaStreamingSource
Build: http://builds.cask.co/browse/HYP-BAD242-1