### PR TITLE
Fix compilation errors caused by new emitAlert APIs.

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/JavaScriptTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/JavaScriptTransform.java
@@ -194,6 +194,11 @@ public class JavaScriptTransform extends Transform<StructuredRecord, StructuredR
     }
 
     @Override
+    public void emitAlert(Map<String, String> payload) {
+      emitter.emitAlert(payload);
+    }
+
+    @Override
     public void emitError(InvalidEntry<Map> invalidEntry) {
       emitter.emitError(new InvalidEntry<>(invalidEntry.getErrorCode(), invalidEntry.getErrorMsg(),
                                            decodeRecord(invalidEntry.getInvalidRecord(), errSchema)));

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
@@ -135,6 +135,11 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
     }
 
     @Override
+    public void emitAlert(Map<String, String> payload) {
+      emitter.emitAlert(payload);
+    }
+
+    @Override
     public void emitError(InvalidEntry<Map> invalidEntry) {
       emitter.emitError(new InvalidEntry<>(invalidEntry.getErrorCode(), invalidEntry.getErrorMsg(),
                                            decode(invalidEntry.getInvalidRecord())));


### PR DESCRIPTION
Fix compilation. New API was introduced in CDAP in https://github.com/caskdata/cdap/pull/9273.