### PR TITLE
Revert "HYDRATOR-488 Create fat JAR with shade"

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>org.python</groupId>
       <artifactId>jython-standalone</artifactId>
+      <version>2.5.2</version>
     </dependency>
     <!-- Start for JMS Source -->
     <dependency>
@@ -244,36 +245,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.0.0</version>
-        <configuration>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>2.5.4</version>
@@ -294,13 +265,16 @@
               <!-- Used by S3 source/sink -->
               org.apache.http.*
             </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
           </instructions>
         </configuration>
         <executions>
           <execution>
-            <phase>process-classes</phase>
+            <phase>package</phase>
             <goals>
-              <goal>manifest</goal>
+              <goal>bundle</goal>
             </goals>
           </execution>
         </executions>

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import javax.annotation.Nullable;
 
 /**
@@ -347,12 +346,6 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
   }
 
   private void init() {
-
-    // This is necessary to prevent 'ImportError' being thrown by Jython
-    Properties properties = new Properties();
-    properties.put("python.import.site", "false");
-    PythonInterpreter.initialize(System.getProperties(), properties, new String[0]);
-
     interpreter = new PythonInterpreter();
     interpreter.set(CONTEXT_NAME, new ScriptContext(
       logger, metrics,

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <twill.version>0.9.0</twill.version>
     <twitter4j.version>4.0.3</twitter4j.version>
     <zookeeper.version>3.4.5</zookeeper.version>
-    <jython.version>2.7.0</jython.version>
+    <jython.version>2.5.2</jython.version>
     <json-path.version>2.2.0</json-path.version>
     <json.version>20160212</json.version>
     <!-- properties for script build step that creates the config files for the artifacts -->


### PR DESCRIPTION
This reverts commit ca99ef9. This
should solve the issue where the JAR produced is massive compared to
before this commit.

At some point, we should probably move the PythonEvaluator plugin into
its own package, though.