### PR TITLE
Feature/fix unit test

### DIFF
--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLFTPTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/ETLFTPTestRun.java
@@ -38,7 +38,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockftpserver.fake.FakeFtpServer;
 import org.mockftpserver.fake.UserAccount;
@@ -97,10 +96,6 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
     }
   }
 
-  // TODO: https://issues.cask.co/browse/CDAP-5480
-  // In unit-test, the classpath has hadoop-common jar ahead of cdap-app-fabric and hence the modified
-  // FTPInputStream.java in cdap-app-fabric is not getting picked up. Hence ignoring the test.
-  @Ignore
   @Test
   public void testFTPBatchSource() throws Exception {
     ETLStage source = new ETLStage("source", new ETLPlugin(
@@ -110,6 +105,7 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
         .put(Properties.File.PATH, String.format("ftp://%s:%s@localhost:%d%s",
                                                  USER, PWD, port, folder.getAbsolutePath()))
         .put(Properties.File.IGNORE_NON_EXISTING_FOLDERS, "false")
+        .put("referenceName", "ftp")
         .build(),
       null));
     ETLStage sink = new ETLStage("sink", new ETLPlugin(

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.text.SimpleDateFormat;
@@ -165,14 +166,14 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
     Assert.assertEquals(CURRENT_TS, (long) row1.get("TIMESTAMP_COL"));
     Assert.assertEquals(CURRENT_TS, (long) row2.get("TIMESTAMP_COL"));
     // verify binary columns
-    Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("BINARY_COL"), 0, 5));
-    Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("BINARY_COL"), 0, 5));
-    Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("LONGVARBINARY_COL"), 0, 5));
-    Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("LONGVARBINARY_COL"), 0, 5));
-    Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("VARBINARY_COL"), 0, 5));
-    Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("VARBINARY_COL"), 0, 5));
-    Assert.assertEquals("user1", Bytes.toString((byte[]) row1.get("BLOB_COL"), 0, 5));
-    Assert.assertEquals("user2", Bytes.toString((byte[]) row2.get("BLOB_COL"), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString(((ByteBuffer) row1.get("BINARY_COL")).array(), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(((ByteBuffer) row2.get("BINARY_COL")).array(), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString(((ByteBuffer) row1.get("LONGVARBINARY_COL")).array(), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(((ByteBuffer) row2.get("LONGVARBINARY_COL")).array(), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString(((ByteBuffer) row1.get("VARBINARY_COL")).array(), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(((ByteBuffer) row2.get("VARBINARY_COL")).array(), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString(((ByteBuffer) row1.get("BLOB_COL")).array(), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(((ByteBuffer) row2.get("BLOB_COL")).array(), 0, 5));
     Assert.assertEquals(CLOB_DATA, row1.get("CLOB_COL"));
     Assert.assertEquals(CLOB_DATA, row2.get("CLOB_COL"));
   }


### PR DESCRIPTION
Failure before the fix
```java.lang.ClassCastException: java.nio.HeapByteBuffer cannot be cast to [B
	at co.cask.hydrator.plugin.db.batch.sink.DBSourceTestRun.testDBSource(DBSourceTestRun.java:168)```