### PR TITLE
Fix unit test

### DIFF
--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSinkTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSinkTestRun.java
@@ -150,7 +150,7 @@ public class DBSinkTestRun extends DatabasePluginTestBase {
       inputRecords.add(StructuredRecord.builder(schema)
         .set("ID", i)
         .set("NAME", name)
-        .set("SCORE", 3.451)
+        .set("SCORE", 3.451f)
         .set("GRADUATED", (i % 2 == 0))
         .set("TINY", i + 1)
         .set("SMALL", i + 2)


### PR DESCRIPTION
Failure before the fix 

```java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Float
	at co.cask.cdap.format.io.StructuredRecordDatumWriter.encode(StructuredRecordDatumWriter.java:85)
	at co.cask.cdap.format.io.JsonStructuredRecordDatumWriter.encodeRecordField(JsonStructuredRecordDatumWriter.java:84)
	at co.cask.cdap.format.io.StructuredRecordDatumWriter.encodeRecord(StructuredRecordDatumWriter.java:307)
	at co.cask.cdap.format.io.StructuredRecordDatumWriter.encode(StructuredRecordDatumWriter.java:107)
	at co.cask.cdap.format.io.StructuredRecordDatumWriter.encode(StructuredRecordDatumWriter.java:59)
	at co.cask.cdap.format.io.JsonStructuredRecordDatumWriter.encode(JsonStructuredRecordDatumWriter.java:37)
	at co.cask.cdap.format.StructuredRecordStringConverter.toJsonString(StructuredRecordStringConverter.java:51)
	at co.cask.cdap.etl.mock.batch.MockSource.writeInput(MockSource.java:169)
	at co.cask.cdap.etl.mock.batch.MockSource.writeInput(MockSource.java:144)
	at co.cask.hydrator.plugin.db.batch.sink.DBSinkTestRun.createInputData(DBSinkTestRun.java:171)
	at co.cask.hydrator.plugin.db.batch.sink.DBSinkTestRun.testDBSink(DBSinkTestRun.java:69)```