### PR TITLE
HYDRATOR-1436 Honour the column case in schema

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
@@ -70,4 +70,8 @@ public class DBConfig extends ConnectionConfig {
     }
     return query.substring(0, idx + 1);
   }
+
+  public FieldCase getFieldCase() {
+    return FieldCase.toFieldCase(columnNameCase);
+  }
 }

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/FieldCase.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/FieldCase.java
@@ -37,4 +37,16 @@ public enum FieldCase {
       return FieldCase.NONE;
     }
   }
+
+  public String convertCase(String input) {
+    switch (this) {
+      case LOWER:
+        return input.toLowerCase();
+      case UPPER:
+        return input.toUpperCase();
+      case NONE:
+      default: // Fallthrough to make the compiler happy
+        return input;
+    }
+  }
 }

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/StructuredRecordUtils.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/StructuredRecordUtils.java
@@ -45,7 +45,7 @@ public class StructuredRecordUtils {
     Map<String, String> fieldNameMap = new HashMap<>();
     List<Schema.Field> newFields = new ArrayList<>();
     for (Schema.Field field : oldSchema.getFields()) {
-      String newName = changeName(field.getName(), fieldCase);
+      String newName = fieldCase.convertCase(field.getName());
       if (fieldNameMap.containsValue(newName)) {
         // field name used already. indication of field names conflict. can't do anything.
         throw new IllegalStateException(String.format(
@@ -63,16 +63,5 @@ public class StructuredRecordUtils {
   }
 
   private StructuredRecordUtils() {
-  }
-
-  private static String changeName(String oldName, FieldCase fieldCase) {
-    switch (fieldCase) {
-      case LOWER:
-        return oldName.toLowerCase();
-      case UPPER:
-        return oldName.toUpperCase();
-      default:
-        return oldName;
-    }
   }
 }

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
@@ -72,7 +72,7 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
   private final DBSinkConfig dbSinkConfig;
   private final DBManager dbManager;
   private Class<? extends Driver> driverClass;
-  private int [] columnTypes;
+  private int[] columnTypes;
   private List<String> columns;
 
   public DBSink(DBSinkConfig dbSinkConfig) {
@@ -167,16 +167,12 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
                                                                dbSinkConfig.columns, dbSinkConfig.tableName))
       ) {
         ResultSetMetaData resultSetMetadata = rs.getMetaData();
-        FieldCase fieldCase = FieldCase.toFieldCase(dbSinkConfig.columnNameCase);
+        FieldCase fieldCase = dbSinkConfig.getFieldCase();
         // JDBC driver column indices start with 1
         for (int i = 0; i < rs.getMetaData().getColumnCount(); i++) {
           String name = resultSetMetadata.getColumnName(i + 1);
           int type = resultSetMetadata.getColumnType(i + 1);
-          if (fieldCase == FieldCase.LOWER) {
-            name = name.toLowerCase();
-          } else if (fieldCase == FieldCase.UPPER) {
-            name = name.toUpperCase();
-          }
+          name = fieldCase.convertCase(name);
           columnToType.put(name, type);
         }
       }


### PR DESCRIPTION
This commit also refactors the FieldCase class such that it can be used
directly to convert Strings.

This has been tested on the CDAP SDK.

JIRA: https://issues.cask.co/browse/HYDRATOR-1445
JIRA: https://issues.cask.co/browse/HYDRATOR-1436
Bamboo: https://builds.cask.co/browse/HYP-BAD286