### PR TITLE
CDAP-12136 add union splitter transform

### DIFF
--- a/transform-plugins/docs/UnionSplitter-splittertransform.md
+++ b/transform-plugins/docs/UnionSplitter-splittertransform.md
@@ -1,0 +1,132 @@
+# Union Splitter
+
+
+Description
+-----------
+The union splitter is used to split data by a union schema, so that type specific logic can be done downstream.
+
+The union splitter will emit records to different ports depending on the schema of a particular field, or of
+the entire record. If no field is specified, each record will be emitted to a port named after the name of the
+record schema. If a field is specified, the schema for that field must be a union of supported schemas. All schemas
+except maps, arrays, unions, and enums are supported. For each input record, the value of that field will be examined
+and emitted to a port corresponding to its schema in the union.
+
+For record schemas, the output port will be the name of the record schema. For simple types, the output port will
+be the schema type in lowercase ('null', 'bool', 'bytes', 'int', 'long', 'float', 'double', or 'string').
+
+
+Properties
+----------
+**unionField:** The union field to split on. If specified, the schema for the field must be a union of
+supported schemas. All schemas except maps, arrays, unions, and enums are supported. Note that nulls are supported,
+which means all nulls will get sent to the 'null' port.
+
+**modifySchema:** Whether to modify the output schema to remove the union. For example, suppose the field 'x'
+is a union of int and long. If modifySchema is true, the schema for field 'x' will be just an int for
+the 'int' port and just a long for the 'long' port. If modifySchema is false, the output schema for each port
+will be the same as the input schema. Defaults to true.
+
+
+Example 1: Splitting on the entire record
+-----------------------------------------
+Suppose the union splitter is configured to split on the entire record:
+
+    {
+        "name": "UnionSplitter",
+        "type": "splittertransform",
+        "properties": { }
+    }
+
+Suppose the splitter receives records with two possible schemas.
+The first possible schema is 'itemMeta':
+
+    +================+
+    | name  | type   |
+    +================+
+    | id    | long   |
+    | desc  | string |
+    +================+
+
+The second possible schema is 'itemDetail', which includes a couple additional fields:
+
+
+    +================+
+    | name  | type   |
+    +================+
+    | id    | long   |
+    | desc  | string |
+    | label | string |
+    | price | double |
+    +================+
+
+If the union splitter receives a record with the 'itemMeta' schema, that record will be emitted to port 'itemMeta'.
+If it receives a record with the 'itemDetail' schema, that record will be emitted to port 'itemDetail'.
+This allows the pipeline to send each type of record to different stages to be handled differently.
+Note that since the schema name is used as the output port, this means that if the plugin receives records
+that have the same schema name, but different schemas, those records will all still go to the same output port.
+
+Example 2: Splitting on a field
+-------------------------------
+Suppose the union splitter is configured to split on the 'item' field:
+
+    {
+        "name": "UnionSplitter",
+        "type": "splittertransform",
+        "properties": {
+            "field": "item",
+            "modifySchema": "true"
+        }
+    }
+
+
+Suppose the splitter receives records with schema:
+
+    +=================================+
+    | name  | type                    |
+    +=================================+
+    | id    | long                    |
+    | user  | string                  |
+    | item  | [ int, long, itemMeta ] |
+    +=================================+
+
+with the 'item' field as a union of int, long and a record named 'itemMeta' with schema:
+
+    +=================================+
+    | name  | type                    |
+    +=================================+
+    | id    | long                    |
+    | desc  | string                  |
+    +=================================+
+
+This means the union splitter will have three output ports, one for each schema in the union.
+
+If a record contains an integer for the 'item' field, it will be emitted to the 'int' port with output schema:
+
+    +===============================+
+    | name  | type                  |
+    +===============================+
+    | id    | long                  |
+    | user  | string                |
+    | item  | int                   |
+    +===============================+
+
+If a record contains a long for the 'item' field, it will be emitted to the 'long' port with output schema:
+
+    +===============================+
+    | name  | type                  |
+    +===============================+
+    | id    | long                  |
+    | user  | string                |
+    | item  | long                  |
+    +===============================+
+
+If a record contains a StructuredRecord with the itemMeta schema for the 'item' field,
+it will be emitted to the 'itemMeta' port with output schema:
+
+    +===============================+
+    | name  | type                  |
+    +===============================+
+    | id    | long                  |
+    | user  | string                |
+    | item  | itemMeta              |
+    +===============================+

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/UnionSplitter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/UnionSplitter.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.MultiOutputEmitter;
+import co.cask.cdap.etl.api.MultiOutputPipelineConfigurer;
+import co.cask.cdap.etl.api.MultiOutputStageConfigurer;
+import co.cask.cdap.etl.api.SplitterTransform;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.ws.rs.Path;
+
+/**
+ * Splits input between multiple output ports, with one port per possible type in the union.
+ */
+@Plugin(type = SplitterTransform.PLUGIN_TYPE)
+@Name("UnionSplitter")
+@Description("Splits input between multiple output ports, with one port per possible type in a field's union schema. " +
+  "Enums, maps, and arrays inside the union are not supported. If the value is a record, the record schema name will " +
+  "be used as the port. If the value is a simple type, the schema type will be used as the port (null, bytes, " +
+  "bool, int, long, float, double, or string).")
+public class UnionSplitter extends SplitterTransform<StructuredRecord, StructuredRecord> {
+  private final Conf conf;
+
+  public UnionSplitter(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void configurePipeline(MultiOutputPipelineConfigurer multiOutputPipelineConfigurer) {
+    MultiOutputStageConfigurer stageConfigurer = multiOutputPipelineConfigurer.getMultiOutputStageConfigurer();
+    Schema inputSchema = stageConfigurer.getInputSchema();
+    if (inputSchema == null) {
+      return;
+    }
+
+    stageConfigurer.setOutputSchemas(getOutputSchemas(inputSchema, conf.unionField, conf.modifySchema));
+  }
+
+  @Override
+  public void transform(StructuredRecord record, MultiOutputEmitter<StructuredRecord> emitter) throws Exception {
+    if (conf.unionField == null) {
+      emitter.emit(record.getSchema().getRecordName(), record);
+      return;
+    }
+
+    Schema.Field schemaField = record.getSchema().getField(conf.unionField);
+    if (schemaField == null) {
+      emitter.emitError(new InvalidEntry<>(100, String.format("Field '%s' does not exist.", conf.unionField), record));
+      return;
+    }
+
+    Schema fieldSchema = schemaField.getSchema();
+    if (fieldSchema.getType() != Schema.Type.UNION) {
+      emitter.emitError(new InvalidEntry<>(200, String.format("Field '%s' is not of type union, but is of type '%s'.",
+                                                              conf.unionField, fieldSchema.getType()), record));
+      return;
+    }
+
+    Object val = record.get(conf.unionField);
+    Schema valSchema;
+    if (val == null) {
+      valSchema = Schema.of(Schema.Type.NULL);
+    } else if (val instanceof Boolean) {
+      valSchema = Schema.of(Schema.Type.BOOLEAN);
+    } else if (val instanceof ByteBuffer || val instanceof byte[] || val instanceof Byte[]) {
+      valSchema = Schema.of(Schema.Type.BYTES);
+    } else if (val instanceof Integer) {
+      valSchema = Schema.of(Schema.Type.INT);
+    } else if (val instanceof Long) {
+      valSchema = Schema.of(Schema.Type.LONG);
+    } else if (val instanceof Float) {
+      valSchema = Schema.of(Schema.Type.FLOAT);
+    } else if (val instanceof Double) {
+      valSchema = Schema.of(Schema.Type.DOUBLE);
+    } else if (val instanceof String) {
+      valSchema = Schema.of(Schema.Type.STRING);
+    } else if (val instanceof StructuredRecord) {
+      valSchema = ((StructuredRecord) val).getSchema();
+    } else if (val.getClass().isEnum()) {
+      emitter.emitError(
+        new InvalidEntry<>(300, String.format("Field '%s' is an Enum, which is not supported.", conf.unionField),
+                           record));
+      return;
+    } else if (val instanceof Map) {
+      emitter.emitError(
+        new InvalidEntry<>(301, String.format("Field '%s' is a Map, which is not supported.", conf.unionField),
+                           record));
+      return;
+    } else if (val instanceof Collection) {
+      emitter.emitError(
+        new InvalidEntry<>(302, String.format("Field '%s' is an array, which is not supported.", conf.unionField),
+                           record));
+      return;
+    } else {
+      emitter.emitError(
+        new InvalidEntry<>(303, String.format("Could not determine type for field '%s' with value of class '%s'.",
+                                              conf.unionField, val.getClass().getName()),
+                           record));
+      return;
+    }
+
+    boolean foundSchema = false;
+    for (Schema unionSchema : fieldSchema.getUnionSchemas()) {
+      // if the schema in the union matches the value's schema
+      if (unionSchema.equals(valSchema)) {
+        foundSchema = true;
+      }
+    }
+    if (!foundSchema) {
+      emitter.emitError(
+        new InvalidEntry<>(400, String.format("Field '%s' has schema '%s', which is not in its union schema.",
+                                              conf.unionField, valSchema), record));
+      return;
+    }
+
+    Schema inputSchema = record.getSchema();
+    List<Schema.Field> fields = new ArrayList<>(inputSchema.getFields().size());
+    for (Schema.Field inputSchemaField : inputSchema.getFields()) {
+      String fieldName = inputSchemaField.getName();
+      if (fieldName.equals(conf.unionField)) {
+        fields.add(Schema.Field.of(fieldName, valSchema));
+      } else {
+        fields.add(inputSchemaField);
+      }
+    }
+
+    Schema.Type valType = valSchema.getType();
+    String port = valType == Schema.Type.RECORD ? valSchema.getRecordName() : valType.name().toLowerCase();
+    Schema outputSchema = conf.modifySchema ?
+      Schema.recordOf(inputSchema.getRecordName() + "." + port, fields) : inputSchema;
+    StructuredRecord.Builder builder = StructuredRecord.builder(outputSchema);
+    for (Schema.Field inputSchemaField : inputSchema.getFields()) {
+      String fieldName = inputSchemaField.getName();
+      builder.set(fieldName, record.get(fieldName));
+    }
+    emitter.emit(port, builder.build());
+  }
+
+  @Path("outputSchema")
+  public Map<String, Schema> getOutputSchemas(GetSchemaRequest request) {
+    return getOutputSchemas(request.inputSchema, request.unionField, request.modifySchema);
+  }
+
+  @VisibleForTesting
+  static Map<String, Schema> getOutputSchemas(Schema inputSchema, String unionField, boolean modifySchema) {
+    Map<String, Schema> outputPortSchemas = new HashMap<>();
+    if (unionField == null) {
+      outputPortSchemas.put(inputSchema.getRecordName(), inputSchema);
+      return outputPortSchemas;
+    }
+
+    Schema.Field unionSchemaField = inputSchema.getField(unionField);
+    if (unionSchemaField == null) {
+      throw new IllegalArgumentException(
+        String.format("Field '%s' does not exist in the input schema.", unionField));
+    }
+    Schema unionSchema = unionSchemaField.getSchema();
+    if (unionSchema.getType() != Schema.Type.UNION) {
+      throw new IllegalArgumentException(
+        String.format("Field '%s' is not of type union, but is of type '%s'", unionField, unionSchema.getType()));
+    }
+
+    int numFields = inputSchema.getFields().size();
+    ArrayList<Schema.Field> outputFields = new ArrayList<>(numFields);
+    int i = 0;
+    int unionIndex = -1;
+    for (Schema.Field inputField : inputSchema.getFields()) {
+      if (inputField.getName().equals(unionField)) {
+        unionIndex = i;
+        outputFields.add(null);
+      } else {
+        outputFields.add(inputField);
+      }
+      i++;
+    }
+
+    for (Schema schema : unionSchema.getUnionSchemas()) {
+      Schema.Type type = schema.getType();
+      switch (type) {
+        case ENUM:
+        case MAP:
+        case ARRAY:
+        case UNION:
+          throw new IllegalArgumentException(String.format("A type of '%s' within a union is not supported.", type));
+      }
+
+      String port = type == Schema.Type.RECORD ? schema.getRecordName() : type.name().toLowerCase();
+      outputFields.set(unionIndex, Schema.Field.of(unionField, modifySchema ? schema : unionSchema));
+      outputPortSchemas.put(port, Schema.recordOf(inputSchema.getRecordName() + "." + port, outputFields));
+    }
+
+    return outputPortSchemas;
+  }
+
+  /**
+   * Request to get output schemas.
+   */
+  static class GetSchemaRequest extends Conf {
+    private Schema inputSchema;
+  }
+
+  /**
+   * Plugin conf
+   */
+  public static class Conf {
+    @Nullable
+    @Description("The union field to split on. Each possible schema in the union will be emitted to a different " +
+      "port. Only unions of records and simple types are supported. In other words, " +
+      "enums, maps, and arrays in the union are not supported. If no union field is specified, " +
+      "it is assumed that the records with multiple schemas can be input to this stage. " +
+      "In that scenario, each record will be emitted to a port based on its schema. ")
+    protected String unionField;
+
+    @Nullable
+    @Description("Whether to modify the schema of records before emitting them. If true, " +
+      "the schema of the union field will be modified to be only a single schema matching the value of the field. " +
+      "Defaults to true.")
+    protected Boolean modifySchema;
+
+    private Conf() {
+      this(null, true);
+    }
+
+    @VisibleForTesting
+    public Conf(String unionField, Boolean modifySchema) {
+      this.unionField = unionField;
+      this.modifySchema = modifySchema;
+    }
+  }
+}

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/UnionSplitterTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/UnionSplitterTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.mock.common.MockMultiOutputEmitter;
+import co.cask.cdap.etl.mock.transform.MockTransformContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests {@link UnionSplitter}
+ */
+public class UnionSplitterTest {
+
+  @Test
+  public void testInvalidSchemas() {
+    Schema inputSchema = Schema.recordOf(
+      "union",
+      Schema.Field.of("a", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.arrayOf(Schema.of(Schema.Type.STRING)))),
+      Schema.Field.of("b", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.enumWith("something"))),
+      Schema.Field.of("c", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING)))),
+      Schema.Field.of("d", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+
+    try {
+      UnionSplitter.getOutputSchemas(inputSchema, "a", true);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      UnionSplitter.getOutputSchemas(inputSchema, "b", true);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      UnionSplitter.getOutputSchemas(inputSchema, "c", true);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    UnionSplitter.getOutputSchemas(inputSchema, "d", true);
+  }
+
+  @Test
+  public void testOutputSchemas() {
+    Schema rec1Schema = Schema.recordOf(
+      "rec1",
+      Schema.Field.of("x", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("y", Schema.of(Schema.Type.INT)));
+    Schema rec2Schema = Schema.recordOf(
+      "rec2",
+      Schema.Field.of("y", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("z", Schema.of(Schema.Type.INT)));
+
+    Schema inputSchema = Schema.recordOf("union",
+                                         Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("b", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                                                             Schema.of(Schema.Type.BOOLEAN),
+                                                                             Schema.of(Schema.Type.BYTES),
+                                                                             Schema.of(Schema.Type.INT),
+                                                                             Schema.of(Schema.Type.LONG),
+                                                                             Schema.of(Schema.Type.FLOAT),
+                                                                             Schema.of(Schema.Type.DOUBLE),
+                                                                             Schema.of(Schema.Type.STRING),
+                                                                             rec1Schema, rec2Schema)));
+
+    // test with schema modification
+    Map<String, Schema> expected = new HashMap<>();
+    expected.put("null", Schema.recordOf("union.null",
+                                         Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("b", Schema.of(Schema.Type.NULL))));
+    expected.put("boolean", Schema.recordOf("union.boolean",
+                                            Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                            Schema.Field.of("b", Schema.of(Schema.Type.BOOLEAN))));
+    expected.put("bytes", Schema.recordOf("union.bytes",
+                                          Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                          Schema.Field.of("b", Schema.of(Schema.Type.BYTES))));
+    expected.put("int", Schema.recordOf("union.int",
+                                        Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                        Schema.Field.of("b", Schema.of(Schema.Type.INT))));
+    expected.put("long", Schema.recordOf("union.long",
+                                         Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("b", Schema.of(Schema.Type.LONG))));
+    expected.put("float", Schema.recordOf("union.double",
+                                           Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                           Schema.Field.of("b", Schema.of(Schema.Type.FLOAT))));
+    expected.put("double", Schema.recordOf("union.double",
+                                           Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                           Schema.Field.of("b", Schema.of(Schema.Type.DOUBLE))));
+    expected.put("string", Schema.recordOf("union.string",
+                                           Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                           Schema.Field.of("b", Schema.of(Schema.Type.STRING))));
+    expected.put("rec1", Schema.recordOf("union.rec1",
+                                         Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("b", rec1Schema)));
+    expected.put("rec2", Schema.recordOf("union.rec2",
+                                         Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("b", rec2Schema)));
+    Map<String, Schema> actual = UnionSplitter.getOutputSchemas(inputSchema, "b", true);
+    Assert.assertEquals(expected, actual);
+
+    // test without schema modification
+    expected.clear();
+    expected.put("null", inputSchema);
+    expected.put("boolean", inputSchema);
+    expected.put("bytes", inputSchema);
+    expected.put("int", inputSchema);
+    expected.put("long", inputSchema);
+    expected.put("float", inputSchema);
+    expected.put("double", inputSchema);
+    expected.put("string", inputSchema);
+    expected.put("rec1", inputSchema);
+    expected.put("rec2", inputSchema);
+    actual = UnionSplitter.getOutputSchemas(inputSchema, "b", false);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSplitOnField() throws Exception {
+    Schema rec1Schema = Schema.recordOf(
+      "rec1",
+      Schema.Field.of("x", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("y", Schema.of(Schema.Type.INT)));
+    Schema rec2Schema = Schema.recordOf(
+      "rec2",
+      Schema.Field.of("y", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("z", Schema.of(Schema.Type.INT)));
+    StructuredRecord rec1 = StructuredRecord.builder(rec1Schema).set("x", 0).set("y", 1).build();
+    StructuredRecord rec2 = StructuredRecord.builder(rec2Schema).set("y", 2).set("z", 3).build();
+
+    Schema inputSchema = Schema.recordOf(
+      "union",
+      Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("b", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.of(Schema.Type.BOOLEAN),
+                                          Schema.of(Schema.Type.INT),
+                                          Schema.of(Schema.Type.LONG),
+                                          Schema.of(Schema.Type.FLOAT),
+                                          Schema.of(Schema.Type.DOUBLE),
+                                          Schema.of(Schema.Type.STRING),
+                                          rec1Schema, rec2Schema)));
+
+    Schema nullSchema = Schema.recordOf("union.null",
+                                        Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                        Schema.Field.of("b", Schema.of(Schema.Type.NULL)));
+    Schema boolSchema = Schema.recordOf("union.boolean",
+                                        Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                        Schema.Field.of("b", Schema.of(Schema.Type.BOOLEAN)));
+    Schema intSchema = Schema.recordOf("union.int",
+                                       Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                       Schema.Field.of("b", Schema.of(Schema.Type.INT)));
+    Schema longSchema = Schema.recordOf("union.long",
+                                        Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                        Schema.Field.of("b", Schema.of(Schema.Type.LONG)));
+    Schema floatSchema = Schema.recordOf("union.double",
+                                         Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("b", Schema.of(Schema.Type.FLOAT)));
+    Schema doubleSchema = Schema.recordOf("union.double",
+                                          Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                          Schema.Field.of("b", Schema.of(Schema.Type.DOUBLE)));
+    Schema stringSchema = Schema.recordOf("union.string",
+                                          Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                          Schema.Field.of("b", Schema.of(Schema.Type.STRING)));
+    Schema withRec1Schema = Schema.recordOf("union.rec1",
+                                            Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                            Schema.Field.of("b", rec1Schema));
+    Schema withRec2Schema = Schema.recordOf("union.rec2",
+                                            Schema.Field.of("a", Schema.of(Schema.Type.LONG)),
+                                            Schema.Field.of("b", rec2Schema));
+
+    UnionSplitter unionSplitter = new UnionSplitter(new UnionSplitter.Conf("b", true));
+    unionSplitter.initialize(new MockTransformContext());
+
+    MockMultiOutputEmitter<StructuredRecord> mockEmitter = new MockMultiOutputEmitter<>();
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", null)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", true)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", new byte[] { 5 })
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", 5)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", 5L)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", 5.5f)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", 5.5d)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", "5")
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", rec1)
+                              .build(),
+                            mockEmitter);
+    unionSplitter.transform(StructuredRecord.builder(inputSchema)
+                              .set("a", 0L)
+                              .set("b", rec2)
+                              .build(),
+                            mockEmitter);
+
+    Map<String, List<StructuredRecord>> expected = new HashMap<>();
+    expected.put("null", ImmutableList.of(StructuredRecord.builder(nullSchema)
+                                            .set("a", 0L)
+                                            .set("b", null)
+                                            .build()));
+    expected.put("boolean", ImmutableList.of(StructuredRecord.builder(boolSchema)
+                                            .set("a", 0L)
+                                            .set("b", true)
+                                            .build()));
+    expected.put("int", ImmutableList.of(StructuredRecord.builder(intSchema)
+                                            .set("a", 0L)
+                                            .set("b", 5)
+                                            .build()));
+    expected.put("long", ImmutableList.of(StructuredRecord.builder(longSchema)
+                                            .set("a", 0L)
+                                            .set("b", 5L)
+                                            .build()));
+    expected.put("float", ImmutableList.of(StructuredRecord.builder(floatSchema)
+                                            .set("a", 0L)
+                                            .set("b", 5.5f)
+                                            .build()));
+    expected.put("double", ImmutableList.of(StructuredRecord.builder(doubleSchema)
+                                            .set("a", 0L)
+                                            .set("b", 5.5d)
+                                            .build()));
+    expected.put("string", ImmutableList.of(StructuredRecord.builder(stringSchema)
+                                            .set("a", 0L)
+                                            .set("b", "5")
+                                            .build()));
+    expected.put("rec1", ImmutableList.of(StructuredRecord.builder(withRec1Schema)
+                                            .set("a", 0L)
+                                            .set("b", rec1)
+                                            .build()));
+    expected.put("rec2", ImmutableList.of(StructuredRecord.builder(withRec2Schema)
+                                            .set("a", 0L)
+                                            .set("b", rec2)
+                                            .build()));
+
+    Map<String, List<Object>> actual = mockEmitter.getEmitted();
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSplitOnRecord() throws Exception {
+    Schema schema1 = Schema.recordOf("s1",
+                                     Schema.Field.of("x", Schema.of(Schema.Type.LONG)),
+                                     Schema.Field.of("y", Schema.of(Schema.Type.INT)));
+    Schema schema2 = Schema.recordOf("s2",
+                                     Schema.Field.of("y", Schema.of(Schema.Type.STRING)),
+                                     Schema.Field.of("z", Schema.of(Schema.Type.STRING)));
+
+    StructuredRecord r1 = StructuredRecord.builder(schema1).set("x", 1L).set("y", 5).build();
+    StructuredRecord r2 = StructuredRecord.builder(schema1).set("x", 2L).set("y", 3).build();
+    StructuredRecord r3 = StructuredRecord.builder(schema2).set("y", "why").set("z", "zee").build();
+    StructuredRecord r4 = StructuredRecord.builder(schema2).set("y", "wye").set("z", "zea").build();
+
+    UnionSplitter unionSplitter = new UnionSplitter(new UnionSplitter.Conf(null, true));
+    unionSplitter.initialize(new MockTransformContext());
+    MockMultiOutputEmitter<StructuredRecord> mockEmitter = new MockMultiOutputEmitter<>();
+
+    unionSplitter.transform(r1, mockEmitter);
+    unionSplitter.transform(r2, mockEmitter);
+    unionSplitter.transform(r3, mockEmitter);
+    unionSplitter.transform(r4, mockEmitter);
+
+    Map<String, List<StructuredRecord>> expected = ImmutableMap.<String, List<StructuredRecord>>of(
+      "s1", ImmutableList.of(r1, r2), "s2", ImmutableList.of(r3, r4));
+    Map<String, List<Object>> actual = mockEmitter.getEmitted();
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/transform-plugins/widgets/UnionSplitter-splittertransform.json
+++ b/transform-plugins/widgets/UnionSplitter-splittertransform.json
@@ -1,0 +1,30 @@
+{
+  "metadata": {
+    "spec-version": "1.4"
+  },
+  "configuration-groups": [
+    {
+      "label": "Union Splitter",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Union field to split on",
+          "name": "unionField"
+        },
+        {
+          "widget-type": "select",
+          "label": "Modify Schema",
+          "name": "modifySchema",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": [ ]
+}


### PR DESCRIPTION
The union splitter will split input into multiple outputs
depending on the values in a union field. Each possible schema
in the union will have its own output port. If no field is given,
each schema received as input will have its own output port.