### PR TITLE
adding validations and documentation

### DIFF
--- a/core-plugins/docs/XMLReader-batchsource.md
+++ b/core-plugins/docs/XMLReader-batchsource.md
@@ -9,41 +9,42 @@ The XML Reader plugin is a source plugin that allows users to read XML files sto
 Use Case
 --------
 A user would like to read XML files that have been dropped into HDFS.
-These can be small to very large XML files. The XMLReader will read and parse the files,
+These can range in size from small to very large XML files. The XMLReader will read and parse the files,
 and when used in conjunction with the XMLParser plugin, fields can be extracted.
 This reader emits one XML event, specified by the node path property, for each file read.
 
 
 Properties
 ----------
-| Configuration | Required | Default | Description |
-| :------------ | :------: | :------ | :---------- |
-| **Reference Name** | **Y** | None | This will be used to uniquely identify this source for lineage, annotating metadata, etc. |
-| **Path** | **Y** | None | Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'. This leverages glob syntax as described in the [Java Documentation](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob). |
-| **Pattern** | **N** | None | The Rrgular expression pattern used to select specific file(s). This should be used in cases when the glob syntax in the ``Path`` is not precise enough. See examples in the Usage Notes. |
-| **Node Path** | **Y** | None | Node path (XPath) to emit as an individual event from the XML schema. Example: '/book/price' to read only the price from under the book node. For more information about XPaths, see the [Java Documentation](https://docs.oracle.com/javase/tutorial/jaxp/xslt/xpath.html). |
-| **Action After Process** | **Y** | None | Action to be taken after processing of the XML file. Possible actions are: 1. Delete from the HDFS; 2. Archived to the target location; and 3. Moved to the target location. |
-| **Target Folder** | **N** | None | Target folder path if user select action after process, either ARCHIVE or MOVE. Target folder must be an existing directory. |
-| **Reprocessing Required?** | **Y** | Yes | Specifies whether the file(s) should be reprocessed. If set to No, the files are tracked and will not be processed again on future runs of the pipeline. |
-| **Table Name** | **N** | None | When keeping track of processed files, this is the name of the Table dataset used to store the data. This is required when Reprocessing is set to No. |
-| **Table Expiry Period** | **N** | None | The amount of time (in days) to wait before clearing the table used to track processed filed. If omitted, data will not expire in the tracking table. Example: For tableExpiryPeriod = 30, data before 30 days get deleted from the table. |
-| **Temporary Folder** | **Y** | None | An existing folder path with read and write access for the current user. This is required for storing temporary files containing paths of the processed XML files. These temporary files will be read at the end of the job to update the file track table. Defaults to /tmp. |
+| Configuration              | Required | Default | Description                                                                                                                                                                                                                                                                     |
+| :------------------------- | :------: | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Reference Name**         |  **Y**   | None    | This will be used to uniquely identify this source for lineage, annotating metadata, etc.                                                                                                                                                                                       |
+| **Path**                   |  **Y**   | None    | Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'. This leverages glob syntax as described in the [Java Documentation](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob).                                       |
+| **Pattern**                |  **N**   | None    | The regular expression pattern used to select specific files. This should be used in cases when the glob syntax in the `Path` is not precise enough. See examples in the Usage Notes.                                                                                           |
+| **Node Path**              |  **Y**   | None    | Node path (XPath) to emit as an individual event from the XML schema. Example: '/book/price' to read only the price from under the book node. For more information about XPaths, see the [Java Documentation](https://docs.oracle.com/javase/tutorial/jaxp/xslt/xpath.html).    |
+| **Action After Process**   |  **Y**   | None    | Action to be taken after processing of the XML file. Possible actions are: (DELETE) delete from HDFS; (ARCHIVE) archive to the target location; and (MOVE) move to the target location.                                                                                         |
+| **Target Folder**          |  **N**   | None    | Target folder path if the user select an action for after the process, either one of ARCHIVE or MOVE. Target folder must be an existing directory.                                                                                                                              |
+| **Reprocessing Required?** |  **Y**   | Yes     | Specifies whether the files should be reprocessed. If set to `No`, the files are tracked and will not be processed again on future runs of the pipeline.                                                                                                                        |
+| **Table Name**             |  **N**   | None    | When keeping track of processed files, this is the name of the Table dataset used to store the data. This is required when reprocessing is set to `No`.                                                                                                                         |
+| **Table Expiry Period**    |  **N**   | None    | The amount of time (in days) to wait before clearing the table used to track processed filed. If omitted, data will not expire in the tracking table. Example: for `tableExpiryPeriod = 30`, data before 30 days is deleted from the table.                                     |
+| **Temporary Folder**       |  **Y**   | None    | An existing folder path with read and write access for the current user. This is required for storing temporary files containing paths of the processed XML files. These temporary files will be read at the end of the job to update the file track table. Defaults to `/tmp`. |
+
 
 Usage Notes
 -----------
+When specifying a regular expression for filtering files, you must use glob syntax in the folder path.
+This usually means ending the path with '/*'.
 
-When specifying a Regular Expression for filtering files, you must use glob syntax in the folder path. This usually just means ending the path with a /*.
-
-When using a Regular Expression pattern, here are some examples:
+Here are some regular expression pattern examples:
 1. Use '^' to select files with names starting with 'catalog', such as '^catalog'.
 2. Use '$' to select files with names ending with 'catalog.xml', such as 'catalog.xml$'.
-3. Use '.\*' to select file with name contains 'catalogBook', such as 'catalogBook.*'.
+3. Use '.\*' to select files with a name that contains 'catalogBook', such as 'catalogBook.*'.
 
 
 Example
 -------
 This example reads data from the folder "hdfs:/cask/source/xmls/" and emits XML records on the basis of the node path
-"/catalog/book/title". It will generate structured records with fields 'offset', 'fileName', and 'record'.
+"/catalog/book/title". It will generate structured records with the fields 'offset', 'fileName', and 'record'.
 It will move the XML files to the target folder "hdfs:/cask/target/xmls/" and update the processed file information
 in the table named "trackingTable".
 

--- a/core-plugins/docs/XMLReader-batchsource.md
+++ b/core-plugins/docs/XMLReader-batchsource.md
@@ -16,41 +16,29 @@ This reader emits one XML event, specified by the node path property, for each f
 
 Properties
 ----------
-**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+| Configuration | Required | Default | Description |
+| :------------ | :------: | :------ | :---------- |
+| **Reference Name** | **Y** | None | This will be used to uniquely identify this source for lineage, annotating metadata, etc. |
+| **Path** | **Y** | None | Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'. This leverages glob syntax as described in the [Java Documentation](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob). |
+| **Pattern** | **N** | None | The Rrgular expression pattern used to select specific file(s). This should be used in cases when the glob syntax in the ``Path`` is not precise enough. See examples in the Usage Notes. |
+| **Node Path** | **Y** | None | Node path (XPath) to emit as an individual event from the XML schema. Example: '/book/price' to read only the price from under the book node. For more information about XPaths, see the [Java Documentation](https://docs.oracle.com/javase/tutorial/jaxp/xslt/xpath.html). |
+| **Action After Process** | **Y** | None | Action to be taken after processing of the XML file. Possible actions are: 1. Delete from the HDFS; 2. Archived to the target location; and 3. Moved to the target location. |
+| **Target Folder** | **N** | None | Target folder path if user select action after process, either ARCHIVE or MOVE. Target folder must be an existing directory. |
+| **Reprocessing Required?** | **Y** | Yes | Specifies whether the file(s) should be reprocessed. If set to No, the files are tracked and will not be processed again on future runs of the pipeline. |
+| **Table Name** | **N** | None | When keeping track of processed files, this is the name of the Table dataset used to store the data. This is required when Reprocessing is set to No. |
+| **Table Expiry Period** | **N** | None | The amount of time (in days) to wait before clearing the table used to track processed filed. If omitted, data will not expire in the tracking table. Example: For tableExpiryPeriod = 30, data before 30 days get deleted from the table. |
+| **Temporary Folder** | **Y** | None | An existing folder path with read and write access for the current user. This is required for storing temporary files containing paths of the processed XML files. These temporary files will be read at the end of the job to update the file track table. Defaults to /tmp. |
 
-**path:** Path to file(s) to be read. If a directory is specified, terminate the path name with a '/'. (Macro-enabled)
+Usage Notes
+-----------
 
-**nodePath:** Node path to emit as an individual event from the XML schema.
-Example: '/book/price' to read only the price from under the book node. (Macro-enabled)
+When specifying a Regular Expression for filtering files, you must use glob syntax in the folder path. This usually just means ending the path with a /*.
 
-**pattern:** Pattern to select specific file(s). (Optional) (Macro-enabled)
-Examples:
-
+When using a Regular Expression pattern, here are some examples:
 1. Use '^' to select files with names starting with 'catalog', such as '^catalog'.
 2. Use '$' to select files with names ending with 'catalog.xml', such as 'catalog.xml$'.
-3. Use '\*' to select file with name contains 'catalogBook', such as 'catalogBook*'.
+3. Use '.\*' to select file with name contains 'catalogBook', such as 'catalogBook.*'.
 
-**actionAfterProcess:** Action to be taken after processing of the XML file.
-Possible actions are:
-
-1. Delete from the HDFS;
-2. Archived to the target location; and
-3. Moved to the target location.
-
-**targetFolder:** Target folder path if user select action after process, either ARCHIVE or MOVE.
-Target folder must be an existing directory. (Optional) (Macro-enabled)
-
-**reprocessingRequired:** Specifies whether the file(s) should be reprocessed.
-
-**tableName:** Table name to be used to keep track of processed file(s). (Macro-enabled)
-
-**tableExpiryPeriod:** Expiry period (days) for data in the table. Data will be persisted in the table if no expiry
-period is provided. Example: For tableExpiryPeriod = 30, data before 30 days get deleted from the table. (Macro-enabled)
-
-**temporaryFolder:** An existing HDFS folder path with read and write access for the current user;
-required for storing temporary files containing paths of the processed XML files.
-These temporary files will be read at the end of the job to update the file track table.
-Default to /tmp. (Macro-enabled)
 
 Example
 -------
@@ -66,8 +54,8 @@ in the table named "trackingTable".
                     "type": "batchsource",
                     "properties":{
                                   "referenceName": "referenceName""
-                                  "path": "hdfs:/cask/source/xmls/",
-                                  "Pattern": "^catalog"
+                                  "path": "hdfs:/cask/source/xmls/*",
+                                  "Pattern": "^catalog.*"
                                   "nodePath": "/catalog/book/title"
                                   "actionAfterProcess" : "Move",
                                   "targetFolder":"hdfs:/cask/target/xmls/",

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
@@ -349,8 +349,8 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
         if (path.endsWith("/") ||
           !(path.contains("*") || path.contains("?") || path.contains("{") || path.contains("["))) {
           throw new IllegalArgumentException("When filtering with regular expressions, " +
-                                               "the Path must be a directory and leverage glob syntax. Most likely, " +
-                                               "you just need to end your folder path with a /*");
+                                               "the path must be a directory and leverage glob syntax. Usually " +
+                                               "the folder path needs to end with '/*'.");
         }
       }
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
@@ -63,6 +63,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -336,6 +337,22 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
         actionAfterProcess.equalsIgnoreCase("MOVE")) && Strings.isNullOrEmpty(targetFolder);
       Preconditions.checkArgument(!targetFolderEmpty, "Target folder cannot be empty for Action = '" +
         actionAfterProcess + "'.");
+
+      if (!Strings.isNullOrEmpty(pattern)) {
+        try {
+          Pattern.compile(pattern);
+        } catch (Exception e) {
+          throw new IllegalArgumentException(String.format("The regular expression '%s' is not valid.", pattern), e);
+        }
+        // By default, the Hadoop FileInputFormat won't return any files when using a regex pattern unless the path
+        // has globs in it. Checking for that scenario.
+        if (path.endsWith("/") ||
+          !(path.contains("*") || path.contains("?") || path.contains("{") || path.contains("["))) {
+          throw new IllegalArgumentException("When filtering with regular expressions, " +
+                                               "the Path must be a directory and leverage glob syntax. Most likely, " +
+                                               "you just need to end your folder path with a /*");
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This is meant to solve https://issues.cask.co/browse/CDAP-10241 and https://issues.cask.co/browse/CDAP-10158

Since this uses the default FileInputFormat, I am working around some limitations when using patterns in the config. Hopefully, the added validations and docs will help others in the future.

No unit tests since the unit tests for this plugin are ignored right now anyway