### PR TITLE
CDAP-12137 add null field splitter

### DIFF
--- a/transform-plugins/docs/NullFieldSplitter-splittertransform.md
+++ b/transform-plugins/docs/NullFieldSplitter-splittertransform.md
@@ -1,0 +1,64 @@
+# Null Field Splitter
+
+
+Description
+-----------
+This plugin is used when you want to split records based on whether a specific field is null or not.
+Records with a null value for the field are sent to the ``null`` port while records with a non-null
+value are sent to the ``nonnull`` port.
+
+Properties
+----------
+**field:** Specifies which field should be checked for null values.
+
+**modifySchema:** Whether to modify the schema for non-null output.
+If set to true, the schema for non-null output will be modified so that the field is no longer nullable.
+Defaults to true.
+
+Example
+-------
+
+    {
+        "name": "NullFieldSplitter",
+        "type": "splittertransform"
+        "properties": {
+            "field": "email",
+            "modifySchema": "true"
+        }
+    }
+
+This example takes splits input based on whether the ``email`` field is null.
+For example, if the input to the plugin is:
+
+     +======================================================+
+     | id (long) | name (string) | email (nullable string)  |
+     +======================================================+
+     | 0         | alice         |                          |
+     | 1         | bob           |                          |
+     | 2         | carl          | karl@example.com         |
+     | 3         | duncan        | duncandonuts@example.com |
+     | 4         | evelyn        |                          |
+     | 5         | frank         | frankfurter@example.com  |
+     | 6         | gary          | gerry@example.com        |
+     +======================================================+
+
+then records emitted to the ``null`` port will be:
+
+     +======================================================+
+     | id (long) | name (string) | email (nullable string)  |
+     +======================================================+
+     | 0         | alice         |                          |
+     | 1         | bob           |                          |
+     | 4         | evelyn        |                          |
+     +======================================================+
+
+and records emitted to the ``nonnull`` port will be:
+
+     +======================================================+
+     | id (long) | name (string) | email (string)           |
+     +======================================================+
+     | 2         | carl          | karl@example.com         |
+     | 3         | duncan        | duncandonuts@example.com |
+     | 5         | frank         | frankfurter@example.com  |
+     | 6         | gary          | gerry@example.com        |
+     +======================================================+

--- a/transform-plugins/docs/NullFieldSplitter-splittertransform.md
+++ b/transform-plugins/docs/NullFieldSplitter-splittertransform.md
@@ -9,7 +9,7 @@ value are sent to the ``nonnull`` port.
 
 Properties
 ----------
