### PR TITLE
The rowField of TableSourceConfig need to be mandatory

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/TableSourceConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/TableSourceConfig.java
@@ -43,7 +43,6 @@ public class TableSourceConfig extends BatchReadableWritableConfig {
   @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
   @Description("Optional record field for which row key will be considered as value instead of row column. " +
     "The field name specified must be present in the schema, and must not be nullable.")
-  @Nullable
   @Macro
   private String rowField;
 


### PR DESCRIPTION
The description say “must not be nullable” , but here  still contain an
annotation of “@Nullable”. It’s opposite.
And after my testing, if pipeline doesn’t contain this field, result
will failed.