### PR TITLE
Add S3 to HDFS File copy functionality.

### DIFF
--- a/core-plugins/docs/HDFSFileCopySink-batchsink.md
+++ b/core-plugins/docs/HDFSFileCopySink-batchsink.md
@@ -35,7 +35,7 @@ This sink plugin only reads StructuredRecords with the following schema. Each re
 | **group**              | String | The group that the of the file belongs to.                                                                                                     |
 | **owner**              | String | The owner of the file.                                                                                                                         |
 | **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
-| **relativePath**       | String | The relavite path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
+| **relativePath**       | String | The relative path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
 | **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
 | **permission**         | int    | The file's access permission                                                                                                                   |
 | **Credentials**        | Record | Additional information required to connect to the source Filesystem.                                                                           |

--- a/core-plugins/docs/HDFSFileCopySink-batchsink.md
+++ b/core-plugins/docs/HDFSFileCopySink-batchsink.md
@@ -1,0 +1,37 @@
+# HDfS File Copy Batch Sink
+
+Description
+-----------
+The HDFS File Copy plugin is a sink plugin that takes file metadata records as inputs and copies the files into local HDFS
+
+
+Use Case
+--------
+Use this sink to copy files from any source to your local HDFS.
+You may want to periodically sync your HDFS with some remote filesystem. Schedule to run a pipeline with this plugin to copy new files periodically.
+
+
+Properties
+----------
+| Configuration          | Required | Default   | Description                                                                                 |
+| :--------------------- | :------: | :------   | :------------------------------------------------------------------------------------------ |
+| **Reference Name**     |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.   |
+| **Base Path**          |  **Y**   | None      | The folder where the copied files will be placed. It will be created if it doesn't exist.   |
+| **Enable Overwrite**   |  **Y**   | False     | Specifies whether or not to overwrite files if it already exists.                           |
+| **Buffer Size**        |  **Y**   | True      | The size of the buffer that temporarily stores data from file input stream while copying.   |
+
+Usage Notes
+-----------
+This sink plugin only reads StructuredRecords with the follwing schema. Each record should contain the metadata for a file to be copied
+
+| Field                  | Type   | Description                                                                                                                                    |
+| :--------------------- | :----- | :-------------------------                                                                                                                     |
+| **File Name**          | String | Only contains the name of the file.                                                                                                            |
+| **Full Path**          | String | Contains the full path of the file in the source file system.                                                                                  |
+| **File Size**          | long   | Specifies the number of fi                                                                                                                     |
+| **Timestamp**          | long   | The modification timestamp of the file.                                                                                                        |
+| **Owner**              | String | The owner of the file.                                                                                                                         |
+| **Is Folder**          | Boolean| Whether or not the file is a folder.                                                                                                           |
+| **Base Path**          | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
+| **Data Base Type**     | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **Credentials**        | Record | Additional information required to connect to the source Filesystem.                                                                           |

--- a/core-plugins/docs/HDFSFileCopySink-batchsink.md
+++ b/core-plugins/docs/HDFSFileCopySink-batchsink.md
@@ -13,14 +13,13 @@ You may want to periodically sync your HDFS with some remote filesystem. Schedul
 
 Properties
 ----------
-| Configuration                            | Required | Default   | Description                                                                                            |
-| :--------------------------------------- | :------: | :------   | :----------------------------------------------------------------------------------------------------- |
-| **Reference Name**                       |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.              |
-| **Base Path**                            |  **Y**   | None      | The folder where the copied files will be placed. It will be created if it doesn't exist.              |
-| **Enable Overwrite**                     |  **Y**   | False     | Specifies whether or not to overwrite files if it already exists.                                      |
-| **Preserve File Owner**                  |  **Y**   | False     | Whether or not to preserve the owner of the file from source filesystem.                               |
-| **Enable Filesystem Connection Caching** |  **Y**   | True      | Whether or not for splits to use cached connections to filesystems.                                    |
-| **Buffer Size**                          |  **Y**   | 1 MB      | The size of the buffer (in Bytes) that temporarily stores data from file input stream while copying.   |
+| Configuration                            | Required | Default   | Description                                                                                                                  |
+| :--------------------------------------- | :------: | :------   | :--------------------------------------------------------------------------------------------------------------------------- |
+| **Reference Name**                       |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.                                    |
+| **Base Path**                            |  **Y**   | None      | The folder where the copied files will be placed. It will be created if it doesn't exist.                                    |
+| **Enable Overwrite**                     |  **Y**   | False     | Specifies whether or not to overwrite files if it already exists.                                                            |
+| **Preserve File Owner**                  |  **Y**   | False     | Whether or not to preserve the owner of the file from source filesystem.                                                     |
+| **Buffer Size**                          |  **Y**   | 1 MB      | The size of the buffer (in MegaBytes) that temporarily stores data from file input stream while copying. Defaults to 1 MB.   |
 
 Usage Notes
 -----------
@@ -36,7 +35,7 @@ This sink plugin only reads StructuredRecords with the following schema. Each re
 | **group**              | String | The group that the of the file belongs to.                                                                                                     |
 | **owner**              | String | The owner of the file.                                                                                                                         |
 | **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
-| **basePath**           | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
+| **relativePath**       | String | The relavite path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
 | **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
 | **permission**         | int    | The file's access permission                                                                                                                   |
 | **Credentials**        | Record | Additional information required to connect to the source Filesystem.                                                                           |

--- a/core-plugins/docs/HDFSFileCopySink-batchsink.md
+++ b/core-plugins/docs/HDFSFileCopySink-batchsink.md
@@ -13,25 +13,30 @@ You may want to periodically sync your HDFS with some remote filesystem. Schedul
 
 Properties
 ----------
-| Configuration          | Required | Default   | Description                                                                                 |
-| :--------------------- | :------: | :------   | :------------------------------------------------------------------------------------------ |
-| **Reference Name**     |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.   |
-| **Base Path**          |  **Y**   | None      | The folder where the copied files will be placed. It will be created if it doesn't exist.   |
-| **Enable Overwrite**   |  **Y**   | False     | Specifies whether or not to overwrite files if it already exists.                           |
-| **Buffer Size**        |  **Y**   | True      | The size of the buffer that temporarily stores data from file input stream while copying.   |
+| Configuration                            | Required | Default   | Description                                                                                            |
+| :--------------------------------------- | :------: | :------   | :----------------------------------------------------------------------------------------------------- |
+| **Reference Name**                       |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.              |
+| **Base Path**                            |  **Y**   | None      | The folder where the copied files will be placed. It will be created if it doesn't exist.              |
+| **Enable Overwrite**                     |  **Y**   | False     | Specifies whether or not to overwrite files if it already exists.                                      |
+| **Preserve File Owner**                  |  **Y**   | False     | Whether or not to preserve the owner of the file from source filesystem.                               |
+| **Enable Filesystem Connection Caching** |  **Y**   | True      | Whether or not for splits to use cached connections to filesystems.                                    |
+| **Buffer Size**                          |  **Y**   | 1 MB      | The size of the buffer (in Bytes) that temporarily stores data from file input stream while copying.   |
 
 Usage Notes
 -----------
-This sink plugin only reads StructuredRecords with the follwing schema. Each record should contain the metadata for a file to be copied
+This sink plugin only reads StructuredRecords with the following schema. Each record should contain the metadata for a file to be copied
 
 | Field                  | Type   | Description                                                                                                                                    |
 | :--------------------- | :----- | :-------------------------                                                                                                                     |
-| **File Name**          | String | Only contains the name of the file.                                                                                                            |
-| **Full Path**          | String | Contains the full path of the file in the source file system.                                                                                  |
-| **File Size**          | long   | Specifies the number of fi                                                                                                                     |
-| **Timestamp**          | long   | The modification timestamp of the file.                                                                                                        |
-| **Owner**              | String | The owner of the file.                                                                                                                         |
-| **Is Folder**          | Boolean| Whether or not the file is a folder.                                                                                                           |
-| **Base Path**          | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
-| **Data Base Type**     | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **fileName**           | String | Only contains the name of the file.                                                                                                            |
+| **fullPath**           | String | Contains the full path of the file in the source file system.                                                                                  |
+| **fileSize**           | long   | File size in bytes.                                                                                                                            |
+| **hostURI**            | String | The source filesystem's URI.                                                                                                                   |
+| **modificationTime**   | long   | The modification timestamp of the file.                                                                                                        |
+| **group**              | String | The group that the of the file belongs to.                                                                                                     |
+| **owner**              | String | The owner of the file.                                                                                                                         |
+| **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
+| **basePath**           | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
+| **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **permission**         | int    | The file's access permission                                                                                                                   |
 | **Credentials**        | Record | Additional information required to connect to the source Filesystem.                                                                           |

--- a/core-plugins/docs/S3FileMetadataSource-batchsource.md
+++ b/core-plugins/docs/S3FileMetadataSource-batchsource.md
@@ -18,10 +18,10 @@ Properties
 | **Reference Name**     |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.                                                                                                                                                                                       |
 | **Source Paths**       |  **Y**   | None      | Path(s) to file(s) to be read. If a directory is specified, terminate the path name with a '/'.                                                                                                                                                                                 |
 | **Max Split Size**     |  **Y**   | None      | Specifies the number of files that are controlled by each split. The number of splits created will be the total number of files divided by Max Split Size. The InputFormat will assign roughly the same number of bytes to each split.                                          |
+| **Host URI**           |  **Y**   | None      | URI of the bucket which you want to read from. For example, if you want to read from s3 bucket `example.bucket.co`, this configuration would be `s3a://example.bucket.co`                                                                                                       |
 | **Copy Recursively**   |  **Y**   | True      | Whether or not to copy recursively. Similar to the '-r' option in the linux cp command. Set this to true if you want to copy the entire directory.                                                                                                                              |
 | **Access Key ID**      |  **Y**   | None      | Your Amazon S3 access key ID.                                                                                                                                                                                                                                                   |
 | **Secret Key ID**      |  **Y**   | None      | Your Amazon S3 secret key ID.                                                                                                                                                                                                                                                   |
-| **Bucket Name**        |  **Y**   | None      | Address of the bucket which you want to read from.                                                                                                                                                                                                                              |
 | **Amazon Region**      |  **N**   | us-east-1 | Region of the bucket which you want to read from.                                                                                                                                                                                                                               |
 
 Usage Notes
@@ -31,14 +31,17 @@ A structured record with the following schema is emitted for each file it reads.
 
 | Field                  | Type   | Description                                                                                                                                    |
 | :--------------------- | :----- | :-------------------------                                                                                                                     |
-| **File Name**          | String | Only contains the name of the file.                                                                                                            |
-| **Full Path**          | String | Contains the full path of the file in the source file system.                                                                                  |
-| **File Size**          | long   | Specifies the number of fi                                                                                                                     |
-| **Timestamp**          | long   | The modification timestamp of the file.                                                                                                        |
-| **Owner**              | String | The owner of the file.                                                                                                                         |
-| **Is Folder**          | Boolean| Whether or not the file is a folder.                                                                                                           |
-| **Base Path**          | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
-| **Data Base Type**     | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
-| **Access Key ID**      | String | Access Key ID for the source Filesystem.                                                                                                       |
-| **Secret Key ID**      | String | Secret Key ID for the source Filesystem.                                                                                                       |
-| **Bucket Name**        | String | The bucket which this file came from.                                                                                                          |
+| **fileName**           | String | Only contains the name of the file.                                                                                                            |
+| **fullPath**           | String | Contains the full path of the file in the source file system.                                                                                  |
+| **fileSize**           | long   | File Szie in bytes.                                                                                                                            |
+| **hostURI**            | String | The source filesystem's URI.                                                                                                                   |
+| **modificationTime**   | long   | The modification timestamp of the file.                                                                                                        |
+| **group**              | String | The group that the of the file belongs to.                                                                                                     |
+| **owner**              | String | The owner of the file.                                                                                                                         |
+| **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
+| **basePath**           | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
+| **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **permission**         | int    | The file's access permission                                                                                                                   |
+| **accessKeyID**        | String | Access Key ID for the source Filesystem.                                                                                                       |
+| **secretKeyID**        | String | Secret Key ID for the source Filesystem.                                                                                                       |
+| **region**             | String | Region of the source Filesystem.                                                                                                               |

--- a/core-plugins/docs/S3FileMetadataSource-batchsource.md
+++ b/core-plugins/docs/S3FileMetadataSource-batchsource.md
@@ -39,7 +39,7 @@ A structured record with the following schema is emitted for each file it reads.
 | **group**              | String | The group that the of the file belongs to.                                                                                                     |
 | **owner**              | String | The owner of the file.                                                                                                                         |
 | **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
-| **basePath**           | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
+| **relativePath**       | String | The relavite path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
 | **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
 | **permission**         | int    | The file's access permission                                                                                                                   |
 | **accessKeyID**        | String | Access Key ID for the source Filesystem.                                                                                                       |

--- a/core-plugins/docs/S3FileMetadataSource-batchsource.md
+++ b/core-plugins/docs/S3FileMetadataSource-batchsource.md
@@ -39,7 +39,7 @@ A structured record with the following schema is emitted for each file it reads.
 | **group**              | String | The group that the of the file belongs to.                                                                                                     |
 | **owner**              | String | The owner of the file.                                                                                                                         |
 | **isFolder**           | Boolean| Whether or not the file is a folder.                                                                                                           |
-| **relativePath**       | String | The relavite path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
+| **relativePath**       | String | The relative path is constructed by deleting the portion of the source path that comes before the last path separator ("/") from the full path.|
 | **filesystem**         | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
 | **permission**         | int    | The file's access permission                                                                                                                   |
 | **accessKeyID**        | String | Access Key ID for the source Filesystem.                                                                                                       |

