### PR TITLE
CDAP-11417 fix a bug with byte fields in parquet and avro sinks

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToAvroTransformer.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToAvroTransformer.java
@@ -67,17 +67,17 @@ public class StructuredToAvroTransformer extends RecordConverter<StructuredRecor
       if (schemaField == null) {
         throw new IllegalArgumentException("Input record does not contain the " + fieldName + " field.");
       }
-      co.cask.cdap.api.data.schema.Schema schemaFieldSchema = schemaField.getSchema();
-      co.cask.cdap.api.data.schema.Schema.Type inputFieldType = (schemaFieldSchema.isNullableSimple())
-        ? schemaFieldSchema.getNonNullable().getType()
-        : schemaFieldSchema.getType();
-      if (inputFieldType.equals(co.cask.cdap.api.data.schema.Schema.Type.BYTES)) {
-        recordBuilder.set(fieldName, ByteBuffer.wrap((byte[]) structuredRecord.get(fieldName)));
-      } else {
-        recordBuilder.set(fieldName, convertField(structuredRecord.get(fieldName), schemaField.getSchema()));
-      }
+      recordBuilder.set(fieldName, convertField(structuredRecord.get(fieldName), schemaField.getSchema()));
     }
     return recordBuilder.build();
+  }
+
+  @Override
+  protected Object convertBytes(Object field) {
+    if (field instanceof ByteBuffer) {
+      return field;
+    }
+    return ByteBuffer.wrap((byte[]) field);
   }
 
   private Schema getAvroSchema(co.cask.cdap.api.data.schema.Schema cdapSchema) {

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/StructuredtoAvroTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/StructuredtoAvroTest.java
@@ -76,28 +76,39 @@ public class StructuredtoAvroTest {
 
   @Test
   public void testByteArrayConversionToByteBuffer() throws Exception {
-    Schema outputSchema = Schema.recordOf("output",
-                                          Schema.Field.of("testForBytes", Schema.of(Schema.Type.BYTES)));
-    Schema inputSchema = Schema.recordOf("input",
-                                         Schema.Field.of("testForBytes", Schema.of(Schema.Type.BYTES)));
-    StructuredRecord record = StructuredRecord.builder(inputSchema).set("testForBytes", new byte[1234]).build();
-    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(outputSchema.toString());
+    Schema schema = Schema.recordOf("output",
+                                    Schema.Field.of("byteArray", Schema.of(Schema.Type.BYTES)),
+                                    Schema.Field.of("byteBuffer", Schema.of(Schema.Type.BYTES)));
+    byte[] bytes = new byte[]{ 1, 2, 3, 4 };
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("byteArray", bytes)
+      .set("byteBuffer", ByteBuffer.wrap(bytes))
+      .build();
+    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(schema.toString());
     GenericRecord result = avroTransformer.transform(record);
-    Assert.assertEquals(ByteBuffer.wrap(new byte[1234]), result.get("testForBytes"));
+    Assert.assertEquals(ByteBuffer.wrap(bytes), result.get("byteBuffer"));
+    Assert.assertEquals(ByteBuffer.wrap(bytes), result.get("byteArray"));
   }
 
   @Test
   public void testByteArrayConversionToByteBufferForNullableField() throws Exception {
-    Schema outputSchema = Schema.recordOf("output",
-                                          Schema.Field.of("testForBytes",
-                                                          Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
-    Schema inputSchema = Schema.recordOf("input",
-                                         Schema.Field.of("testForBytes",
-                                                         Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
-    StructuredRecord record = StructuredRecord.builder(inputSchema).set("testForBytes", new byte[1234]).build();
-    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(outputSchema.toString());
+    Schema schema = Schema.recordOf("output",
+                                    Schema.Field.of("byteArray", Schema.nullableOf(Schema.of(Schema.Type.BYTES))),
+                                    Schema.Field.of("byteBuffer", Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
+    byte[] bytes = new byte[]{ 1, 2, 3, 4 };
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("byteArray", bytes)
+      .set("byteBuffer", ByteBuffer.wrap(bytes))
+      .build();
+    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(schema.toString());
     GenericRecord result = avroTransformer.transform(record);
-    Assert.assertEquals(ByteBuffer.wrap(new byte[1234]), result.get("testForBytes"));
-  }
+    Assert.assertEquals(ByteBuffer.wrap(bytes), result.get("byteBuffer"));
+    Assert.assertEquals(ByteBuffer.wrap(bytes), result.get("byteArray"));
 
+    // test nulls
+    record = StructuredRecord.builder(schema).build();
+    result = avroTransformer.transform(record);
+    Assert.assertNull(result.get("byteBuffer"));
+    Assert.assertNull(result.get("byteArray"));
+  }
 }

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/RecordConverter.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/RecordConverter.java
@@ -104,6 +104,7 @@ public abstract class RecordConverter<INPUT, OUTPUT> {
       case STRING:
         return field.toString();
       case BYTES:
+        return convertBytes(field);
       case INT:
       case LONG:
       case FLOAT:
@@ -113,5 +114,9 @@ public abstract class RecordConverter<INPUT, OUTPUT> {
       default:
         throw new UnexpectedFormatException("field type " + fieldType + " is not supported.");
     }
+  }
+
+  protected Object convertBytes(Object field) {
+    return field;
   }
 }


### PR DESCRIPTION
Fixed a bug introduced when a fix was added to convert
byte[] fields to ByteBuffers, but which caused ClassCastExceptions
when the field actually contained a ByteBuffer and not a byte[].

Also cleaned up the logic to avoid a special case for bytes.
Also improved a weird unit test that was testing conversion
using empty byte arrays.