### PR TITLE
CDAP-8132 add file path as an output field in file source

### DIFF
--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -36,11 +36,18 @@ left blank. If it's currently *2015-06-16-15* (June 16th 2015, 3pm), it will rea
 in files that contain *2015-06-16-14* in the filename. If the field ``timeTable`` is
 present, then it will read in files that have not yet been read. (Macro-enabled)
 
+**pathField:** If specified, each output record will include a field with this name that contains the file URI
+that the record was read from. Requires a customized version of CombineFileInputFormat, so it cannot be used if
+an inputFormatClass is given.
+
+**filenameOnly:** If true and a pathField is specified, only the filename will be used.
+If false, the full URI will be used. Defaults to false.
+
 **timeTable:** Name of the Table that keeps track of the last time files
 were read in. (Macro-enabled)
 
-**inputFormatClass:** Name of the input format class, which must be a
-subclass of FileInputFormat. Defaults to CombineTextInputFormat. (Macro-enabled)
+**inputFormatClass:** Name of the input format class, which must be a subclass of FileInputFormat.
+Cannot be used if pathField is set. (Macro-enabled)
 
 **maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB. (Macro-enabled)
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AzureBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AzureBatchSource.java
@@ -21,13 +21,9 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
 
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * {@link BatchSource} for Azure Blob Store.
@@ -36,33 +32,13 @@ import javax.annotation.Nullable;
 @Name("AzureBlobStore")
 @Description("Batch source to read from Azure Blob Storage.")
 public class AzureBatchSource extends FileBatchSource {
-  private static final Gson GSON = new Gson();
-  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
   @SuppressWarnings("unused")
   private final AzureBatchConfig config;
 
   public AzureBatchSource(AzureBatchConfig config) {
-    super(new FileBatchConfig(config.referenceName, config.path, config.fileRegex, config.timeTable,
-                              config.inputFormatClass, updateFileSystemProperties(
-                                config.fileSystemProperties, config.account, config.container, config.storageKey),
-                              config.maxSplitSize, config.ignoreNonExistingFolders, config.recursive));
+    super(config);
     this.config = config;
-  }
-
-  private static String updateFileSystemProperties(@Nullable String fileSystemProperties, String account,
-                                                   String container, String storageKey) {
-    Map<String, String> providedProperties;
-    if (fileSystemProperties == null) {
-      providedProperties = new HashMap<>();
-    } else {
-      providedProperties = GSON.fromJson(fileSystemProperties, MAP_STRING_STRING_TYPE);
-    }
-    providedProperties.put("fs.defaultFS", String.format("wasb://%s@%s/", container, account));
-    providedProperties.put("fs.wasb.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
-    providedProperties.put("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
-    providedProperties.put(String.format("fs.azure.account.key.%s", account), storageKey);
-    return GSON.toJson(providedProperties);
   }
 
   /**
@@ -71,34 +47,25 @@ public class AzureBatchSource extends FileBatchSource {
   public static class AzureBatchConfig extends FileBatchConfig {
     @Description("The Microsoft Azure Storage account to use.")
     @Macro
-    private final String account;
+    private String account;
 
     @Description("The container to use on the specified Microsoft Azure Storage account.")
     @Macro
-    private final String container;
+    private String container;
 
     @Description("The storage key for the specified container on the specified Azure Storage account. Must be a " +
       "valid base64 encoded storage key provided by Microsoft Azure.")
     @Macro
-    private final String storageKey;
+    private String storageKey;
 
-    public AzureBatchConfig(String referenceName, String path, String account, String container, String storageKey) {
-      this(referenceName, path, account, container, storageKey, null, null, null, null, null, false, false);
-    }
-
-    public AzureBatchConfig(String referenceName, String path, String account, String container, String storageKey,
-                            @Nullable String regex, @Nullable String timeTable, @Nullable String inputFormatClass,
-                            @Nullable String fileSystemProperties, @Nullable Long maxSplitSize,
-                            @Nullable Boolean ignoreNonExistingFolders, @Nullable Boolean recursive) {
-      super(referenceName, path, regex, timeTable, inputFormatClass,
-            updateFileSystemProperties(fileSystemProperties, account, container, storageKey),
-            maxSplitSize, ignoreNonExistingFolders, recursive);
-      this.account = account;
-      this.container = container;
-      this.storageKey = storageKey;
-      this.path = path;
-      this.ignoreNonExistingFolders = ignoreNonExistingFolders == null ? false : ignoreNonExistingFolders;
-      this.recursive = recursive == null ? false : recursive;
+    @Override
+    protected Map<String, String> getFileSystemProperties() {
+      Map<String, String> properties = new HashMap<>(super.getFileSystemProperties());
+      properties.put("fs.defaultFS", String.format("wasb://%s@%s/", container, account));
+      properties.put("fs.wasb.impl", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+      properties.put("fs.AbstractFileSystem.wasb.impl", "org.apache.hadoop.fs.azure.Wasb");
+      properties.put(String.format("fs.azure.account.key.%s", account), storageKey);
+      return properties;
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/CombinePathTrackingInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/CombinePathTrackingInputFormat.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.source;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+
+import java.io.IOException;
+
+/**
+ * Similar to CombineTextInputFormat except it uses PathTrackingInputFormat to keep track of filepaths that
+ * records were read from.
+ */
+public class CombinePathTrackingInputFormat extends CombineFileInputFormat<NullWritable, StructuredRecord> {
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord> createRecordReader(InputSplit split, TaskAttemptContext context)
+    throws IOException {
+    return new CombineFileRecordReader<>((CombineFileSplit) split, context, RecordReaderWrapper.class);
+  }
+
+  /**
+   * Required because CombineFileRecordReader expects a specific constructor signature.
+   */
+  private static class RecordReaderWrapper extends CombineFileRecordReaderWrapper<NullWritable, StructuredRecord> {
+    // this constructor signature is required by CombineFileRecordReader
+    RecordReaderWrapper(CombineFileSplit split, TaskAttemptContext context,
+                        Integer idx) throws IOException, InterruptedException {
+      super(new PathTrackingInputFormat(), split, context, idx);
+    }
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/PathTrackingInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/PathTrackingInputFormat.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.source;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * An input format that tracks which the file path each record was read from.
+ */
+public class PathTrackingInputFormat extends FileInputFormat<NullWritable, StructuredRecord> {
+  private static final String PATH_FIELD = "path.tracking.path.field";
+  private static final String FILENAME_ONLY = "path.tracking.filename.only";
+
+  /**
+   * Configure the input format to use the specified schema and optional path field.
+   */
+  public static void configure(Configuration conf, @Nullable String pathField, boolean filenameOnly) {
+    if (pathField != null) {
+      conf.set(PATH_FIELD, pathField);
+    }
+    conf.setBoolean(FILENAME_ONLY, filenameOnly);
+  }
+
+  public static Schema getOutputSchema(@Nullable String pathField) {
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.add(Schema.Field.of("offset", Schema.of(Schema.Type.LONG)));
+    fields.add(Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    if (pathField != null) {
+      fields.add(Schema.Field.of(pathField, Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    }
+    return Schema.recordOf("file.record", fields);
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord> createRecordReader(InputSplit split,
+                                                                         TaskAttemptContext context)
+    throws IOException, InterruptedException {
+
+    if (!(split instanceof FileSplit)) {
+      // should never happen
+      throw new IllegalStateException("Input split is not a FileSplit.");
+    }
+
+    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    FileSplit fileSplit = (FileSplit) split;
+    String pathField = context.getConfiguration().get(PATH_FIELD);
+    boolean filenameOnly = context.getConfiguration().getBoolean(FILENAME_ONLY, false);
+    String path = filenameOnly ? fileSplit.getPath().getName() : fileSplit.getPath().toUri().toString();
+
+    return new TrackingTextRecordReader(delegate, pathField, path);
+  }
+
+  private static class TrackingTextRecordReader extends RecordReader<NullWritable, StructuredRecord> {
+    private final RecordReader<LongWritable, Text> delegate;
+    private final Schema schema;
+    private final String pathField;
+    private final String path;
+
+    private TrackingTextRecordReader(RecordReader<LongWritable, Text> delegate, @Nullable String pathField,
+                                     String path) {
+      this.delegate = delegate;
+      this.pathField = pathField;
+      this.path = path;
+      schema = getOutputSchema(pathField);
+    }
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+      delegate.initialize(split, context);
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+      return delegate.nextKeyValue();
+    }
+
+    @Override
+    public NullWritable getCurrentKey() throws IOException, InterruptedException {
+      return NullWritable.get();
+    }
+
+    @Override
+    public StructuredRecord getCurrentValue() throws IOException, InterruptedException {
+      LongWritable key = delegate.getCurrentKey();
+      Text text = delegate.getCurrentValue();
+
+      StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema)
+        .set("offset", key.get())
+        .set("body", text.toString());
+      if (pathField != null) {
+        recordBuilder.set(pathField, path);
+      }
+      return recordBuilder.build();
+    }
+
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+      return delegate.getProgress();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/S3BatchSourceConfigTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/S3BatchSourceConfigTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.hydrator.plugin.batch.source;
 
-import co.cask.cdap.etl.mock.common.MockPipelineConfigurer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
@@ -29,24 +28,20 @@ import java.util.Map;
 /**
  * Tests for {@link S3BatchSource} configuration.
  */
-public class S3BatchSourceTest {
+public class S3BatchSourceConfigTest {
   private static final Gson GSON = new Gson();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() {
   }.getType();
 
   @Test
   public void testFileSystemProperties() {
-    String referenceName = "s3source";
     String accessID = "accessID";
     String accessKey = "accessKey";
-    String path = "/path";
     String authenticationMethod = "Access Credentials";
     // Test default properties
-    S3BatchSource.S3BatchConfig s3BatchConfig = new S3BatchSource.S3BatchConfig(referenceName, accessID, accessKey,
-                                                                                path, authenticationMethod);
-    S3BatchSource s3BatchSource = new S3BatchSource(s3BatchConfig);
-    FileBatchSource.FileBatchConfig fileBatchConfig = s3BatchSource.getConfig();
-    Map<String, String> fsProperties = GSON.fromJson(fileBatchConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    S3BatchSource.S3BatchConfig s3BatchConfig = new S3BatchSource.S3BatchConfig(accessID, accessKey,
+                                                                                authenticationMethod);
+    Map<String, String> fsProperties = s3BatchConfig.getFileSystemProperties();
     Assert.assertNotNull(fsProperties);
     Assert.assertEquals(2, fsProperties.size());
     Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
@@ -54,12 +49,9 @@ public class S3BatchSourceTest {
 
 
     // Test extra properties
-    s3BatchConfig = new S3BatchSource.S3BatchConfig(referenceName, accessID, accessKey, path, null, null, null,
-                                                    GSON.toJson(ImmutableMap.of("s3.compression", "gzip")), null,
-                                                    false, false, authenticationMethod);
-    s3BatchSource = new S3BatchSource(s3BatchConfig);
-    fileBatchConfig = s3BatchSource.getConfig();
-    fsProperties = GSON.fromJson(fileBatchConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    s3BatchConfig = new S3BatchSource.S3BatchConfig(accessID, accessKey, authenticationMethod,
+                                                    ImmutableMap.of("s3.compression", "gzip"));
+    fsProperties = s3BatchConfig.getFileSystemProperties();
     Assert.assertNotNull(fsProperties);
     Assert.assertEquals(3, fsProperties.size());
     Assert.assertEquals(accessID, fsProperties.get("fs.s3n.awsAccessKeyId"));
@@ -69,16 +61,10 @@ public class S3BatchSourceTest {
 
   @Test
   public void testFileSystemPropertiesForIAM() {
-    String referenceName = "s3sourceIAM";
-    String accessID = null;
-    String accessKey = null;
-    String path = "/path";
     String authenticationMethod = "IAM";
-    S3BatchSource.S3BatchConfig s3BatchConfig = new S3BatchSource.S3BatchConfig(referenceName, accessID, accessKey,
-                                                                                path, authenticationMethod);
-    S3BatchSource s3BatchSource = new S3BatchSource(s3BatchConfig);
-    FileBatchSource.FileBatchConfig fileBatchConfig = s3BatchSource.getConfig();
-    Map<String, String> fsProperties = GSON.fromJson(fileBatchConfig.fileSystemProperties, MAP_STRING_STRING_TYPE);
+    S3BatchSource.S3BatchConfig s3BatchConfig = new S3BatchSource.S3BatchConfig(null, null,
+                                                                                authenticationMethod);
+    Map<String, String> fsProperties = s3BatchConfig.getFileSystemProperties();
     Assert.assertEquals(0, fsProperties.size());
   }
 }

--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -4,7 +4,7 @@
   },
   "configuration-groups": [
     {
-      "label": "File Batch Source Properties",
+      "label": "Input Properties",
       "properties": [
         {
           "widget-type": "textbox",
@@ -23,18 +23,58 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Time Table",
-          "name": "timeTable"
+          "label": "Maximum Split Size",
+          "name": "maxSplitSize"
         },
+        {
+          "widget-type": "select",
+          "label": "Read files recursively",
+          "name": "recursive",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Output Schema Properties",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Path Field",
+          "name": "pathField",
+          "plugin-function": {
+            "method": "POST",
+            "widget": "outputSchema",
+            "output-property": "schema",
+            "plugin-method": "getSchema"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Use File Name as Path Field",
+          "name": "filenameOnly",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Advanced Properties",
+      "properties": [
         {
           "widget-type": "textbox",
           "label": "Input Format Class",
           "name": "inputFormatClass"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Maximum Split Size",
-          "name": "maxSplitSize"
         },
         {
           "widget-type": "json-editor",
@@ -54,25 +94,18 @@
           }
         },
         {
-          "widget-type": "select",
-          "label": "Read files recursively",
-          "name": "recursive",
-          "widget-attributes": {
-            "values": [
-              "true",
-              "false"
-            ],
-            "default": "false"
-          }
+          "widget-type": "textbox",
+          "label": "Time Table",
+          "name": "timeTable"
         }
       ]
     }
   ],
   "outputs": [
     {
-      "widget-type": "non-editable-schema-editor",
+      "widget-type": "schema",
       "schema": {
-        "name": "etlSchemaBody",
+        "name": "fileRecord",
         "type": "record",
         "fields": [
           {


### PR DESCRIPTION
Adds an optional property for the file source to include the file
path that the record came from. The property cannot be used if
the input format class is set.

Also contains some refactoring with children of the FileBatchSource
to override config methods instead of some odd constructor json
string manipulation that was happening.