-**field:** Specifies which field should be checked for null values.
+**field:** Specifies which field should be checked for null values. (Macro-enabled)
 
 **modifySchema:** Whether to modify the schema for non-null output.
 If set to true, the schema for non-null output will be modified so that the field is no longer nullable.

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/NullFieldSplitter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/NullFieldSplitter.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.MultiOutputEmitter;
+import co.cask.cdap.etl.api.MultiOutputPipelineConfigurer;
+import co.cask.cdap.etl.api.MultiOutputStageConfigurer;
+import co.cask.cdap.etl.api.SplitterTransform;
+import co.cask.cdap.etl.api.TransformContext;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Splits input data into two outputs based on whether a configurable field is null or not.
+ */
+@Plugin(type = SplitterTransform.PLUGIN_TYPE)
+@Name("NullFieldSplitter")
+@Description("This plugin is used when you want to split records based on whether a specific field is null or not. " +
+  "Records with a null value for the field are sent to the 'null' port while records with a non-null " +
+  "value are sent to the 'nonnull' port.")
+public class NullFieldSplitter extends SplitterTransform<StructuredRecord, StructuredRecord> {
+  public static final String NULL_PORT = "null";
+  public static final String NON_NULL_PORT = "nonnull";
+  private final Conf conf;
+  // only used when input schema is variable
+  private Map<Schema, Schema> schemaMap;
+
+  public NullFieldSplitter(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void configurePipeline(MultiOutputPipelineConfigurer multiOutputPipelineConfigurer) {
+    MultiOutputStageConfigurer stageConfigurer = multiOutputPipelineConfigurer.getMultiOutputStageConfigurer();
+    Schema inputSchema = stageConfigurer.getInputSchema();
+    if (inputSchema != null) {
+      stageConfigurer.setOutputSchemas(getOutputSchemas(inputSchema));
+    }
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    schemaMap = new HashMap<>();
+    Schema inputSchema = context.getInputSchema();
+    if (inputSchema != null) {
+      Schema nonNullSchema = getNonNullSchema(context.getInputSchema(), conf.field);
+      schemaMap.put(inputSchema, nonNullSchema);
+    }
+  }
+
+  @Override
+  public void transform(StructuredRecord record, MultiOutputEmitter<StructuredRecord> emitter) {
+    Schema recordSchema = record.getSchema();
+    Object val = record.get(conf.field);
+    if (val == null) {
+      emitter.emit(NULL_PORT, record);
+    } else if (!conf.modifySchema) {
+      emitter.emit(NON_NULL_PORT, record);
+    } else {
+      Schema outputSchema = schemaMap.get(recordSchema);
+      if (outputSchema == null) {
+        outputSchema = getNonNullSchema(recordSchema, conf.field);
+        schemaMap.put(recordSchema, outputSchema);
+      }
+      StructuredRecord.Builder builder = StructuredRecord.builder(outputSchema);
+      for (Schema.Field recordField : record.getSchema().getFields()) {
+        String fieldName = recordField.getName();
+        builder.set(fieldName, record.get(fieldName));
+      }
+      emitter.emit(NON_NULL_PORT, builder.build());
+    }
+  }
+
+  private Map<String, Schema> getOutputSchemas(Schema inputSchema) {
+    Map<String, Schema> outputs = new HashMap<>();
+    if (inputSchema.getField(conf.field) == null) {
+      throw new IllegalArgumentException("Field " + conf.field + " does not exist in input schema.");
+    }
+
+    outputs.put(NULL_PORT, inputSchema);
+    outputs.put(NON_NULL_PORT, conf.modifySchema ? getNonNullSchema(inputSchema, conf.field) : inputSchema);
+
+    return outputs;
+  }
+
+  @VisibleForTesting
+  static Schema getNonNullSchema(Schema nullableSchema, String fieldName) {
+    List<Schema.Field> fields = new ArrayList<>(nullableSchema.getFields().size());
+    for (Schema.Field field : nullableSchema.getFields()) {
+      Schema fieldSchema = field.getSchema();
+      if (!field.getName().equals(fieldName) || fieldSchema.getType() != Schema.Type.UNION) {
+        fields.add(field);
+        continue;
+      }
+
+      List<Schema> unionSchemas = fieldSchema.getUnionSchemas();
+      List<Schema> fieldSchemas = new ArrayList<>(unionSchemas.size());
+      for (Schema unionSchema : unionSchemas) {
+        if (unionSchema.getType() != Schema.Type.NULL) {
+          fieldSchemas.add(unionSchema);
+        }
+      }
+
+      if (fieldSchemas.isEmpty()) {
+        throw new IllegalArgumentException(
+          String.format("Field '%s' does not contain a non-null type in its union schema.", fieldName));
+      } else if (fieldSchemas.size() == 1) {
+        fields.add(Schema.Field.of(fieldName, fieldSchemas.iterator().next()));
+      } else {
+        fields.add(Schema.Field.of(fieldName, Schema.unionOf(fieldSchemas)));
+      }
+    }
+    return Schema.recordOf(nullableSchema.getRecordName() + ".nonnull", fields);
+  }
+
+  /**
+   * Configuration for the plugin.
+   */
+  public static class Conf extends PluginConfig {
+    @Description("Which field should be checked for null values.")
+    private final String field;
+
+    @Nullable
+    @Description("Whether to modify the schema for non-null output. If set to true, the schema for non-null " +
+      "output will be modified so that it is not nullable. Defaults to true.")
+    private final Boolean modifySchema;
+
+    private Conf() {
+      this(null, true);
+    }
+
+    @VisibleForTesting
+    public Conf(String field, Boolean modifySchema) {
+      this.field = field;
+      this.modifySchema = modifySchema;
+    }
+  }
+}

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/NullFieldSplitterTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/NullFieldSplitterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.mock.common.MockMultiOutputEmitter;
+import co.cask.cdap.etl.mock.transform.MockTransformContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link NullFieldSplitter}
+ */
+public class NullFieldSplitterTest {
+
+  @Test
+  public void testGetNonNullSchema() {
+    Schema schema = Schema.recordOf("abc",
+                                    Schema.Field.of("a", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                    Schema.Field.of("b", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                                    Schema.Field.of("c",
+                                                    Schema.unionOf(
+                                                      Schema.of(Schema.Type.NULL),
+                                                      Schema.of(Schema.Type.BYTES),
+                                                      Schema.of(Schema.Type.INT),
+                                                      Schema.of(Schema.Type.LONG))));
+
+    Schema expected = Schema.recordOf("abc.nonnull",
+                                      Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
+                                      Schema.Field.of("b", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                                      Schema.Field.of("c",
+                                                      Schema.unionOf(
+                                                        Schema.of(Schema.Type.NULL),
+                                                        Schema.of(Schema.Type.BYTES),
+                                                        Schema.of(Schema.Type.INT),
+                                                        Schema.of(Schema.Type.LONG))));
+    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "a"));
+
+    expected = Schema.recordOf("abc.nonull",
+                               Schema.Field.of("a", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                               Schema.Field.of("b", Schema.of(Schema.Type.DOUBLE)),
+                               Schema.Field.of("c",
+                                               Schema.unionOf(
+                                                 Schema.of(Schema.Type.NULL),
+                                                 Schema.of(Schema.Type.BYTES),
+                                                 Schema.of(Schema.Type.INT),
+                                                 Schema.of(Schema.Type.LONG))));
+    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "b"));
+
+    expected = Schema.recordOf("abc.nonull",
+                               Schema.Field.of("a", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                               Schema.Field.of("b", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                               Schema.Field.of("c",
+                                               Schema.unionOf(
+                                                 Schema.of(Schema.Type.BYTES),
+                                                 Schema.of(Schema.Type.INT),
+                                                 Schema.of(Schema.Type.LONG))));
+    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "c"));
+  }
+
+  @Test
+  public void testModifySchemaSplit() throws Exception {
+    Schema nullSchema = Schema.recordOf("test",
+                                         Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                                         Schema.Field.of("y", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+                                         Schema.Field.of("z", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    Schema nonNullSchema = Schema.recordOf("test",
+                                           Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                                           Schema.Field.of("y", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+                                           Schema.Field.of("z", Schema.of(Schema.Type.STRING)));
+    NullFieldSplitter nullFieldSplitter = new NullFieldSplitter(new NullFieldSplitter.Conf("z", true));
+    nullFieldSplitter.initialize(new MockTransformContext());
+
+    MockMultiOutputEmitter<StructuredRecord> mockEmitter = new MockMultiOutputEmitter<>();
+
+    // test non-null
+    nullFieldSplitter.transform(StructuredRecord.builder(nullSchema).set("x", 0L).set("z", "abc").build(), mockEmitter);
+    Assert.assertEquals(
+      ImmutableMap.of(NullFieldSplitter.NON_NULL_PORT,
+                      ImmutableList.of(StructuredRecord.builder(nonNullSchema).set("x", 0L).set("z", "abc").build())),
+      mockEmitter.getEmitted());
+
+    // test null
+    mockEmitter.clear();
+    nullFieldSplitter.transform(StructuredRecord.builder(nullSchema).set("y", 5).build(), mockEmitter);
+    Assert.assertEquals(
+      ImmutableMap.of(NullFieldSplitter.NULL_PORT,
+                      ImmutableList.of(StructuredRecord.builder(nullSchema).set("y", 5).build())),
+      mockEmitter.getEmitted());
+  }
+
+  @Test
+  public void testSameSchemaSplit() throws Exception {
+    Schema schema = Schema.recordOf("test",
+                                        Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                                        Schema.Field.of("y", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+                                        Schema.Field.of("z", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    NullFieldSplitter nullFieldSplitter = new NullFieldSplitter(new NullFieldSplitter.Conf("z", false));
+    nullFieldSplitter.initialize(new MockTransformContext());
+
+    MockMultiOutputEmitter<StructuredRecord> mockEmitter = new MockMultiOutputEmitter<>();
+
+    // test non-null
+    nullFieldSplitter.transform(StructuredRecord.builder(schema).set("x", 0L).set("z", "abc").build(), mockEmitter);
+    Assert.assertEquals(
+      ImmutableMap.of(NullFieldSplitter.NON_NULL_PORT,
+                      ImmutableList.of(StructuredRecord.builder(schema).set("x", 0L).set("z", "abc").build())),
+      mockEmitter.getEmitted());
+
+    // test null
+    mockEmitter.clear();
+    nullFieldSplitter.transform(StructuredRecord.builder(schema).set("y", 5).build(), mockEmitter);
+    Assert.assertEquals(
+      ImmutableMap.of(NullFieldSplitter.NULL_PORT,
+                      ImmutableList.of(StructuredRecord.builder(schema).set("y", 5).build())),
+      mockEmitter.getEmitted());
+  }
+
+}

--- a/transform-plugins/widgets/NullFieldSplitter-splittertransform.json
+++ b/transform-plugins/widgets/NullFieldSplitter-splittertransform.json
@@ -1,0 +1,29 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "configuration-groups": [
+    {
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Field to Split on",
+          "name": "field"
+        },
+        {
+          "widget-type": "select",
+          "label": "Modify Schema",
+          "name": "modifySchema",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [ ]
+}


### PR DESCRIPTION
Adding a SplitterTransform that has two output ports, one for
records with a null field value and one for records that have
a non-null value.