### PR TITLE
CDAP-11843 make schema request a concrete class

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AbstractFileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AbstractFileBatchSource.java
@@ -218,7 +218,18 @@ public abstract class AbstractFileBatchSource<T extends FileSourceConfig>
    * @return output schema
    */
   @javax.ws.rs.Path("getSchema")
-  public Schema getSchema(T request, EndpointPluginContext pluginContext) {
+  public Schema getSchema(SchemaRequest request, EndpointPluginContext pluginContext) {
     return PathTrackingInputFormat.getOutputSchema(request.pathField);
+  }
+
+  /**
+   * Concrete class used to get schema by the UI.
+   */
+  public static class SchemaRequest extends FileSourceConfig {
+
+    @Override
+    protected String getPath() {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
This fixes a bug where the endpoint throws an error, because CDAP
is unable to instantiate the request, since the request used to
be a generic that extends an abstract class.