--- a/core-plugins/docs/S3FileMetadataSource-batchsource.md
+++ b/core-plugins/docs/S3FileMetadataSource-batchsource.md
@@ -1,0 +1,44 @@
+# S3 File Metadata Batch Source
+
+Description
+-----------
+The S3 File Metadata plugin is a source plugin that allows users to read file metadata from an S3 Filesystem.
+
+
+Use Case
+--------
+Use this source to extract the metadata of files under specified paths. The metadata can be passed to the
+HDFSFileCopySink and the files will be copied from S3 to HDFS
+
+
+Properties
+----------
+| Configuration          | Required | Default   | Description                                                                                                                                                                                                                                                                     |
+| :--------------------- | :------: | :------   | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Reference Name**     |  **Y**   | None      | This will be used to uniquely identify this source for lineage, annotating metadata, etc.                                                                                                                                                                                       |
+| **Source Paths**       |  **Y**   | None      | Path(s) to file(s) to be read. If a directory is specified, terminate the path name with a '/'.                                                                                                                                                                                 |
+| **Max Split Size**     |  **Y**   | None      | Specifies the number of files that are controlled by each split. The number of splits created will be the total number of files divided by Max Split Size. The InputFormat will assign roughly the same number of bytes to each split.                                          |
+| **Copy Recursively**   |  **Y**   | True      | Whether or not to copy recursively. Similar to the '-r' option in the linux cp command. Set this to true if you want to copy the entire directory.                                                                                                                              |
+| **Access Key ID**      |  **Y**   | None      | Your Amazon S3 access key ID.                                                                                                                                                                                                                                                   |
+| **Secret Key ID**      |  **Y**   | None      | Your Amazon S3 secret key ID.                                                                                                                                                                                                                                                   |
+| **Bucket Name**        |  **Y**   | None      | Address of the bucket which you want to read from.                                                                                                                                                                                                                              |
+| **Amazon Region**      |  **N**   | us-east-1 | Region of the bucket which you want to read from.                                                                                                                                                                                                                               |
+
+Usage Notes
+-----------
+This source plugin only reads filemetadata from the source. To copy files, pass its outputs to a FileCopySink of the desired Filesystem.
+A structured record with the following schema is emitted for each file it reads.
+
+| Field                  | Type   | Description                                                                                                                                    |
+| :--------------------- | :----- | :-------------------------                                                                                                                     |
+| **File Name**          | String | Only contains the name of the file.                                                                                                            |
+| **Full Path**          | String | Contains the full path of the file in the source file system.                                                                                  |
+| **File Size**          | long   | Specifies the number of fi                                                                                                                     |
+| **Timestamp**          | long   | The modification timestamp of the file.                                                                                                        |
+| **Owner**              | String | The owner of the file.                                                                                                                         |
+| **Is Folder**          | Boolean| Whether or not the file is a folder.                                                                                                           |
+| **Base Path**          | String | The base path of the file. This path will be appended to the base path specified in the FileCopySink to create the file in the destination.    |
+| **Data Base Type**     | String | Contains the string "amazons3". Used to identify the type of filesystem this record originated from.                                           |
+| **Access Key ID**      | String | Access Key ID for the source Filesystem.                                                                                                       |
+| **Secret Key ID**      | String | Secret Key ID for the source Filesystem.                                                                                                       |
+| **Bucket Name**        | String | The bucket which this file came from.                                                                                                          |

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -162,6 +162,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>2.8.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileCopySink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileCopySink.java
@@ -147,6 +147,7 @@ public abstract class AbstractFileCopySink
       FileCopyOutputFormat.setBasePath(conf, config.basePath);
       FileCopyOutputFormat.setEnableOverwrite(conf, config.enableOverwrite.toString());
       FileCopyOutputFormat.setPreserveFileOwner(conf, config.preserveFileOwner.toString());
+      FileCopyOutputFormat.setFilesystemScheme(conf, config.getScheme());
 
       if (config.bufferSize != null) {
         // bufferSize is in megabytes
@@ -154,9 +155,6 @@ public abstract class AbstractFileCopySink
       } else {
         FileCopyOutputFormat.setBufferSize(conf, String.valueOf(FileCopyRecordWriter.DEFAULT_BUFFER_SIZE));
       }
-
-      // always disable caching
-      conf.put(String.format("fs.%s.impl.disable.cache", config.getScheme()), String.valueOf(true));
 
       // set the URI for the destination filesystem if it's provided
       if (config.getHostUri() != null) {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileCopySink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileCopySink.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.hydrator.common.ReferenceBatchSink;
+import co.cask.hydrator.common.ReferencePluginConfig;
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata.S3Credentials;
+import com.sun.istack.Nullable;
+import org.apache.hadoop.io.NullWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Abstract template for a FileCopySink. The transform method converts a structured record
+ * to AbstractFileMetadata class.
+ */
+public abstract class AbstractFileCopySink
+  extends ReferenceBatchSink<StructuredRecord, NullWritable, AbstractFileMetadata> {
+  protected final AbstractFileCopySinkConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileCopySink.class);
+
+  public AbstractFileCopySink(AbstractFileCopySinkConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  /**
+   * Converts input StructuredRecord to AbstractFileMetadata class. Loads credentials and
+   * file metadata from the input.
+   * @param input The input structured record that contains credentials and file metadata.
+   * @param emitter
+   * @throws Exception
+   */
+  @Override
+  public void transform(StructuredRecord input,
+                        Emitter<KeyValue<NullWritable, AbstractFileMetadata>> emitter)
+    throws Exception {
+    AbstractFileMetadata output;
+    switch ((String) input.get(AbstractFileMetadata.Credentials.DATA_BASE_TYPE)) {
+      case S3FileMetadata.DATA_BASE_NAME :
+        output = new S3FileMetadata((String) input.get(AbstractFileMetadata.FILE_NAME),
+                                    (String) input.get(AbstractFileMetadata.FULL_PATH),
+                                    (long) input.get(AbstractFileMetadata.TIMESTAMP),
+                                    (String) input.get(AbstractFileMetadata.OWNER),
+                                    (long) input.get(AbstractFileMetadata.FILE_SIZE),
+                                    (Boolean) input.get(AbstractFileMetadata.IS_FOLDER),
+                                    (String) input.get(AbstractFileMetadata.BASE_PATH),
+                                    (short) input.get(AbstractFileMetadata.PERMISSION),
+                                    new S3FileMetadata.S3Credentials((String) input.get(S3Credentials.ACCESS_KEY_ID),
+                                                                     (String) input.get(S3Credentials.SECRET_KEY_ID),
+                                                                     (String) input.get(S3Credentials.REGION),
+                                                                     (String) input.get(S3Credentials.BUCKET_NAME))
+
+          );
+        break;
+
+      default:
+        throw new IllegalArgumentException("unrecognized database type");
+
+    }
+    emitter.emit(new KeyValue<NullWritable, AbstractFileMetadata>(null, output));
+  }
+
+  /**
+   * Abstract class for the configuration of FileCopySink
+   */
+  public abstract class AbstractFileCopySinkConfig extends ReferencePluginConfig {
+
+    @Macro
+    @Description("The destination path. Will be created if it doesn't exist.")
+    public String basePath;
+
+    @Description("Whether or not to overwrite if the file already exists.")
+    public Boolean enableOverwrite;
+
+    @Macro
+    @Nullable
+    @Description("The size of the buffer that temporarily stores data from file input stream.")
+    public int bufferSize;
+
+    public AbstractFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite, @Nullable int bufferSize) {
+      super(name);
+      this.basePath = basePath;
+      this.enableOverwrite = enableOverwrite;
+      this.bufferSize = bufferSize;
+    }
+    /*
+     * Additional configurations for the file sink should be implemented in the extended class
+     */
+  }
+
+  /**
+   * Adds necessary configuration resources and provides OutputFormat Class
+   */
+  public class FileCopyOutputFormatProvider implements OutputFormatProvider {
+    private final Map<String, String> conf;
+
+    /**
+     *
+     * @param config
+     */
+    public FileCopyOutputFormatProvider(AbstractFileCopySink.AbstractFileCopySinkConfig config) {
+      this.conf = new HashMap<>();
+      FileCopyOutputFormat.setBasePath(conf, config.basePath);
+      FileCopyOutputFormat.setEnableOverwrite(conf, config.enableOverwrite.toString());
+      FileCopyOutputFormat.setBufferSize(conf, String.valueOf(config.bufferSize));
+    }
+
+    @Override
+    public Map<String, String> getOutputFormatConfiguration() {
+      return conf;
+    }
+
+    @Override
+    public String getOutputFormatClassName() {
+      return FileCopyOutputFormat.class.getName();
+    }
+  }
+
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadata.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadata.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class that contains file metadata fields.
+ * Extend from this class to add credentials specific to different filesystems.
+ */
+public abstract class AbstractFileMetadata {
+  public static final String FILE_NAME = "fileName";
+  public static final String FILE_SIZE = "fileSize";
+  public static final String TIMESTAMP = "timeStamp";
+  public static final String OWNER = "owner";
+  public static final String FULL_PATH = "fullPath";
+  public static final String IS_FOLDER = "isFolder";
+  public static final String BASE_PATH = "basePath";
+  public static final String PERMISSION = "permission";
+
+  // contains only the name of the file
+  protected String fileName;
+
+  // full path of the file in the source filesystem
+  protected String fullPath;
+
+  // file size
+  protected long fileSize;
+
+  // modification time of file
+  protected long timeStamp;
+
+  // owner of file
+  protected String owner;
+
+  // whether or not the file is a folder
+  protected Boolean isFolder;
+
+  // the base path that will be appended to the path the sink is writing to
+  protected String basePath;
+
+  // perission of file, encoded in short
+  protected short permission;
+
+  // Credentials needed to connect to the filesystem that contains this file
+  protected final Credentials credentials;
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileMetadata.class);
+
+  public AbstractFileMetadata(FileStatus fileStatus, String sourcePath, Credentials credentials) {
+    String fullPath = fileStatus.getPath().toString();
+    String[] paths = fullPath.split("/");
+    this.fileName = paths[paths.length - 1];
+    this.timeStamp = fileStatus.getModificationTime();
+    this.owner = fileStatus.getOwner();
+    this.fileSize = fileStatus.getLen();
+    this.credentials = credentials;
+    this.permission = fileStatus.getPermission().toShort();
+
+    // generate file folder
+    this.fullPath = fullPath;
+
+    // check if file is a folder
+    this.isFolder = fileStatus.isDirectory();
+
+    // TODO: investigate how to cleanly set basePath
+    if (sourcePath.equals("")) {
+      basePath = this.fileName;
+    } else {
+      /*
+       * this block of code calculates how many folders (separated by "/")
+       * should be dropped from the prefix
+       */
+      int numSourcePaths = sourcePath.split("/").length;
+      int numStrip;
+      if (sourcePath.endsWith("/")) {
+        numStrip = numSourcePaths;
+        sourcePath = sourcePath.substring(0, sourcePath.length() - 1);
+      } else {
+        numStrip = numSourcePaths - 1;
+      }
+
+      /*
+       * this block of code drops the URI and reconstructs basePath by
+       * concatenating the folders with "/"
+       */
+      String pathWithoutURI = fullPath.substring(fullPath.indexOf(sourcePath));
+      String[] pathsWithoutURI = pathWithoutURI.split("/");
+      basePath = "";
+      for (int i = numStrip; i < pathsWithoutURI.length; i++) {
+        basePath = basePath.concat(pathsWithoutURI[i] + "/");
+      }
+      if (basePath.length() > 0) {
+        basePath = basePath.substring(0, basePath.length() - 1);
+      }
+    }
+  }
+
+  public AbstractFileMetadata(String fileName, String fullPath, long timeStamp, String owner,
+                              Long fileSize, Boolean isFolder, String basePath,
+                              short permission, Credentials credentials) {
+    this.fileName = fileName;
+    this.fullPath = fullPath;
+    this.timeStamp = timeStamp;
+    this.owner = owner;
+    this.fileSize = fileSize;
+    this.credentials = credentials;
+    this.isFolder = isFolder;
+    this.basePath = basePath;
+    this.permission = permission;
+  }
+
+  public String getFullPath() {
+    return fullPath;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public long getFileSize() {
+    return fileSize;
+  }
+
+  public long getTimeStamp() {
+    return timeStamp;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public abstract Credentials getCredentials();
+
+  public Boolean getIsFolder() {
+    return this.isFolder;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public short getPermission() {
+    return permission;
+  }
+
+  /**
+   * extend from this class to create a credential class for each filesystem
+   */
+  public abstract static class Credentials {
+    public String databaseType;
+    public static final String DATA_BASE_TYPE = "databaseType";
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadata.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadata.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.WritableComparable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +35,7 @@ import java.util.List;
  * Abstract class that contains file metadata fields.
  * Extend from this class to add credentials specific to different filesystems.
  */
-public abstract class AbstractFileMetadata implements WritableComparable {
+public abstract class AbstractFileMetadata implements Comparable {
 
   public static final String FILE_NAME = "fileName";
   public static final String FILE_SIZE = "fileSize";
@@ -45,9 +44,8 @@ public abstract class AbstractFileMetadata implements WritableComparable {
   public static final String GROUP = "group";
   public static final String FULL_PATH = "fullPath";
   public static final String IS_FOLDER = "isFolder";
-  public static final String BASE_PATH = "basePath";
+  public static final String RELATIVE_PATH = "relativePath";
   public static final String PERMISSION = "permission";
-  public static final String FILESYSTEM = "filesystem";
   public static final String HOST_URI = "hostURI";
 
   public static final Schema DEFAULT_SCHEMA = Schema.recordOf(
@@ -59,9 +57,8 @@ public abstract class AbstractFileMetadata implements WritableComparable {
     Schema.Field.of(GROUP, Schema.of(Schema.Type.LONG)),
     Schema.Field.of(OWNER, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(IS_FOLDER, Schema.of(Schema.Type.BOOLEAN)),
-    Schema.Field.of(BASE_PATH, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(RELATIVE_PATH, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(PERMISSION, Schema.of(Schema.Type.INT)),
-    Schema.Field.of(FILESYSTEM, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(HOST_URI, Schema.of(Schema.Type.STRING))
   );
 
@@ -88,20 +85,19 @@ public abstract class AbstractFileMetadata implements WritableComparable {
   private final boolean isFolder;
 
   /*
-   * the base path that will be appended to the path the sink is writing to
+   * The relavite path is constructed by deleting the portion of the source
+   * path that comes before the last path separator ("/") from the full path.
+   * It is assumed here that the source path is always a prefix of the full
+   * path.
+   *
    * For example, given full path http://example.com/foo/bar/baz/index.html
    *              and source path /foo/bar
-   *              the base path will be bar/baz/index.html
-   * Also note if the source path is an empty string, the base path will default to file name (index.html)
-   * in the case above
+   *              the relative path will be bar/baz/index.html
    */
-  private final String basePath;
+  private final String relativePath;
 
   // file permission, encoded in short
   private final short permission;
-
-  // AbstractCredentials needed to connect to the filesystem that contains this file
-  private final String filesystem;
 
   /*
    * URI for the Filesystem
@@ -113,55 +109,27 @@ public abstract class AbstractFileMetadata implements WritableComparable {
 
   protected AbstractFileMetadata(FileStatus fileStatus, String sourcePath) throws IOException {
     fileName = fileStatus.getPath().getName();
-    fullPath = fileStatus.getPath().toString();
+    fullPath = fileStatus.getPath().toUri().getPath();
     isFolder = fileStatus.isDirectory();
     modificationTime = fileStatus.getModificationTime();
     owner = fileStatus.getOwner();
     group = fileStatus.getGroup();
     fileSize = fileStatus.getLen();
-    filesystem = getFSName();
     permission = fileStatus.getPermission().toShort();
+
+    // check if sourcePath is a valid prefix of fullPath
+    if (fullPath.startsWith(sourcePath)) {
+      relativePath = fullPath.substring(sourcePath.lastIndexOf(Path.SEPARATOR) + 1);
+    } else {
+      throw new IOException("sourcePath should be a valid prefix of fullPath");
+    }
+
+    // construct host URI given the full path from filestatus
     try {
       hostURI = new URI(fileStatus.getPath().toUri().getScheme(), fileStatus.getPath().toUri().getHost(), null, null)
         .toString();
     } catch (URISyntaxException e) {
       throw new IOException(e.getMessage());
-    }
-
-    String pathSeparator = String.valueOf(Path.SEPARATOR_CHAR);
-    // TODO: investigate how to cleanly set basePath
-    if (sourcePath.isEmpty()) {
-      basePath = this.fileName;
-    } else {
-      /*
-       * this block of code calculates how many path components (separated by "/")
-       * should be dropped from the full path prefix
-       */
-      int numSourcePaths = sourcePath.split(pathSeparator).length;
-      int numStrip;
-      if (sourcePath.equals(String.valueOf(pathSeparator))) {
-        numStrip = 1;
-      } else if (sourcePath.endsWith(pathSeparator)) {
-        numStrip = numSourcePaths;
-      } else {
-        numStrip = numSourcePaths - 1;
-      }
-
-      /*
-       * this block of code drops the host name and reconstructs basePath by
-       * concatenating the folders with "/"
-       */
-      String pathWithoutHostName = fullPath.substring(hostURI.length());
-      String[] pathComponents = pathWithoutHostName.split(pathSeparator);
-      if (numStrip >= pathComponents.length) {
-        basePath = "";
-      } else {
-        Path tempBasePath = new Path(pathComponents[numStrip]);
-        for (int i = numStrip + 1; i < pathComponents.length; i++) {
-          tempBasePath = new Path(tempBasePath, pathComponents[i]);
-        }
-        basePath = tempBasePath.toString();
-      }
     }
   }
 
@@ -173,9 +141,8 @@ public abstract class AbstractFileMetadata implements WritableComparable {
     this.owner = record.get(OWNER);
     this.fileSize = record.get(FILE_SIZE);
     this.isFolder = record.get(IS_FOLDER);
-    this.basePath = record.get(BASE_PATH);
+    this.relativePath = record.get(RELATIVE_PATH);
     this.permission = record.get(PERMISSION);
-    this.filesystem = getFSName();
     this.hostURI = record.get(HOST_URI);
   }
 
@@ -191,9 +158,8 @@ public abstract class AbstractFileMetadata implements WritableComparable {
     this.owner = dataInput.readUTF();
     this.fileSize = dataInput.readLong();
     this.isFolder = dataInput.readBoolean();
-    this.basePath = dataInput.readUTF();
+    this.relativePath = dataInput.readUTF();
     this.permission = dataInput.readShort();
-    this.filesystem = dataInput.readUTF();
     this.hostURI = dataInput.readUTF();
   }
 
@@ -225,8 +191,8 @@ public abstract class AbstractFileMetadata implements WritableComparable {
     return isFolder;
   }
 
-  public String getBasePath() {
-    return basePath;
+  public String getRelativePath() {
+    return relativePath;
   }
 
   public short getPermission() {
@@ -235,10 +201,6 @@ public abstract class AbstractFileMetadata implements WritableComparable {
 
   public String getHostURI() {
     return hostURI;
-  }
-
-  public String getFilesystem() {
-    return filesystem;
   }
 
   /**
@@ -260,7 +222,7 @@ public abstract class AbstractFileMetadata implements WritableComparable {
       .set(GROUP, group)
       .set(OWNER, owner)
       .set(IS_FOLDER, isFolder)
-      .set(BASE_PATH, basePath)
+      .set(RELATIVE_PATH, relativePath)
       .set(PERMISSION, permission)
       .set(HOST_URI, hostURI);
     addCredentialsToBuilder(outputBuilder);
@@ -273,7 +235,6 @@ public abstract class AbstractFileMetadata implements WritableComparable {
     return Long.compare(fileSize, ((AbstractFileMetadata) o).getFileSize());
   }
 
-  @Override
   public void write(DataOutput dataOutput) throws IOException {
     dataOutput.writeUTF(getFileName());
     dataOutput.writeUTF(getFullPath());
@@ -282,21 +243,9 @@ public abstract class AbstractFileMetadata implements WritableComparable {
     dataOutput.writeUTF(getOwner());
     dataOutput.writeLong(getFileSize());
     dataOutput.writeBoolean(isFolder());
-    dataOutput.writeUTF(getBasePath());
+    dataOutput.writeUTF(getRelativePath());
     dataOutput.writeShort(getPermission());
-    dataOutput.writeUTF(getFilesystem());
     dataOutput.writeUTF(getHostURI());
-  }
-
-  /**
-   * Don't use this to deserialize AbstractFileMetadata. Use the constructor
-   * that takes DataInput as an input instead.
-   * @param dataInput
-   * @throws IOException
-   */
-  @Override
-  @Deprecated
-  public void readFields(DataInput dataInput) throws IOException {
   }
 
   /**
@@ -305,6 +254,4 @@ public abstract class AbstractFileMetadata implements WritableComparable {
   protected abstract Schema getCredentialSchema();
 
   protected abstract void addCredentialsToBuilder(StructuredRecord.Builder builder);
-
-  protected abstract String getFSName();
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataSource.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.hydrator.common.ReferenceBatchSource;
+import co.cask.hydrator.common.ReferencePluginConfig;
+import org.apache.hadoop.io.NullWritable;
+
+/**
+ * Abstract class for FileCopySource plugin. Extracts metadata of desired files
+ * from the source database.
+ * @param <K> the FileMetadata class specific to each database.
+ */
+public abstract class AbstractFileMetadataSource<K extends AbstractFileMetadata>
+  extends ReferenceBatchSource<NullWritable, K, StructuredRecord> {
+  public static final Schema DEFAULT_SCHEMA = Schema.recordOf(
+    "metadata",
+    Schema.Field.of(AbstractFileMetadata.FILE_NAME, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(AbstractFileMetadata.FULL_PATH, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(AbstractFileMetadata.FILE_SIZE, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(AbstractFileMetadata.TIMESTAMP, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(AbstractFileMetadata.OWNER, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(AbstractFileMetadata.IS_FOLDER, Schema.of(Schema.Type.BOOLEAN)),
+    Schema.Field.of(AbstractFileMetadata.BASE_PATH, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(AbstractFileMetadata.PERMISSION, Schema.of(Schema.Type.INT))
+  );
+
+  private final AbstractFileMetadataSourceConfig config;
+
+  public AbstractFileMetadataSource(AbstractFileMetadataSourceConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  /**
+   * Loads configurations from UI and check if they are valid.
+   */
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    this.config.validate();
+  }
+
+  /**
+   * Initialize the output StructuredRecord Schema here.
+   * @param context
+   * @throws Exception
+   */
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+  }
+
+  /**
+   * Load job configurations here.
+   */
+  public abstract void prepareRun(BatchSourceContext context) throws Exception;
+
+  /**
+   * Convert file metadata to StructuredRecord and emit.
+   */
+  public abstract void transform(KeyValue<NullWritable, K> input, Emitter<StructuredRecord> emitter);
+
+  /**
+   * Abstract class for the configuration of FileCopySink
+   */
+  public abstract class AbstractFileMetadataSourceConfig extends ReferencePluginConfig {
+
+    @Macro
+    @Description("Collection of sourcePaths separated by \",\" to read files from")
+    public String sourcePaths;
+
+    @Macro
+    @Description("The number of files each split manipulates")
+    public int maxSplitSize;
+
+    @Description("Whether or not to copy recursively")
+    public Boolean recursiveCopy;
+
+    public AbstractFileMetadataSourceConfig(String name, String sourcePaths, int maxSplitSize) {
+      super(name);
+      this.sourcePaths = sourcePaths;
+      this.maxSplitSize = maxSplitSize;
+    }
+
+    public void validate() {
+      }
+    }
+
+    /*
+     * Put additional configurations here for specific databases.
+     */
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputFormat.java
@@ -24,16 +24,17 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
 
@@ -49,7 +50,7 @@ public abstract class AbstractMetadataInputFormat<KEY, VALUE> extends InputForma
 
   protected static final String SOURCE_PATHS = "source.paths";
   protected static final String MAX_SPLIT_SIZE = "max.split.size";
-  protected static final String FS_URI = "uri";
+  protected static final String FS_URI = "filesystem.uri";
   protected static final String RECURSIVE_COPY = "recursive.copy";
   protected static final int DEFAULT_MAX_SPLIT_SIZE = 128;
   private static final Logger LOG = LoggerFactory.getLogger(AbstractMetadataInputFormat.class);
@@ -63,30 +64,27 @@ public abstract class AbstractMetadataInputFormat<KEY, VALUE> extends InputForma
     Configuration conf = jobContext.getConfiguration();
     URI uri = URI.create(conf.get(FS_URI));
     String[] sourcePaths = conf.get(SOURCE_PATHS).split(",");
-    Boolean recursiveCopy = conf.getBoolean(RECURSIVE_COPY, true);
+    boolean recursiveCopy = conf.getBoolean(RECURSIVE_COPY, true);
     FileSystem fileSystem = FileSystem.get(uri, conf);
     int maxSplitSize = conf.getInt(MAX_SPLIT_SIZE, DEFAULT_MAX_SPLIT_SIZE);
 
-    List<FileStatus> fileStatuses = new ArrayList<>();
-    List<String> baseFolders = new ArrayList<>();
-    for (String prefix : sourcePaths) {
-      try {
+    List<AbstractFileMetadata> fileMetaDataList = new ArrayList<>();
+    try {
+      for (String prefix : sourcePaths) {
         FileStatus fileStatus = fileSystem.getFileStatus(new Path(prefix));
         if (fileStatus.isFile()) {
           prefix = "";
         }
-        recursivelyAddFileStatus(fileStatuses, baseFolders, prefix, fileStatus, recursiveCopy, fileSystem);
-      } catch (Exception e) {
-        LOG.warn(e.getMessage());
+        recursivelyAddFileStatus(fileMetaDataList, prefix, fileStatus, recursiveCopy, fileSystem, conf);
       }
+    } catch (FileNotFoundException e) {
+      LOG.warn(e.getMessage());
+    } finally {
+      fileSystem.close();
     }
 
-    fileSystem.close();
-
-    // create a filemetadata list of all the files
-    List<AbstractFileMetadata> fileMetaDataList = getFileMetadaDataList(fileStatuses, baseFolders,
-                                                                        fileStatuses.size(),
-                                                                        getCredentialsFromConf(conf));
+    // sort fileMetadataList such that total number of bytes can be more evenly distributed
+    Collections.sort(fileMetaDataList);
 
     // compute number of splits and instantiate the splits
     int numSplits = (fileMetaDataList.size() - 1) / maxSplitSize + 1;
@@ -96,14 +94,20 @@ public abstract class AbstractMetadataInputFormat<KEY, VALUE> extends InputForma
     }
 
     // assign each split approximately the same number of bytes (2-approx)
+    List<InputSplit> inputSplits = new ArrayList<>();
     for (int i = 0; i < fileMetaDataList.size(); i++) {
       AbstractMetadataInputSplit minInputSplit = abstractInputSplits.poll();
       minInputSplit.addFileMetadata(fileMetaDataList.get(i));
-      abstractInputSplits.add(minInputSplit);
+
+      // if the inputsplit has number files more than maxSplitSize, we stop adding files to it
+      if (minInputSplit.getLength() < maxSplitSize) {
+        abstractInputSplits.add(minInputSplit);
+      } else {
+        inputSplits.add(minInputSplit);
+      }
     }
 
     // cast from AbstractMetadataInputSplit to InputSplit
-    List<InputSplit> inputSplits = new ArrayList<>();
     inputSplits.addAll(abstractInputSplits);
 
     return inputSplits;
@@ -118,54 +122,37 @@ public abstract class AbstractMetadataInputFormat<KEY, VALUE> extends InputForma
     return recordReader;
   }
 
-  private void recursivelyAddFileStatus (List<FileStatus> fileStatuses, List<String> baseFolders,
+  private void recursivelyAddFileStatus(List<AbstractFileMetadata> fileMetadataList,
                                          String prefix, FileStatus fileStatus, Boolean enable,
-                                         FileSystem fileSystem) throws Exception {
-    fileStatuses.add(fileStatus);
-    baseFolders.add(prefix);
+                                         FileSystem fileSystem, Configuration conf) throws IOException {
+    fileMetadataList.add(getFileMetaData(fileStatus, prefix, conf));
     if (enable && fileStatus.isDirectory()) {
       RemoteIterator<LocatedFileStatus> iter = fileSystem.listLocatedStatus(fileStatus.getPath());
       while (iter.hasNext()) {
         LocatedFileStatus fStatus = iter.next();
-        recursivelyAddFileStatus(fileStatuses, baseFolders, prefix, fStatus, enable, fileSystem);
+        recursivelyAddFileStatus(fileMetadataList, prefix, fStatus, enable, fileSystem, conf);
       }
     }
   }
 
-  private List<AbstractFileMetadata> getFileMetadaDataList (List<FileStatus> fileStatuses,
-                                                            List<String> baseFolders,
-                                                            int maxSplitSize,
-                                                            AbstractFileMetadata.Credentials credentials) {
-    int numFiles = Math.min(fileStatuses.size(), maxSplitSize);
-    List<AbstractFileMetadata> metaDataList = new ArrayList<>();
-    for (int i = 0; i < numFiles; i++) {
-      metaDataList.add(getFileMetaData(fileStatuses.remove(0), baseFolders.remove(0), credentials));
-    }
-
-    return metaDataList;
-  }
-
-  protected abstract AbstractFileMetadata.Credentials getCredentialsFromConf(Configuration conf);
-
   protected abstract AbstractMetadataInputSplit getInputSplit();
 
-  protected abstract AbstractFileMetadata getFileMetaData(FileStatus fileStatus,
-                                                          String sourcePath,
-                                                          AbstractFileMetadata.Credentials credentials);
+  protected abstract AbstractFileMetadata getFileMetaData(FileStatus fileStatus, String sourcePath, Configuration conf)
+    throws IOException;
 
-  public static void setSourcePaths(Job job, String value) {
-    job.getConfiguration().set(SOURCE_PATHS, value);
+  public static void setSourcePaths(Configuration conf, String value) {
+    conf.set(SOURCE_PATHS, value);
   }
 
-  public static void setMaxSplitSize(Job job, int value) {
-    job.getConfiguration().setInt(MAX_SPLIT_SIZE, value);
+  public static void setMaxSplitSize(Configuration conf, int value) {
+    conf.setInt(MAX_SPLIT_SIZE, value);
   }
 
-  public static void setURI(Job job, String value) {
-    job.getConfiguration().set(FS_URI, value);
+  public static void setURI(Configuration conf, String value) {
+    conf.set(FS_URI, value);
   }
 
-  public static void setRecursiveCopy(Job job, String value) {
-    job.getConfiguration().set(RECURSIVE_COPY, value);
+  public static void setRecursiveCopy(Configuration conf, String value) {
+    conf.set(RECURSIVE_COPY, value);
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputFormat.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+
+/**
+ * Abstract class that implements the inputFormat for the FileCopySource plugin to
+ * read file metadata. The getsplit method creates splits according to user-set configuration
+ * and tries to assign files to each split such that every split copies roughly the same number of bytes.
+ * @param <KEY>
+ * @param <VALUE>
+ */
+public abstract class AbstractMetadataInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE> {
+
+  protected static final String SOURCE_PATHS = "source.paths";
+  protected static final String MAX_SPLIT_SIZE = "max.split.size";
+  protected static final String FS_URI = "uri";
+  protected static final String RECURSIVE_COPY = "recursive.copy";
+  protected static final int DEFAULT_MAX_SPLIT_SIZE = 128;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractMetadataInputFormat.class);
+
+  public AbstractMetadataInputFormat() {
+  }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext jobContext) throws IOException, InterruptedException {
+    // connect to the source filesystem
+    Configuration conf = jobContext.getConfiguration();
+    URI uri = URI.create(conf.get(FS_URI));
+    String[] sourcePaths = conf.get(SOURCE_PATHS).split(",");
+    Boolean recursiveCopy = conf.getBoolean(RECURSIVE_COPY, true);
+    FileSystem fileSystem = FileSystem.get(uri, conf);
+    int maxSplitSize = conf.getInt(MAX_SPLIT_SIZE, DEFAULT_MAX_SPLIT_SIZE);
+
+    List<FileStatus> fileStatuses = new ArrayList<>();
+    List<String> baseFolders = new ArrayList<>();
+    for (String prefix : sourcePaths) {
+      try {
+        FileStatus fileStatus = fileSystem.getFileStatus(new Path(prefix));
+        if (fileStatus.isFile()) {
+          prefix = "";
+        }
+        recursivelyAddFileStatus(fileStatuses, baseFolders, prefix, fileStatus, recursiveCopy, fileSystem);
+      } catch (Exception e) {
+        LOG.warn(e.getMessage());
+      }
+    }
+
+    fileSystem.close();
+
+    // create a filemetadata list of all the files
+    List<AbstractFileMetadata> fileMetaDataList = getFileMetadaDataList(fileStatuses, baseFolders,
+                                                                        fileStatuses.size(),
+                                                                        getCredentialsFromConf(conf));
+
+    // compute number of splits and instantiate the splits
+    int numSplits = (fileMetaDataList.size() - 1) / maxSplitSize + 1;
+    PriorityQueue<AbstractMetadataInputSplit> abstractInputSplits = new PriorityQueue<>(numSplits);
+    for (int i = 0; i < numSplits; i++) {
+      abstractInputSplits.add(getInputSplit());
+    }
+
+    // assign each split approximately the same number of bytes (2-approx)
+    for (int i = 0; i < fileMetaDataList.size(); i++) {
+      AbstractMetadataInputSplit minInputSplit = abstractInputSplits.poll();
+      minInputSplit.addFileMetadata(fileMetaDataList.get(i));
+      abstractInputSplits.add(minInputSplit);
+    }
+
+    // cast from AbstractMetadataInputSplit to InputSplit
+    List<InputSplit> inputSplits = new ArrayList<>();
+    inputSplits.addAll(abstractInputSplits);
+
+    return inputSplits;
+  }
+
+
+  @Override
+  public RecordReader createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+    MetadataRecordReader recordReader = new MetadataRecordReader();
+    recordReader.initialize(inputSplit, taskAttemptContext);
+    return recordReader;
+  }
+
+  private void recursivelyAddFileStatus (List<FileStatus> fileStatuses, List<String> baseFolders,
+                                         String prefix, FileStatus fileStatus, Boolean enable,
+                                         FileSystem fileSystem) throws Exception {
+    fileStatuses.add(fileStatus);
+    baseFolders.add(prefix);
+    if (enable && fileStatus.isDirectory()) {
+      RemoteIterator<LocatedFileStatus> iter = fileSystem.listLocatedStatus(fileStatus.getPath());
+      while (iter.hasNext()) {
+        LocatedFileStatus fStatus = iter.next();
+        recursivelyAddFileStatus(fileStatuses, baseFolders, prefix, fStatus, enable, fileSystem);
+      }
+    }
+  }
+
+  private List<AbstractFileMetadata> getFileMetadaDataList (List<FileStatus> fileStatuses,
+                                                            List<String> baseFolders,
+                                                            int maxSplitSize,
+                                                            AbstractFileMetadata.Credentials credentials) {
+    int numFiles = Math.min(fileStatuses.size(), maxSplitSize);
+    List<AbstractFileMetadata> metaDataList = new ArrayList<>();
+    for (int i = 0; i < numFiles; i++) {
+      metaDataList.add(getFileMetaData(fileStatuses.remove(0), baseFolders.remove(0), credentials));
+    }
+
+    return metaDataList;
+  }
+
+  protected abstract AbstractFileMetadata.Credentials getCredentialsFromConf(Configuration conf);
+
+  protected abstract AbstractMetadataInputSplit getInputSplit();
+
+  protected abstract AbstractFileMetadata getFileMetaData(FileStatus fileStatus,
+                                                          String sourcePath,
+                                                          AbstractFileMetadata.Credentials credentials);
+
+  public static void setSourcePaths(Job job, String value) {
+    job.getConfiguration().set(SOURCE_PATHS, value);
+  }
+
+  public static void setMaxSplitSize(Job job, int value) {
+    job.getConfiguration().setInt(MAX_SPLIT_SIZE, value);
+  }
+
+  public static void setURI(Job job, String value) {
+    job.getConfiguration().set(FS_URI, value);
+  }
+
+  public static void setRecursiveCopy(Job job, String value) {
+    job.getConfiguration().set(RECURSIVE_COPY, value);
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplit.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplit.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract class that implements information for InputSplit.
+ * Contains a list of fileMetadata that is assigned to the specific split.
+ */
+public abstract class AbstractMetadataInputSplit extends InputSplit implements Writable, Comparable {
+  protected List<AbstractFileMetadata> fileMetaDataList;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractMetadataInputSplit.class);
+
+  public AbstractMetadataInputSplit(List<AbstractFileMetadata> fileMetaDataList) {
+    this.fileMetaDataList = fileMetaDataList;
+  }
+
+  public AbstractMetadataInputSplit() {
+    this.fileMetaDataList = new ArrayList<>();
+  }
+
+  public List<AbstractFileMetadata> getFileMetaDataList() {
+    return this.fileMetaDataList;
+  }
+
+  @Override
+  public void write(DataOutput dataOutput) throws IOException {
+    try {
+      // write obj summaries
+      dataOutput.writeLong(this.getLength());
+      for (int i = 0; i < this.getLength(); i++) {
+        // convert each filestatus (serializable) to byte array
+        AbstractFileMetadata fileMetaData = fileMetaDataList.get(i);
+
+        dataOutput.writeUTF(fileMetaData.getFileName());
+        dataOutput.writeUTF(fileMetaData.getFullPath());
+        dataOutput.writeLong(fileMetaData.getTimeStamp());
+        dataOutput.writeUTF(fileMetaData.getOwner());
+        dataOutput.writeLong(fileMetaData.getFileSize());
+        dataOutput.writeBoolean(fileMetaData.getIsFolder());
+        dataOutput.writeUTF(fileMetaData.getBasePath());
+        dataOutput.writeShort(fileMetaData.getPermission());
+
+        writeCredentials(dataOutput, fileMetaData.getCredentials());
+      }
+
+    } catch (Exception e) {
+      LOG.error("serialization failed");
+    }
+  }
+
+  @Override
+  public void readFields(DataInput dataInput) throws IOException {
+    try {
+      long numObjects = dataInput.readLong();
+      fileMetaDataList = new ArrayList<>();
+      for (long i = 0; i < numObjects; i++) {
+        String fileName = dataInput.readUTF();
+        String fileFolder = dataInput.readUTF();
+        long timeStamp = dataInput.readLong();
+        String owner = dataInput.readUTF();
+        long fileSize = dataInput.readLong();
+        Boolean isFolder = dataInput.readBoolean();
+        String baseFolder = dataInput.readUTF();
+        short permission = dataInput.readShort();
+
+        AbstractFileMetadata.Credentials credentials = readCredentials(dataInput);
+
+        fileMetaDataList.add(getFileMetaData(fileName,
+                                             fileFolder,
+                                             timeStamp,
+                                             owner,
+                                             fileSize,
+                                             isFolder,
+                                             baseFolder,
+                                             permission,
+                                             credentials));
+      }
+    } catch (Exception e) {
+      LOG.error("deserialization failed");
+    }
+  }
+
+  @Override
+  public long getLength() throws IOException, InterruptedException {
+    return fileMetaDataList.size();
+  }
+
+  public long getTotalSize() {
+    long size = 0;
+    for (AbstractFileMetadata fileMetaData : fileMetaDataList) {
+      size += fileMetaData.getFileSize();
+    }
+
+    return size;
+  }
+
+  @Override
+  public String[] getLocations() throws IOException, InterruptedException {
+    return new String[0];
+  }
+
+  public void addFileMetadata(AbstractFileMetadata fileMetaData) {
+    fileMetaDataList.add(fileMetaData);
+  }
+
+  @Override
+  public int compareTo(Object o) {
+    AbstractMetadataInputSplit other = (AbstractMetadataInputSplit) o;
+    long myLength = getTotalSize();
+    long otherLength = other.getTotalSize();
+    if (myLength < otherLength) {
+      return -1;
+    } else if (myLength == otherLength) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
+
+  protected abstract void writeCredentials(DataOutput dataOutput,
+                                           AbstractFileMetadata.Credentials credentials) throws Exception;
+
+  protected abstract AbstractFileMetadata.Credentials readCredentials(DataInput dataInput)
+    throws Exception;
+
+  protected abstract AbstractFileMetadata getFileMetaData(String fileName,
+                                                          String fileFolder,
+                                                          long timeStamp,
+                                                          String owner,
+                                                          long fileSize,
+                                                          Boolean isFolder,
+                                                          String baseFolder,
+                                                          short permission,
+                                                          AbstractFileMetadata.Credentials credentials);
+}
+
+

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplit.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplit.java
@@ -56,11 +56,11 @@ public abstract class AbstractMetadataInputSplit extends InputSplit implements W
   @Override
   public void write(DataOutput dataOutput) throws IOException {
     try {
-      // write number of files
-      dataOutput.writeLong(this.getLength());
-
       // write total number of file bytes
       dataOutput.writeLong(this.getTotalBytes());
+
+      // write number of files
+      dataOutput.writeLong(this.getLength());
 
       for (AbstractFileMetadata fileMetaData : fileMetaDataList) {
         // convert each filestatus (serializable) to byte array
@@ -74,17 +74,16 @@ public abstract class AbstractMetadataInputSplit extends InputSplit implements W
 
   @Override
   public void readFields(DataInput dataInput) throws IOException {
-    // read number of files
-    long numObjects = dataInput.readLong();
-
     // get total number of bytes
     totalBytes = dataInput.readLong();
+
+    // read number of files
+    long numObjects = dataInput.readLong();
 
     fileMetaDataList = new ArrayList<>();
     for (long i = 0; i < numObjects; i++) {
       AbstractFileMetadata metadata = readFileMetaData(dataInput);
       fileMetaDataList.add(metadata);
-      totalBytes += metadata.getFileSize();
     }
   }
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
@@ -35,7 +35,6 @@ public class FileCopyOutputFormat extends OutputFormat {
   public static final String BASE_PATH = "base.path";
   public static final String ENABLE_OVERWRITE = "enable.overwrite";
   public static final String PRESERVE_OWNER = "preserve.owner";
-  public static final String FS_CACHE = "filesystem.cache";
   public static final String BUFFER_SIZE = "buffer.size";
   public static final String FS_HOST_URI = "filesystem.host.uri";
 
@@ -51,11 +50,6 @@ public class FileCopyOutputFormat extends OutputFormat {
 
   public static void setPreserveFileOwner(Map<String, String> conf, String value) {
     conf.put(PRESERVE_OWNER, value);
-  }
-
-  public static void setFilesystemCaching(Map<String, String> conf, Boolean value, String destScheme) {
-    conf.put(FS_CACHE, value.toString());
-    conf.put(String.format("fs.%s.impl.disable.cache", destScheme), String.valueOf(!value));
   }
 
   public static void setBufferSize(Map<String, String> conf, String value) {
@@ -109,10 +103,6 @@ public class FileCopyOutputFormat extends OutputFormat {
   @Override
   public RecordWriter getRecordWriter(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
     Configuration conf = taskAttemptContext.getConfiguration();
-    try {
-      return new FileCopyRecordWriter(conf);
-    } catch (Exception e) {
-      throw new IOException(e.getMessage());
-    }
+    return new FileCopyRecordWriter(conf);
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Class for the OutputFormat that FileCopySink uses.
+ */
+public class FileCopyOutputFormat extends OutputFormat {
+  protected static final String BASE_PATH = "base.path";
+  protected static final String ENABLE_OVERWRITE = "enable.overwrite";
+  protected static final String BUFFER_SIZE = "buffer.size";
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileCopyOutputFormat.class);
+
+  public static void setBasePath(Map<String, String> conf, String value) {
+    conf.put(BASE_PATH, value);
+  }
+
+  public static void setEnableOverwrite(Map<String, String> conf, String value) {
+    conf.put(ENABLE_OVERWRITE, value);
+  }
+
+  public static void setBufferSize(Map<String, String> conf, String value) {
+    conf.put(BUFFER_SIZE, value);
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
+
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) {
+    try {
+      return new FileOutputCommitter(new Path(taskAttemptContext.getConfiguration().get(BASE_PATH)),
+                                     taskAttemptContext);
+    } catch (IOException e) {
+      LOG.error(e.getMessage());
+      return null;
+    }
+  }
+
+  @Override
+  public RecordWriter getRecordWriter(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    Configuration conf = taskAttemptContext.getConfiguration();
+    try {
+      return new FileCopyRecordWriter(conf);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
@@ -17,13 +17,11 @@
 package co.cask.hydrator.plugin.batch.file;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,9 +32,12 @@ import java.util.Map;
  * Class for the OutputFormat that FileCopySink uses.
  */
 public class FileCopyOutputFormat extends OutputFormat {
-  protected static final String BASE_PATH = "base.path";
-  protected static final String ENABLE_OVERWRITE = "enable.overwrite";
-  protected static final String BUFFER_SIZE = "buffer.size";
+  public static final String BASE_PATH = "base.path";
+  public static final String ENABLE_OVERWRITE = "enable.overwrite";
+  public static final String PRESERVE_OWNER = "preserve.owner";
+  public static final String FS_CACHE = "filesystem.cache";
+  public static final String BUFFER_SIZE = "buffer.size";
+  public static final String FS_HOST_URI = "filesystem.host.uri";
 
   private static final Logger LOG = LoggerFactory.getLogger(FileCopyOutputFormat.class);
 
@@ -48,24 +49,61 @@ public class FileCopyOutputFormat extends OutputFormat {
     conf.put(ENABLE_OVERWRITE, value);
   }
 
+  public static void setPreserveFileOwner(Map<String, String> conf, String value) {
+    conf.put(PRESERVE_OWNER, value);
+  }
+
+  public static void setFilesystemCaching(Map<String, String> conf, Boolean value, String destScheme) {
+    conf.put(FS_CACHE, value.toString());
+    conf.put(String.format("fs.%s.impl.disable.cache", destScheme), String.valueOf(!value));
+  }
+
   public static void setBufferSize(Map<String, String> conf, String value) {
     conf.put(BUFFER_SIZE, value);
   }
 
+  public static void setFilesystemHostUri(Map<String, String> conf, String value) {
+    conf.put(FS_HOST_URI, value);
+  }
+
+
   @Override
   public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
-
+    // check if base path is set
+    if (jobContext.getConfiguration().get(BASE_PATH, null) == null) {
+      throw new IOException("Base path not set.");
+    }
   }
 
   @Override
   public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) {
-    try {
-      return new FileOutputCommitter(new Path(taskAttemptContext.getConfiguration().get(BASE_PATH)),
-                                     taskAttemptContext);
-    } catch (IOException e) {
-      LOG.error(e.getMessage());
-      return null;
-    }
+    // TODO: implement an OutputCommitter for file copying jobs, or investigate whether we can use FileOutputCommitter
+    return new OutputCommitter() {
+      @Override
+      public void setupJob(JobContext jobContext) throws IOException {
+        // no op
+      }
+
+      @Override
+      public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+        // no op
+      }
+
+      @Override
+      public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+        return false;
+      }
+
+      @Override
+      public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+        // no op
+      }
+
+      @Override
+      public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+        // no op
+      }
+    };
   }
 
   @Override
@@ -74,7 +112,7 @@ public class FileCopyOutputFormat extends OutputFormat {
     try {
       return new FileCopyRecordWriter(conf);
     } catch (Exception e) {
-      return null;
+      throw new IOException(e.getMessage());
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyOutputFormat.java
@@ -37,6 +37,7 @@ public class FileCopyOutputFormat extends OutputFormat {
   public static final String PRESERVE_OWNER = "preserve.owner";
   public static final String BUFFER_SIZE = "buffer.size";
   public static final String FS_HOST_URI = "filesystem.host.uri";
+  public static final String FS_SCHEME = "filesystem.scheme";
 
   private static final Logger LOG = LoggerFactory.getLogger(FileCopyOutputFormat.class);
 
@@ -60,6 +61,9 @@ public class FileCopyOutputFormat extends OutputFormat {
     conf.put(FS_HOST_URI, value);
   }
 
+  public static void setFilesystemScheme(Map<String, String> conf, String value) {
+    conf.put(FS_SCHEME, value);
+  }
 
   @Override
   public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
@@ -41,88 +41,128 @@ import java.util.Map;
  * to destination database
  */
 public class FileCopyRecordWriter extends RecordWriter<NullWritable, AbstractFileMetadata> {
-  private FileSystem destFileSystem;
-  private String basePath;
-  private Boolean enableOverwrite;
-  private int bufferSize;
+  private final FileSystem destFileSystem;
+  private final String basePath;
+  private final boolean enableOverwrite;
+  private final boolean preserveOwner;
+  private final boolean fsCache;
+  private final int bufferSize;
+
   // buffer size defaults to 1 MB
   private static final int defaultBufferSize = 2 << 20;
   private static final Logger LOG = LoggerFactory.getLogger(FileCopyRecordWriter.class);
 
-  public FileCopyRecordWriter(Configuration conf)
-    throws Exception {
-    this.destFileSystem = FileSystem.get(conf);
-    this.basePath = conf.get(FileCopyOutputFormat.BASE_PATH);
-    this.enableOverwrite = conf.getBoolean(FileCopyOutputFormat.ENABLE_OVERWRITE, false);
-    this.bufferSize = conf.getInt(FileCopyOutputFormat.BUFFER_SIZE, defaultBufferSize);
-    this.sourceFilesystemMap = new HashMap<>();
-  }
-
   // source filesystems
-  private Map<AbstractFileMetadata.Credentials, FileSystem> sourceFilesystemMap;
+  private Map<String, FileSystem> sourceFilesystemMap;
+
+  public FileCopyRecordWriter(Configuration conf) throws Exception {
+    // connect to destination filesystem using uri if it is provided
+    String uriString;
+    if ((uriString = conf.get(FileCopyOutputFormat.FS_HOST_URI, null)) != null) {
+      destFileSystem = FileSystem.get(URI.create(uriString), conf);
+    } else {
+      destFileSystem = FileSystem.get(conf);
+    }
+    basePath = conf.get(FileCopyOutputFormat.BASE_PATH);
+    enableOverwrite = conf.getBoolean(FileCopyOutputFormat.ENABLE_OVERWRITE, false);
+    preserveOwner = conf.getBoolean(FileCopyOutputFormat.PRESERVE_OWNER, false);
+    fsCache = conf.getBoolean(FileCopyOutputFormat.FS_CACHE, true);
+    bufferSize = conf.getInt(FileCopyOutputFormat.BUFFER_SIZE, defaultBufferSize);
+    sourceFilesystemMap = new HashMap<>();
+  }
 
   @Override
   public void write(NullWritable key, AbstractFileMetadata fileMetadata) throws IOException, InterruptedException {
-    // get source database connection
-    AbstractFileMetadata.Credentials sourceCredentials = fileMetadata.getCredentials();
-    if (!sourceFilesystemMap.containsKey(sourceCredentials)) {
-      sourceFilesystemMap.put(sourceCredentials, getSourceFilesystemFromCredentials(sourceCredentials));
-    }
-    FileSystem sourceFilesystem = sourceFilesystemMap.get(sourceCredentials);
-
     // construct file paths for source and destination
-    Path srcPath = new Path(fileMetadata.fullPath);
-    Path destPath = new Path(basePath + "/" + fileMetadata.basePath);
+    Path srcPath = new Path(fileMetadata.getFullPath());
+    Path destPath;
+    if (fileMetadata.getBasePath().isEmpty()) {
+      // nothing to create
+      return;
+    } else {
+      destPath = new Path(basePath, fileMetadata.getBasePath());
+    }
     FsPermission permission = new FsPermission(fileMetadata.getPermission());
 
-    if (fileMetadata.isFolder) {
+    // immediately return if we don't want to overwrite and file exists in destination
+    if (!enableOverwrite && destFileSystem.exists(destPath)) {
+      return;
+    }
+
+    // get source database connection
+    String uriString = fileMetadata.getHostURI();
+    if (!sourceFilesystemMap.containsKey(uriString)) {
+      sourceFilesystemMap.put(uriString, getSourceFilesystemConnection(fileMetadata, fsCache));
+    }
+    FileSystem sourceFilesystem = sourceFilesystemMap.get(uriString);
+
+    if (fileMetadata.isFolder()) {
       // create an empty folder and return
       if (!destFileSystem.exists(destPath) && sourceFilesystem.isDirectory(srcPath)) {
         destFileSystem.mkdirs(destPath, permission);
+        if (preserveOwner) {
+          destFileSystem.setOwner(destPath, fileMetadata.getOwner(), fileMetadata.getGroup());
+        }
       }
       return;
     } else if (!sourceFilesystem.exists(srcPath)) {
       // file doesn't exist in source, return immediately
-      return;
-    }
-
-    // immediately return if we dont want to overwrite and file exists in destination
-    if (!enableOverwrite && destFileSystem.exists(destPath)) {
+      LOG.warn("{} doesn't exist in source filesystem.", fileMetadata.getFullPath());
       return;
     }
 
     // data streaming
     FSDataInputStream inputStream = sourceFilesystem.open(srcPath);
     FSDataOutputStream outputStream = FileSystem.create(destFileSystem, destPath, permission);
-    byte[] buf = new byte[bufferSize];
-    int len;
-    while ((len = inputStream.read(buf)) >= 0) {
-      outputStream.write(buf, 0, len);
+    try {
+      byte[] buf = new byte[bufferSize];
+      int len;
+      while ((len = inputStream.read(buf)) >= 0) {
+        outputStream.write(buf, 0, len);
+      }
+    } finally {
+      if (preserveOwner) {
+        destFileSystem.setOwner(destPath, fileMetadata.getOwner(), fileMetadata.getGroup());
+      }
+      inputStream.close();
+      outputStream.close();
     }
-    inputStream.close();
-    outputStream.close();
   }
 
   @Override
   public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
     /*
      * TODO: investigate when to close the destination filesystem and the source filesystems
-     * We can't close the filesystems here because the filesystem instantiation is shared across
+     * if we use cached connections
+     * We can't close the filesystems here because the filesystem cache is shared across
      * multiple splits. If one split closes the connection, other splits will fail to transfer.
      */
+    if (!fsCache) {
+      destFileSystem.close();
+      for (Map.Entry<String, FileSystem> fs : sourceFilesystemMap.entrySet()) {
+        fs.getValue().close();
+      }
+    }
   }
 
-  private FileSystem getSourceFilesystemFromCredentials(AbstractFileMetadata.Credentials credentials)
+  private FileSystem getSourceFilesystemConnection(AbstractFileMetadata metadata, boolean cache)
     throws IOException {
     Configuration conf = new Configuration(false);
     conf.clear();
-    switch (credentials.databaseType) {
-      case S3FileMetadata.DATA_BASE_NAME :
-        S3FileMetadata.S3Credentials s3Credentials = (S3FileMetadata.S3Credentials) credentials;
-        conf.set("fs.s3a.access.key", s3Credentials.accessKeyId);
-        conf.set("fs.s3a.secret.key", s3Credentials.secretKeyId);
+
+    // turn filesystem caching off
+    URI uri = URI.create(metadata.getHostURI());
+
+    // whether or not to disable caching for source filesystems
+    String disableCacheName = String.format("fs.%s.impl.disable.cache", uri.getScheme());
+    conf.set(disableCacheName, String.valueOf(!cache));
+
+    switch (metadata.getFilesystem()) {
+      case S3FileMetadata.FILESYSTEM_NAME :
+        S3FileMetadata s3FileMetadata = (S3FileMetadata) metadata;
+        conf.set("fs.s3a.access.key", s3FileMetadata.getAccessKeyId());
+        conf.set("fs.s3a.secret.key", s3FileMetadata.getSecretKeyId());
         conf.set("fs.s3a.impl", S3AFileSystem.class.getName());
-        URI uri = URI.create("s3a://" + s3Credentials.bucketName);
         return NativeS3FileSystem.get(uri, conf);
     }
     return null;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/FileCopyRecordWriter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3native.NativeS3FileSystem;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The record writer that takes file metadata and streams data from source database
+ * to destination database
+ */
+public class FileCopyRecordWriter extends RecordWriter<NullWritable, AbstractFileMetadata> {
+  private FileSystem destFileSystem;
+  private String basePath;
+  private Boolean enableOverwrite;
+  private int bufferSize;
+  // buffer size defaults to 1 MB
+  private static final int defaultBufferSize = 2 << 20;
+  private static final Logger LOG = LoggerFactory.getLogger(FileCopyRecordWriter.class);
+
+  public FileCopyRecordWriter(Configuration conf)
+    throws Exception {
+    this.destFileSystem = FileSystem.get(conf);
+    this.basePath = conf.get(FileCopyOutputFormat.BASE_PATH);
+    this.enableOverwrite = conf.getBoolean(FileCopyOutputFormat.ENABLE_OVERWRITE, false);
+    this.bufferSize = conf.getInt(FileCopyOutputFormat.BUFFER_SIZE, defaultBufferSize);
+    this.sourceFilesystemMap = new HashMap<>();
+  }
+
+  // source filesystems
+  private Map<AbstractFileMetadata.Credentials, FileSystem> sourceFilesystemMap;
+
+  @Override
+  public void write(NullWritable key, AbstractFileMetadata fileMetadata) throws IOException, InterruptedException {
+    // get source database connection
+    AbstractFileMetadata.Credentials sourceCredentials = fileMetadata.getCredentials();
+    if (!sourceFilesystemMap.containsKey(sourceCredentials)) {
+      sourceFilesystemMap.put(sourceCredentials, getSourceFilesystemFromCredentials(sourceCredentials));
+    }
+    FileSystem sourceFilesystem = sourceFilesystemMap.get(sourceCredentials);
+
+    // construct file paths for source and destination
+    Path srcPath = new Path(fileMetadata.fullPath);
+    Path destPath = new Path(basePath + "/" + fileMetadata.basePath);
+    FsPermission permission = new FsPermission(fileMetadata.getPermission());
+
+    if (fileMetadata.isFolder) {
+      // create an empty folder and return
+      if (!destFileSystem.exists(destPath) && sourceFilesystem.isDirectory(srcPath)) {
+        destFileSystem.mkdirs(destPath, permission);
+      }
+      return;
+    } else if (!sourceFilesystem.exists(srcPath)) {
+      // file doesn't exist in source, return immediately
+      return;
+    }
+
+    // immediately return if we dont want to overwrite and file exists in destination
+    if (!enableOverwrite && destFileSystem.exists(destPath)) {
+      return;
+    }
+
+    // data streaming
+    FSDataInputStream inputStream = sourceFilesystem.open(srcPath);
+    FSDataOutputStream outputStream = FileSystem.create(destFileSystem, destPath, permission);
+    byte[] buf = new byte[bufferSize];
+    int len;
+    while ((len = inputStream.read(buf)) >= 0) {
+      outputStream.write(buf, 0, len);
+    }
+    inputStream.close();
+    outputStream.close();
+  }
+
+  @Override
+  public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    /*
+     * TODO: investigate when to close the destination filesystem and the source filesystems
+     * We can't close the filesystems here because the filesystem instantiation is shared across
+     * multiple splits. If one split closes the connection, other splits will fail to transfer.
+     */
+  }
+
+  private FileSystem getSourceFilesystemFromCredentials(AbstractFileMetadata.Credentials credentials)
+    throws IOException {
+    Configuration conf = new Configuration(false);
+    conf.clear();
+    switch (credentials.databaseType) {
+      case S3FileMetadata.DATA_BASE_NAME :
+        S3FileMetadata.S3Credentials s3Credentials = (S3FileMetadata.S3Credentials) credentials;
+        conf.set("fs.s3a.access.key", s3Credentials.accessKeyId);
+        conf.set("fs.s3a.secret.key", s3Credentials.secretKeyId);
+        conf.set("fs.s3a.impl", S3AFileSystem.class.getName());
+        URI uri = URI.create("s3a://" + s3Credentials.bucketName);
+        return NativeS3FileSystem.get(uri, conf);
+    }
+    return null;
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/MetadataRecordReader.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/MetadataRecordReader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * Returns key that contains file path.
+ * Returns value that contains file attributes.
+ */
+public class MetadataRecordReader extends RecordReader<NullWritable, AbstractFileMetadata> {
+
+  protected int currentIndex;
+  protected AbstractMetadataInputSplit split;
+
+  public MetadataRecordReader() {
+    super();
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    if ((currentIndex + 1) < split.getLength()) {
+      currentIndex++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public NullWritable getCurrentKey() throws IOException, InterruptedException {
+    return null;
+  }
+
+
+  @Override
+  public float getProgress() throws IOException, InterruptedException {
+    return (1 - ((float) currentIndex / split.getLength()));
+  }
+
+  @Override
+  public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+
+    // sorry I should think of a better way instead of casting
+    this.split = (AbstractMetadataInputSplit) inputSplit;
+
+    this.currentIndex = -1;
+  }
+
+  @Override
+  public AbstractFileMetadata getCurrentValue() throws IOException, InterruptedException {
+    return split.getFileMetaDataList().get(currentIndex);
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
@@ -45,9 +45,9 @@ public class HDFSFileCopySink extends AbstractFileCopySink {
    * Configurations required for connecting to HDFS.
    */
   public class HDFSFileCopySinkConfig extends AbstractFileCopySinkConfig {
-    public HDFSFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite, Boolean filesystemCaching,
+    public HDFSFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite,
                                   Boolean preserveFileOwner, @Nullable Integer bufferSize) {
-      super(name, basePath, enableOverwrite, filesystemCaching, preserveFileOwner, bufferSize);
+      super(name, basePath, enableOverwrite, preserveFileOwner, bufferSize);
     }
 
     @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.hdfs;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.hydrator.plugin.batch.file.AbstractFileCopySink;
+import com.sun.istack.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FileCopySink that writes to HDFS.
+ */
+@Plugin(type = BatchSink.PLUGIN_TYPE)
+@Name("HDFSFileCopySink")
+@Description("Copies files from remote filesystem to HDFS")
+public class HDFSFileCopySink extends AbstractFileCopySink {
+
+  private HDFSFileCopySinkConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(HDFSFileCopySink.class);
+
+  public HDFSFileCopySink(HDFSFileCopySinkConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    context.addOutput(Output.of(config.referenceName, new FileCopyOutputFormatProvider(config)));
+  }
+
+  /**
+   * Configurations required for connecting to HDFS.
+   */
+  public class HDFSFileCopySinkConfig extends AbstractFileCopySinkConfig {
+    public HDFSFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite, @Nullable int bufferSize) {
+      super(name, basePath, enableOverwrite, bufferSize);
+    }
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/hdfs/HDFSFileCopySink.java
@@ -19,9 +19,7 @@ package co.cask.hydrator.plugin.batch.file.hdfs;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
-import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.etl.api.batch.BatchSink;
-import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.hydrator.plugin.batch.file.AbstractFileCopySink;
 import com.sun.istack.Nullable;
 import org.slf4j.Logger;
@@ -43,17 +41,23 @@ public class HDFSFileCopySink extends AbstractFileCopySink {
     this.config = config;
   }
 
-  @Override
-  public void prepareRun(BatchSinkContext context) throws Exception {
-    context.addOutput(Output.of(config.referenceName, new FileCopyOutputFormatProvider(config)));
-  }
-
   /**
    * Configurations required for connecting to HDFS.
    */
   public class HDFSFileCopySinkConfig extends AbstractFileCopySinkConfig {
-    public HDFSFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite, @Nullable int bufferSize) {
-      super(name, basePath, enableOverwrite, bufferSize);
+    public HDFSFileCopySinkConfig(String name, String basePath, Boolean enableOverwrite, Boolean filesystemCaching,
+                                  Boolean preserveFileOwner, @Nullable Integer bufferSize) {
+      super(name, basePath, enableOverwrite, filesystemCaching, preserveFileOwner, bufferSize);
+    }
+
+    @Override
+    public String getScheme() {
+      return "hdfs";
+    }
+
+    @Override
+    public String getHostUri() {
+      return null;
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadata.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadata.java
@@ -33,13 +33,11 @@ import java.io.IOException;
  */
 public class S3FileMetadata extends AbstractFileMetadata {
 
-  public static final String FILESYSTEM_NAME = "amazons3";
   public static final String ACCESS_KEY_ID = "accessKeyID";
   public static final String SECRET_KEY_ID = "secretKeyID";
   public static final String REGION = "region";
   public static final Schema CREDENTIAL_SCHEMA = Schema.recordOf(
     "metadata",
-    Schema.Field.of(FILESYSTEM, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(ACCESS_KEY_ID, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(SECRET_KEY_ID, Schema.of(Schema.Type.STRING)),
     Schema.Field.of(REGION, Schema.of(Schema.Type.STRING))
@@ -93,7 +91,6 @@ public class S3FileMetadata extends AbstractFileMetadata {
   @Override
   protected void addCredentialsToBuilder(StructuredRecord.Builder builder) {
     builder
-      .set(FILESYSTEM, FILESYSTEM_NAME)
       .set(ACCESS_KEY_ID, accessKeyId)
       .set(SECRET_KEY_ID, secretKeyId)
       .set(REGION, region);
@@ -105,10 +102,5 @@ public class S3FileMetadata extends AbstractFileMetadata {
     dataOutput.writeUTF(accessKeyId);
     dataOutput.writeUTF(secretKeyId);
     dataOutput.writeUTF(region);
-  }
-
-  @Override
-  protected String getFSName() {
-    return FILESYSTEM_NAME;
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadata.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadata.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import org.apache.hadoop.fs.FileStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filemetadata specific for S3. Defines credentials that are required for
+ * connecting to S3.
+ */
+public class S3FileMetadata extends AbstractFileMetadata {
+
+  public static final String DATA_BASE_NAME = "amazons3";
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3FileMetadata.class);
+
+  public S3FileMetadata(FileStatus fileStatus, String sourcePath, S3Credentials credentials) {
+    super(fileStatus, sourcePath, credentials);
+  }
+
+  public S3FileMetadata(String fileName, String fileFolder, long timeStamp, String owner, Long fileSize,
+                        Boolean isFolder, String baseFolder, short permission, S3Credentials credentials) {
+    super(fileName, fileFolder, timeStamp, owner, fileSize, isFolder, baseFolder, permission, credentials);
+  }
+
+  /**
+   * S3Credentials. Contains access key, secret key, region, and bucket name.
+   */
+  public static class S3Credentials extends Credentials {
+    // use these strings to set the schema
+    public static final String ACCESS_KEY_ID = "accessKeyId";
+    public static final String SECRET_KEY_ID = "secretKeyId";
+    public static final String REGION = "region";
+    public static final String BUCKET_NAME = "bucketName";
+
+    public String accessKeyId;
+    public String secretKeyId;
+    public String region;
+    public String bucketName;
+
+    public S3Credentials(String accessKeyId, String secretKeyId, String region, String bucketName) {
+      this.databaseType = S3FileMetadata.DATA_BASE_NAME;
+      this.accessKeyId = accessKeyId;
+      this.secretKeyId = secretKeyId;
+      this.region = region;
+      this.bucketName = bucketName;
+    }
+  }
+
+  @Override
+  public S3Credentials getCredentials() {
+    return (S3Credentials) this.credentials;
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.format.StructuredRecord;
-import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
@@ -31,7 +30,6 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.hydrator.common.SourceInputFormatProvider;
 import co.cask.hydrator.common.batch.JobUtils;
-import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
 import co.cask.hydrator.plugin.batch.file.AbstractFileMetadataSource;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
@@ -39,8 +37,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -58,31 +54,20 @@ public class S3FileMetadataSource extends AbstractFileMetadataSource<S3FileMetad
     this.config = config;
   }
 
-  public static final Schema S3_CREDENTIAL_SCHEMA = Schema.recordOf(
-    "metadata",
-    Schema.Field.of(S3FileMetadata.S3Credentials.DATA_BASE_TYPE, Schema.of(Schema.Type.STRING)),
-    Schema.Field.of(S3FileMetadata.S3Credentials.ACCESS_KEY_ID, Schema.of(Schema.Type.STRING)),
-    Schema.Field.of(S3FileMetadata.S3Credentials.SECRET_KEY_ID, Schema.of(Schema.Type.STRING)),
-    Schema.Field.of(S3FileMetadata.S3Credentials.REGION, Schema.of(Schema.Type.STRING)),
-    Schema.Field.of(S3FileMetadata.S3Credentials.BUCKET_NAME, Schema.of(Schema.Type.STRING))
-  );
-
-  private Schema outputSchema;
-
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
+    super.prepareRun(context);
     Job job = JobUtils.createInstance();
     Configuration conf = job.getConfiguration();
 
-    S3MetadataInputFormat.setSourcePaths(job, config.sourcePaths);
-    S3MetadataInputFormat.setMaxSplitSize(job, config.maxSplitSize);
-    S3MetadataInputFormat.setAccessKeyId(job, config.accessKeyId);
-    S3MetadataInputFormat.setRecursiveCopy(job, config.recursiveCopy.toString());
-    S3MetadataInputFormat.setSecretKeyId(job, config.secretKeyId);
-    S3MetadataInputFormat.setRegion(job, config.region);
-    S3MetadataInputFormat.setURI(job, "s3a://" + config.bucketName);
-    S3MetadataInputFormat.setFsClass(job);
-    S3MetadataInputFormat.setBucketName(job, config.bucketName);
+    S3MetadataInputFormat.setSourcePaths(conf, config.sourcePaths);
+    S3MetadataInputFormat.setMaxSplitSize(conf, config.maxSplitSize);
+    S3MetadataInputFormat.setAccessKeyId(conf, config.accessKeyId);
+    S3MetadataInputFormat.setRecursiveCopy(conf, config.recursiveCopy.toString());
+    S3MetadataInputFormat.setSecretKeyId(conf, config.secretKeyId);
+    S3MetadataInputFormat.setRegion(conf, config.region);
+    S3MetadataInputFormat.setURI(conf, config.filesystemURI);
+    S3MetadataInputFormat.setFsClass(conf);
 
     context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(S3MetadataInputFormat.class, conf)));
   }
@@ -90,36 +75,15 @@ public class S3FileMetadataSource extends AbstractFileMetadataSource<S3FileMetad
   @Override
   public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
-
-    // initialize output schema
-    List<Schema.Field> fieldList = new ArrayList<>(DEFAULT_SCHEMA.getFields());
-    fieldList.addAll(S3_CREDENTIAL_SCHEMA.getFields());
-    outputSchema = Schema.recordOf("metadata", fieldList);
   }
 
   @Override
   public void transform(KeyValue<NullWritable, S3FileMetadata> input, Emitter<StructuredRecord> emitter) {
-    StructuredRecord output = StructuredRecord.builder(outputSchema)
-      .set(AbstractFileMetadata.FILE_NAME, input.getValue().getFileName())
-      .set(AbstractFileMetadata.FULL_PATH, input.getValue().getFullPath())
-      .set(AbstractFileMetadata.FILE_SIZE, input.getValue().getFileSize())
-      .set(AbstractFileMetadata.TIMESTAMP, input.getValue().getTimeStamp())
-      .set(AbstractFileMetadata.OWNER, input.getValue().getOwner())
-      .set(AbstractFileMetadata.IS_FOLDER, input.getValue().getIsFolder())
-      .set(AbstractFileMetadata.BASE_PATH, input.getValue().getBasePath())
-      .set(AbstractFileMetadata.PERMISSION, input.getValue().getPermission())
-      // credentials
-      .set(S3FileMetadata.S3Credentials.DATA_BASE_TYPE, input.getValue().getCredentials().databaseType)
-      .set(S3FileMetadata.S3Credentials.ACCESS_KEY_ID, input.getValue().getCredentials().accessKeyId)
-      .set(S3FileMetadata.S3Credentials.SECRET_KEY_ID, input.getValue().getCredentials().secretKeyId)
-      .set(S3FileMetadata.S3Credentials.REGION, input.getValue().getCredentials().region)
-      .set(S3FileMetadata.S3Credentials.BUCKET_NAME, input.getValue().getCredentials().bucketName)
-      .build();
-    emitter.emit(output);
+    emitter.emit(input.getValue().toRecord());
   }
 
   /**
-   * Credentials required for connecting to S3Filesystem.
+   * AbstractCredentials required for connecting to S3Filesystem.
    */
   public class S3FileMetadataSourceConfig extends AbstractFileMetadataSourceConfig {
 
@@ -137,17 +101,22 @@ public class S3FileMetadataSource extends AbstractFileMetadataSource<S3FileMetad
     @Description("The AWS Region to operate in")
     public String region;
 
-    @Macro
-    @Description("The AWS Bucket Name to work with")
-    public String bucketName;
-
-    public S3FileMetadataSourceConfig(String name, String sourcePaths, int maxSplitSize,
-                                  String accessKeyId, String secretKeyId, String region, String bucketName) {
-      super(name, sourcePaths, maxSplitSize);
+    public S3FileMetadataSourceConfig(String name, String sourcePaths, Integer maxSplitSize, String filesystemURI,
+                                      String accessKeyId, String secretKeyId, String region) {
+      super(name, sourcePaths, maxSplitSize, filesystemURI);
       this.accessKeyId = accessKeyId;
       this.secretKeyId = secretKeyId;
       this.region = region;
-      this.bucketName = bucketName;
+    }
+
+    @Override
+    public void validate() {
+      super.validate();
+      if (!this.containsMacro("filesystemURI")) {
+        if (!filesystemURI.startsWith("s3a://")) {
+          throw new IllegalArgumentException("URI for S3 source must start with s3a://");
+        }
+      }
     }
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.hydrator.common.SourceInputFormatProvider;
+import co.cask.hydrator.common.batch.JobUtils;
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadataSource;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * FileCopySource plugin that pulls filemetadata from S3 Filesystem.
+ */
+@Plugin(type = BatchSource.PLUGIN_TYPE)
+@Name("S3FileMetadataSource")
+@Description("Reads file metadata from S3 bucket.")
+public class S3FileMetadataSource extends AbstractFileMetadataSource<S3FileMetadata> {
+  private S3FileMetadataSourceConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(S3FileMetadataSource.class);
+
+  public S3FileMetadataSource(S3FileMetadataSourceConfig config) {
+    super(config);
+    this.config = config;
+  }
+
+  public static final Schema S3_CREDENTIAL_SCHEMA = Schema.recordOf(
+    "metadata",
+    Schema.Field.of(S3FileMetadata.S3Credentials.DATA_BASE_TYPE, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(S3FileMetadata.S3Credentials.ACCESS_KEY_ID, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(S3FileMetadata.S3Credentials.SECRET_KEY_ID, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(S3FileMetadata.S3Credentials.REGION, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(S3FileMetadata.S3Credentials.BUCKET_NAME, Schema.of(Schema.Type.STRING))
+  );
+
+  private Schema outputSchema;
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    Job job = JobUtils.createInstance();
+    Configuration conf = job.getConfiguration();
+
+    S3MetadataInputFormat.setSourcePaths(job, config.sourcePaths);
+    S3MetadataInputFormat.setMaxSplitSize(job, config.maxSplitSize);
+    S3MetadataInputFormat.setAccessKeyId(job, config.accessKeyId);
+    S3MetadataInputFormat.setRecursiveCopy(job, config.recursiveCopy.toString());
+    S3MetadataInputFormat.setSecretKeyId(job, config.secretKeyId);
+    S3MetadataInputFormat.setRegion(job, config.region);
+    S3MetadataInputFormat.setURI(job, "s3a://" + config.bucketName);
+    S3MetadataInputFormat.setFsClass(job);
+    S3MetadataInputFormat.setBucketName(job, config.bucketName);
+
+    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(S3MetadataInputFormat.class, conf)));
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+
+    // initialize output schema
+    List<Schema.Field> fieldList = new ArrayList<>(DEFAULT_SCHEMA.getFields());
+    fieldList.addAll(S3_CREDENTIAL_SCHEMA.getFields());
+    outputSchema = Schema.recordOf("metadata", fieldList);
+  }
+
+  @Override
+  public void transform(KeyValue<NullWritable, S3FileMetadata> input, Emitter<StructuredRecord> emitter) {
+    StructuredRecord output = StructuredRecord.builder(outputSchema)
+      .set(AbstractFileMetadata.FILE_NAME, input.getValue().getFileName())
+      .set(AbstractFileMetadata.FULL_PATH, input.getValue().getFullPath())
+      .set(AbstractFileMetadata.FILE_SIZE, input.getValue().getFileSize())
+      .set(AbstractFileMetadata.TIMESTAMP, input.getValue().getTimeStamp())
+      .set(AbstractFileMetadata.OWNER, input.getValue().getOwner())
+      .set(AbstractFileMetadata.IS_FOLDER, input.getValue().getIsFolder())
+      .set(AbstractFileMetadata.BASE_PATH, input.getValue().getBasePath())
+      .set(AbstractFileMetadata.PERMISSION, input.getValue().getPermission())
+      // credentials
+      .set(S3FileMetadata.S3Credentials.DATA_BASE_TYPE, input.getValue().getCredentials().databaseType)
+      .set(S3FileMetadata.S3Credentials.ACCESS_KEY_ID, input.getValue().getCredentials().accessKeyId)
+      .set(S3FileMetadata.S3Credentials.SECRET_KEY_ID, input.getValue().getCredentials().secretKeyId)
+      .set(S3FileMetadata.S3Credentials.REGION, input.getValue().getCredentials().region)
+      .set(S3FileMetadata.S3Credentials.BUCKET_NAME, input.getValue().getCredentials().bucketName)
+      .build();
+    emitter.emit(output);
+  }
+
+  /**
+   * Credentials required for connecting to S3Filesystem.
+   */
+  public class S3FileMetadataSourceConfig extends AbstractFileMetadataSourceConfig {
+
+    // configurations for S3
+    @Macro
+    @Description("Your AWS Access Key Id")
+    public String accessKeyId;
+
+    @Macro
+    @Description("Your AWS Secret Key Id")
+    public String secretKeyId;
+
+    @Macro
+    @Nullable
+    @Description("The AWS Region to operate in")
+    public String region;
+
+    @Macro
+    @Description("The AWS Bucket Name to work with")
+    public String bucketName;
+
+    public S3FileMetadataSourceConfig(String name, String sourcePaths, int maxSplitSize,
+                                  String accessKeyId, String secretKeyId, String region, String bucketName) {
+      super(name, sourcePaths, maxSplitSize);
+      this.accessKeyId = accessKeyId;
+      this.secretKeyId = secretKeyId;
+      this.region = region;
+      this.bucketName = bucketName;
+    }
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3FileMetadataSource.java
@@ -67,11 +67,12 @@ public class S3FileMetadataSource extends AbstractFileMetadataSource<S3FileMetad
     S3MetadataInputFormat.setRegion(conf, config.region);
     S3MetadataInputFormat.setURI(conf, config.filesystemURI);
 
-    if (config.filesystemURI.startsWith("s3a")) {
+    String fsScheme = URI.create(config.filesystemURI).getScheme();
+    if (fsScheme.equals("s3a")) {
       S3MetadataInputFormat.setS3aAccessKeyId(conf, config.accessKeyId);
       S3MetadataInputFormat.setS3aSecretKeyId(conf, config.secretKeyId);
       S3MetadataInputFormat.setS3aFsClass(conf);
-    } else if (config.filesystemURI.startsWith("s3n")) {
+    } else if (fsScheme.equals("s3n")) {
       S3MetadataInputFormat.setS3nAccessKeyId(conf, config.accessKeyId);
       S3MetadataInputFormat.setS3nSecretKeyId(conf, config.secretKeyId);
       S3MetadataInputFormat.setS3nFsClass(conf);

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputFormat.java
@@ -22,9 +22,10 @@ import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputSplit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.mapreduce.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * MetadataInputFormat for S3 Filesystem. Implements credentials setters
@@ -36,37 +37,23 @@ public class S3MetadataInputFormat extends AbstractMetadataInputFormat {
   private static final String SECRET_KEY_ID = "fs.s3a.secret.key";
   private static final String FS_CLASS = "fs.s3a.impl";
   private static final String REGION = "amazons3.region";
-  private static final String BUCKET_NAME = "amazons3.bucket.name";
   private static final Logger LOG = LoggerFactory.getLogger(S3MetadataInputFormat.class);
 
 
-  public static void setAccessKeyId(Job job, String value) {
-    job.getConfiguration().set(ACCESS_KEY_ID, value);
+  public static void setAccessKeyId(Configuration conf, String value) {
+    conf.set(ACCESS_KEY_ID, value);
   }
 
-  public static void setSecretKeyId(Job job, String value) {
-    job.getConfiguration().set(SECRET_KEY_ID, value);
+  public static void setSecretKeyId(Configuration conf, String value) {
+    conf.set(SECRET_KEY_ID, value);
   }
 
-  public static void setRegion(Job job, String value) {
-    job.getConfiguration().set(REGION, value);
+  public static void setRegion(Configuration conf, String value) {
+    conf.set(REGION, value);
   }
 
-  public static void setFsClass(Job job) {
-    job.getConfiguration().set(FS_CLASS, S3AFileSystem.class.getName());
-  }
-
-  public static void setBucketName(Job job, String value) {
-    job.getConfiguration().set(BUCKET_NAME, value);
-  }
-
-  @Override
-  protected AbstractFileMetadata.Credentials getCredentialsFromConf(Configuration conf) {
-    String bucketName = conf.get(BUCKET_NAME);
-    String accessKeyId = conf.get(ACCESS_KEY_ID);
-    String region = conf.get(REGION);
-    String secretKeyId = conf.get(SECRET_KEY_ID);
-    return new S3FileMetadata.S3Credentials(accessKeyId, secretKeyId, region, bucketName);
+  public static void setFsClass(Configuration conf) {
+    conf.set(FS_CLASS, S3AFileSystem.class.getName());
   }
 
   @Override
@@ -75,8 +62,9 @@ public class S3MetadataInputFormat extends AbstractMetadataInputFormat {
   }
 
   @Override
-  protected AbstractFileMetadata getFileMetaData(FileStatus fileStatus, String sourcePath,
-                                                 AbstractFileMetadata.Credentials credentials) {
-    return new S3FileMetadata(fileStatus, sourcePath, (S3FileMetadata.S3Credentials) credentials);
+  protected AbstractFileMetadata getFileMetaData(FileStatus fileStatus, String sourcePath, Configuration conf)
+    throws IOException {
+    return new S3FileMetadata(fileStatus, sourcePath,
+                              conf.get(ACCESS_KEY_ID), conf.get(SECRET_KEY_ID), conf.get(REGION));
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputFormat.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputFormat;
+import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputSplit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.mapreduce.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MetadataInputFormat for S3 Filesystem. Implements credentials setters
+ * specific for S3
+ */
+public class S3MetadataInputFormat extends AbstractMetadataInputFormat {
+
+  private static final String ACCESS_KEY_ID = "fs.s3a.access.key";
+  private static final String SECRET_KEY_ID = "fs.s3a.secret.key";
+  private static final String FS_CLASS = "fs.s3a.impl";
+  private static final String REGION = "amazons3.region";
+  private static final String BUCKET_NAME = "amazons3.bucket.name";
+  private static final Logger LOG = LoggerFactory.getLogger(S3MetadataInputFormat.class);
+
+
+  public static void setAccessKeyId(Job job, String value) {
+    job.getConfiguration().set(ACCESS_KEY_ID, value);
+  }
+
+  public static void setSecretKeyId(Job job, String value) {
+    job.getConfiguration().set(SECRET_KEY_ID, value);
+  }
+
+  public static void setRegion(Job job, String value) {
+    job.getConfiguration().set(REGION, value);
+  }
+
+  public static void setFsClass(Job job) {
+    job.getConfiguration().set(FS_CLASS, S3AFileSystem.class.getName());
+  }
+
+  public static void setBucketName(Job job, String value) {
+    job.getConfiguration().set(BUCKET_NAME, value);
+  }
+
+  @Override
+  protected AbstractFileMetadata.Credentials getCredentialsFromConf(Configuration conf) {
+    String bucketName = conf.get(BUCKET_NAME);
+    String accessKeyId = conf.get(ACCESS_KEY_ID);
+    String region = conf.get(REGION);
+    String secretKeyId = conf.get(SECRET_KEY_ID);
+    return new S3FileMetadata.S3Credentials(accessKeyId, secretKeyId, region, bucketName);
+  }
+
+  @Override
+  protected AbstractMetadataInputSplit getInputSplit() {
+    return new S3MetadataInputSplit();
+  }
+
+  @Override
+  protected AbstractFileMetadata getFileMetaData(FileStatus fileStatus, String sourcePath,
+                                                 AbstractFileMetadata.Credentials credentials) {
+    return new S3FileMetadata(fileStatus, sourcePath, (S3FileMetadata.S3Credentials) credentials);
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputSplit.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputSplit.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file.s3;
+
+import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
+import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.util.List;
+
+
+/**
+ * InputSplit that implements methods for serializing S3 Credentials
+ */
+public class S3MetadataInputSplit extends AbstractMetadataInputSplit {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3MetadataInputSplit.class);
+
+  public S3MetadataInputSplit(List<AbstractFileMetadata> s3FileMetadataList) {
+    super(s3FileMetadataList);
+  }
+
+  public S3MetadataInputSplit() {
+    super();
+  }
+
+  @Override
+  protected AbstractFileMetadata getFileMetaData(String fileName,
+                                                 String fileFolder,
+                                                 long timeStamp,
+                                                 String owner,
+                                                 long fileSize,
+                                                 Boolean isFolder,
+                                                 String baseFolder,
+                                                 short permission,
+                                                 AbstractFileMetadata.Credentials credentials) {
+    return new S3FileMetadata(fileName,
+                              fileFolder,
+                              timeStamp,
+                              owner,
+                              fileSize,
+                              isFolder,
+                              baseFolder,
+                              permission,
+                              (S3FileMetadata.S3Credentials) credentials);
+  }
+
+  @Override
+  protected void writeCredentials(DataOutput dataOutput, AbstractFileMetadata.Credentials credentials)
+    throws Exception {
+    S3FileMetadata.S3Credentials s3Credentials = (S3FileMetadata.S3Credentials) credentials;
+    dataOutput.writeUTF(s3Credentials.bucketName);
+    dataOutput.writeUTF(s3Credentials.accessKeyId);
+    dataOutput.writeUTF(s3Credentials.secretKeyId);
+    dataOutput.writeUTF(s3Credentials.region);
+  }
+
+  @Override
+  protected AbstractFileMetadata.Credentials readCredentials(DataInput dataInput) throws Exception {
+    String bucketName = dataInput.readUTF();
+    String accessKeyId = dataInput.readUTF();
+    String secretKeyId = dataInput.readUTF();
+    String region = dataInput.readUTF();
+    return new S3FileMetadata.S3Credentials(accessKeyId, secretKeyId, region, bucketName);
+  }
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputSplit.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/file/s3/S3MetadataInputSplit.java
@@ -18,21 +18,16 @@ package co.cask.hydrator.plugin.batch.file.s3;
 
 import co.cask.hydrator.plugin.batch.file.AbstractFileMetadata;
 import co.cask.hydrator.plugin.batch.file.AbstractMetadataInputSplit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.DataInput;
-import java.io.DataOutput;
+import java.io.IOException;
 import java.util.List;
 
 
 /**
- * InputSplit that implements methods for serializing S3 Credentials
+ * InputSplit that implements methods for serializing S3 AbstractCredentials
  */
 public class S3MetadataInputSplit extends AbstractMetadataInputSplit {
-
-  private static final Logger LOG = LoggerFactory.getLogger(S3MetadataInputSplit.class);
-
   public S3MetadataInputSplit(List<AbstractFileMetadata> s3FileMetadataList) {
     super(s3FileMetadataList);
   }
@@ -42,42 +37,7 @@ public class S3MetadataInputSplit extends AbstractMetadataInputSplit {
   }
 
   @Override
-  protected AbstractFileMetadata getFileMetaData(String fileName,
-                                                 String fileFolder,
-                                                 long timeStamp,
-                                                 String owner,
-                                                 long fileSize,
-                                                 Boolean isFolder,
-                                                 String baseFolder,
-                                                 short permission,
-                                                 AbstractFileMetadata.Credentials credentials) {
-    return new S3FileMetadata(fileName,
-                              fileFolder,
-                              timeStamp,
-                              owner,
-                              fileSize,
-                              isFolder,
-                              baseFolder,
-                              permission,
-                              (S3FileMetadata.S3Credentials) credentials);
-  }
-
-  @Override
-  protected void writeCredentials(DataOutput dataOutput, AbstractFileMetadata.Credentials credentials)
-    throws Exception {
-    S3FileMetadata.S3Credentials s3Credentials = (S3FileMetadata.S3Credentials) credentials;
-    dataOutput.writeUTF(s3Credentials.bucketName);
-    dataOutput.writeUTF(s3Credentials.accessKeyId);
-    dataOutput.writeUTF(s3Credentials.secretKeyId);
-    dataOutput.writeUTF(s3Credentials.region);
-  }
-
-  @Override
-  protected AbstractFileMetadata.Credentials readCredentials(DataInput dataInput) throws Exception {
-    String bucketName = dataInput.readUTF();
-    String accessKeyId = dataInput.readUTF();
-    String secretKeyId = dataInput.readUTF();
-    String region = dataInput.readUTF();
-    return new S3FileMetadata.S3Credentials(accessKeyId, secretKeyId, region, bucketName);
+  protected AbstractFileMetadata readFileMetaData(DataInput dataInput) throws IOException {
+    return new S3FileMetadata(dataInput);
   }
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataTest.java
@@ -36,7 +36,7 @@ public class AbstractFileMetadataTest {
     S3FileMetadata metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
     Assert.assertEquals(metadata.getFileName(), "123.txt");
     Assert.assertEquals(metadata.getFullPath(), "s3a://abc.def.bucket/source/path/directory/123.txt");
-    Assert.assertEquals(metadata.getBasePath(), "directory/123.txt");
+    Assert.assertEquals(metadata.getRelativePath(), "directory/123.txt");
     Assert.assertEquals(metadata.getHostURI(), "s3a://abc.def.bucket");
 
     // Copy a file that is part of a whole directory copy without including the directory
@@ -44,42 +44,18 @@ public class AbstractFileMetadataTest {
     metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
     Assert.assertEquals(metadata.getFileName(), "123.txt");
     Assert.assertEquals(metadata.getFullPath(), "s3a://abc.def.bucket/source/path/directory/123.txt");
-    Assert.assertEquals(metadata.getBasePath(), "directory/123.txt");
+    Assert.assertEquals(metadata.getRelativePath(), "directory/123.txt");
     Assert.assertEquals(metadata.getHostURI(), "s3a://abc.def.bucket");
-
-    // Copy a single file
-    sourcePath = "";
-    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
-    Assert.assertEquals(metadata.getFileName(), "123.txt");
-    Assert.assertEquals(metadata.getFullPath(), "s3a://abc.def.bucket/source/path/directory/123.txt");
-    Assert.assertEquals(metadata.getBasePath(), "123.txt");
-    Assert.assertEquals(metadata.getHostURI(), "s3a://abc.def.bucket");
-
-    // more tests with single directory copy
-    fileStatus.setPath(new Path("s3a://abc.def.bucket/redshift/"));
-    sourcePath = "/redshift/";
-    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
-    Assert.assertEquals(metadata.getBasePath().isEmpty(), true);
-
-    fileStatus.setPath(new Path("s3a://abc.def.bucket/redshift"));
-    sourcePath = "/redshift/";
-    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
-    Assert.assertEquals(metadata.getBasePath().isEmpty(), true);
 
     fileStatus.setPath(new Path("s3a://abc.def.bucket/"));
     sourcePath = "/";
     metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
-    Assert.assertEquals(metadata.getBasePath().isEmpty(), true);
-
-    fileStatus.setPath(new Path("s3a://abc.def.bucket"));
-    sourcePath = "/";
-    metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
-    Assert.assertEquals(metadata.getBasePath().isEmpty(), true);
+    Assert.assertEquals(metadata.getRelativePath().isEmpty(), true);
 
     fileStatus.setPath(new Path("s3a://abc.def.bucket/abc.txt"));
     sourcePath = "/";
     metadata = new S3FileMetadata(fileStatus, sourcePath, null, null, null);
-    Assert.assertEquals(metadata.getBasePath(), "abc.txt");
+    Assert.assertEquals(metadata.getRelativePath(), "abc.txt");
   }
 
   @Test

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractFileMetadataTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractFileMetadataTest {
+
+  @Test
+  public void testConvertFileStatusToFileMetaData() {
+    FileStatus fileStatus = new FileStatus();
+    fileStatus.setPath(new Path("s3a://abc.def.bucket/source/path/directory/123.txt"));
+
+    // Copy a file that is part of a whole directory copy
+    String sourcePath = "/source/path/directory";
+    S3FileMetadata.S3Credentials credentials = new S3FileMetadata.S3Credentials(null, null, null, null);
+    S3FileMetadata metadata = new S3FileMetadata(fileStatus, sourcePath, credentials);
+    Assert.assertEquals(metadata.getFileName(), "123.txt");
+    Assert.assertEquals(metadata.getFullPath(), "s3a://abc.def.bucket/source/path/directory/123.txt");
+    Assert.assertEquals(metadata.getBasePath(), "directory/123.txt");
+
+    // Copy a file that is part of a whole directory copy without including the directory
+    sourcePath = "/source/path/";
+    credentials = new S3FileMetadata.S3Credentials(null, null, null, null);
+    metadata = new S3FileMetadata(fileStatus, sourcePath, credentials);
+    Assert.assertEquals(metadata.getFileName(), "123.txt");
+    Assert.assertEquals(metadata.getFullPath(), "s3a://abc.def.bucket/source/path/directory/123.txt");
+    Assert.assertEquals(metadata.getBasePath(), "directory/123.txt");
+
+    // Copy a single file
+    sourcePath = "";
+    credentials = new S3FileMetadata.S3Credentials(null, null, null, null);
+    metadata = new S3FileMetadata(fileStatus, sourcePath, credentials);
+    Assert.assertEquals(metadata.getFileName(), "123.txt");
+    Assert.assertEquals(metadata.getFullPath(), "s3a://abc.def.bucket/source/path/directory/123.txt");
+    Assert.assertEquals(metadata.getBasePath(), "123.txt");
+  }
+
+}

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplitTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/file/AbstractMetadataInputSplitTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.file;
+
+import co.cask.hydrator.plugin.batch.file.s3.S3FileMetadata;
+import co.cask.hydrator.plugin.batch.file.s3.S3MetadataInputSplit;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
+public class AbstractMetadataInputSplitTest {
+  @Test
+  public void testSerializeAndDeserialize() throws Exception {
+    S3MetadataInputSplit metadataInputSplit = new S3MetadataInputSplit();
+
+    S3FileMetadata.S3Credentials credentials = new S3FileMetadata.S3Credentials("akey", "skey", "region", "bname");
+    S3FileMetadata originalMetadata = new S3FileMetadata("fileName",
+                                                         "fullPath",
+                                                         123456,
+                                                         "owner",
+                                                         (long) 678910,
+                                                         false,
+                                                         "basePath",
+                                                         (short) 166,
+                                                         credentials);
+    metadataInputSplit.addFileMetadata(originalMetadata);
+
+    // serialize input split
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream outputStream = new DataOutputStream(byteArrayOutputStream);
+    metadataInputSplit.write(outputStream);
+    outputStream.flush();
+    outputStream.close();
+    byte[] serialized = byteArrayOutputStream.toByteArray();
+
+    // deserialize input split
+    S3MetadataInputSplit recoveredInputSplit = new S3MetadataInputSplit();
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serialized);
+    DataInputStream inputStream = new DataInputStream(byteArrayInputStream);
+    recoveredInputSplit.readFields(inputStream);
+    inputStream.close();
+
+    // compare if fields are right
+    S3FileMetadata recoveredMetadata = (S3FileMetadata) recoveredInputSplit.getFileMetaDataList().get(0);
+    Assert.assertEquals(recoveredMetadata.getFileName(), "fileName");
+    Assert.assertEquals(recoveredMetadata.getFullPath(), "fullPath");
+    Assert.assertEquals(recoveredMetadata.getTimeStamp(), 123456);
+    Assert.assertEquals(recoveredMetadata.getOwner(), "owner");
+    Assert.assertEquals(recoveredMetadata.getFileSize(), (long) 678910);
+    Assert.assertEquals(recoveredMetadata.getIsFolder(), false);
+    Assert.assertEquals(recoveredMetadata.getBasePath(), "basePath");
+    Assert.assertEquals(recoveredMetadata.getPermission(), (short) 166);
+    Assert.assertEquals(recoveredMetadata.getCredentials().accessKeyId, "akey");
+    Assert.assertEquals(recoveredMetadata.getCredentials().secretKeyId, "skey");
+    Assert.assertEquals(recoveredMetadata.getCredentials().region, "region");
+    Assert.assertEquals(recoveredMetadata.getCredentials().bucketName, "bname");
+  }
+
+  @Test
+  public void testCompare() {
+    S3MetadataInputSplit metadataInputSplita = new S3MetadataInputSplit();
+    S3MetadataInputSplit metadataInputSplitb = new S3MetadataInputSplit();
+    S3MetadataInputSplit metadataInputSplitc = new S3MetadataInputSplit();
+
+    // generate 3 files with different file sizes
+    S3FileMetadata file1 = new S3FileMetadata(null, null, 0, null, (long) 1, false, null, (short) 0, null);
+
+    S3FileMetadata file2 = new S3FileMetadata(null, null, 0, null, (long) 2, false, null, (short) 0, null);
+
+    S3FileMetadata file3 = new S3FileMetadata(null, null, 0, null, (long) 3, false, null, (short) 0, null);
+
+    // a has 3 bytes
+    metadataInputSplita.addFileMetadata(file1);
+    metadataInputSplita.addFileMetadata(file2);
+
+    // b has 3 bytes too
+    metadataInputSplitb.addFileMetadata(file3);
+
+    // c only has 1 byte
+    metadataInputSplitc.addFileMetadata(file1);
+
+
+    Assert.assertEquals(metadataInputSplita.compareTo(metadataInputSplitb), 0);
+    Assert.assertEquals(metadataInputSplita.compareTo(metadataInputSplitc), 1);
+    Assert.assertEquals(metadataInputSplitc.compareTo(metadataInputSplita), -1);
+  }
+}

--- a/core-plugins/widgets/HDFSFileCopySink-batchsink.json
+++ b/core-plugins/widgets/HDFSFileCopySink-batchsink.json
@@ -29,6 +29,30 @@
           }
         },
         {
+          "widget-type": "select",
+          "label": "Preserve File Owner",
+          "name": "preserveFileOwner",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Enable Filesystem Connection Caching",
+          "name": "filesystemCaching",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "true"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Buffer Size",
           "name": "bufferSize",

--- a/core-plugins/widgets/HDFSFileCopySink-batchsink.json
+++ b/core-plugins/widgets/HDFSFileCopySink-batchsink.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "configuration-groups": [
+    {
+      "label": "HDFS File Copy Sink",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Base Path",
+          "name": "basePath"
+        },
+        {
+          "widget-type": "select",
+          "label": "Enable Overwrite",
+          "name": "enableOverwrite",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Buffer Size",
+          "name": "bufferSize",
+          "default": "4096"
+        }
+      ]
+    }
+  ]
+}

--- a/core-plugins/widgets/HDFSFileCopySink-batchsink.json
+++ b/core-plugins/widgets/HDFSFileCopySink-batchsink.json
@@ -44,7 +44,7 @@
           "widget-type": "textbox",
           "label": "Buffer Size (MB)",
           "name": "bufferSize",
-          "default": "4096"
+          "default": "1"
         }
       ]
     }

--- a/core-plugins/widgets/HDFSFileCopySink-batchsink.json
+++ b/core-plugins/widgets/HDFSFileCopySink-batchsink.json
@@ -41,20 +41,8 @@
           }
         },
         {
-          "widget-type": "select",
-          "label": "Enable Filesystem Connection Caching",
-          "name": "filesystemCaching",
-          "widget-attributes": {
-            "values": [
-              "true",
-              "false"
-            ],
-            "default": "true"
-          }
-        },
-        {
           "widget-type": "textbox",
-          "label": "Buffer Size",
+          "label": "Buffer Size (MB)",
           "name": "bufferSize",
           "default": "4096"
         }

--- a/core-plugins/widgets/S3FileMetadataSource-batchsource.json
+++ b/core-plugins/widgets/S3FileMetadataSource-batchsource.json
@@ -12,6 +12,11 @@
           "name": "referenceName"
         },
         {
+          "widget-type": "textbox",
+          "label": "URI",
+          "name": "filesystemURI"
+        },
+        {
           "widget-type": "csv",
           "label": "Source Paths",
           "name": "sourcePaths"
@@ -44,11 +49,6 @@
           "name": "secretKeyId"
         },
         {
-          "widget-type": "textbox",
-          "label": "Bucket Name",
-          "name": "bucketName"
-        },
-        {
           "widget-type": "select",
           "label": "Amazon Region",
           "name": "region",
@@ -75,6 +75,73 @@
           }
         }
       ]
+    }
+  ],
+  "outputs": [
+    {
+      "widget-type": "non-editable-schema-editor",
+      "schema": {
+        "name": "etlSchemaBody",
+        "type": "record",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": "string"
+          },
+          {
+            "name": "fullPath",
+            "type": "string"
+          },
+          {
+            "name": "fileSize",
+            "type": "long"
+          },
+          {
+            "name": "modificationTime",
+            "type": "long"
+          },
+          {
+            "name": "group",
+            "type": "string"
+          },
+          {
+            "name": "owner",
+            "type": "string"
+          },
+          {
+            "name": "isFolder",
+            "type": "boolean"
+          },
+          {
+            "name": "basePath",
+            "type": "string"
+          },
+          {
+            "name": "permission",
+            "type": "int"
+          },
+          {
+            "name": "filesystem",
+            "type": "string"
+          },
+          {
+            "name": "hostURI",
+            "type": "string"
+          },
+          {
+            "name": "accessKeyID",
+            "type": "string"
+          },
+          {
+            "name": "secretKeyID",
+            "type": "string"
+          },
+          {
+            "name": "region",
+            "type": "string"
+          }
+        ]
+      }
     }
   ]
 }

--- a/core-plugins/widgets/S3FileMetadataSource-batchsource.json
+++ b/core-plugins/widgets/S3FileMetadataSource-batchsource.json
@@ -113,16 +113,12 @@
             "type": "boolean"
           },
           {
-            "name": "basePath",
+            "name": "relativePath",
             "type": "string"
           },
           {
             "name": "permission",
             "type": "int"
-          },
-          {
-            "name": "filesystem",
-            "type": "string"
           },
           {
             "name": "hostURI",

--- a/core-plugins/widgets/S3FileMetadataSource-batchsource.json
+++ b/core-plugins/widgets/S3FileMetadataSource-batchsource.json
@@ -44,7 +44,7 @@
           "name": "accessKeyId"
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "password",
           "label": "Secret Key ID",
           "name": "secretKeyId"
         },

--- a/core-plugins/widgets/S3FileMetadataSource-batchsource.json
+++ b/core-plugins/widgets/S3FileMetadataSource-batchsource.json
@@ -1,0 +1,80 @@
+{
+  "metadata": {
+    "spec-version": "1.3"
+  },
+  "configuration-groups": [
+    {
+      "label": "S3 File Copy Source",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Reference Name",
+          "name": "referenceName"
+        },
+        {
+          "widget-type": "csv",
+          "label": "Source Paths",
+          "name": "sourcePaths"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max Split Size",
+          "name": "maxSplitSize"
+        },
+        {
+          "widget-type": "select",
+          "label": "Copy Recursively",
+          "name": "recursiveCopy",
+          "widget-attributes": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "true"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Access Key ID",
+          "name": "accessKeyId"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Secret Key ID",
+          "name": "secretKeyId"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Bucket Name",
+          "name": "bucketName"
+        },
+        {
+          "widget-type": "select",
+          "label": "Amazon Region",
+          "name": "region",
+          "widget-attributes": {
+            "values": [
+              "us-gov-west-1",
+              "us-east-1",
+              "us-east-2",
+              "us-west-1",
+              "us-west-2",
+              "eu-west-1",
+              "eu-west-2",
+              "eu-central-1",
+              "ap-south-1",
+              "ap-southeast-1",
+              "ap-southeast-2",
+              "ap-northeast-1",
+              "ap-northeast-2",
+              "sa-east-1",
+              "cn-north-1",
+              "ca-central-1"
+            ],
+            "default": "us-east-1"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
1. Adds a file metadata source template that can be extended to read
   file metadata from any source filesystem.

2. Adds a file copy sink template that can be exended to copy files
   from a remote source given file metadata as inputs.

3. Added InputFormat and OutputFormat to support source and sink plugins.