### PR TITLE
CDAP-10653 add arguments to script transform contexts

### DIFF
--- a/core-plugins/docs/PythonEvaluator-transform.md
+++ b/core-plugins/docs/PythonEvaluator-transform.md
@@ -43,7 +43,8 @@ as a Python dictionary containing those three fields, with the error records wri
                          'invalidRecord': record,
                        })
                      else:
-                       tax = record['subtotal'] * 0.0975
+                       taxrate = float(context.getArguments().get('taxrate'))
+                       tax = record['subtotal'] * taxrate
                        if (tax > 1000.0):
                          context.getMetrics().count('tax.above.1000', 1)
                        emitter.emit({

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/JavaScriptTransform.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/JavaScriptTransform.java
@@ -22,10 +22,10 @@ import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.etl.api.Arguments;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.LookupConfig;
-import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.Transform;
@@ -348,7 +348,7 @@ public class JavaScriptTransform extends Transform<StructuredRecord, StructuredR
     throw new RuntimeException("Unable decode union with schema " + schemas);
   }
 
-  private void init(LookupProvider lookup) {
+  private void init(@Nullable TransformContext context) {
     ScriptEngineManager manager = new ScriptEngineManager();
     engine = manager.getEngineByName("JavaScript");
     try {
@@ -368,7 +368,8 @@ public class JavaScriptTransform extends Transform<StructuredRecord, StructuredR
       throw new IllegalArgumentException("Invalid lookup config. Expected map of string to string", e);
     }
 
-    engine.put(CONTEXT_NAME, new ScriptContext(LOG, metrics, lookup, lookupConfig, js));
+    Arguments arguments = context == null ? null : context.getArguments();
+    engine.put(CONTEXT_NAME, new ScriptContext(LOG, metrics, context, lookupConfig, js, arguments));
 
     try {
       // this is pretty ugly, but doing this so that we can pass the 'input' json into the transform function.

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/PythonEvaluator.java
@@ -106,7 +106,7 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
   public void initialize(TransformContext context) {
     metrics = context.getMetrics();
     logger = LoggerFactory.getLogger(PythonEvaluator.class.getName() + " - Stage:" + context.getStageName());
-    init();
+    init(context);
   }
 
   @Override
@@ -165,7 +165,7 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
       pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
     }
     // try evaluating the script to fail application creation if the script is invalid
-    init();
+    init(null);
   }
 
   @Override
@@ -350,7 +350,7 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
     throw new RuntimeException("Unable to decode union with schema " + schemas);
   }
 
-  private void init() {
+  private void init(@Nullable TransformContext context) {
     interpreter = new PythonInterpreter();
     interpreter.set(CONTEXT_NAME, new ScriptContext(
       logger, metrics,
@@ -366,7 +366,8 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
         public Object mapToJSObject(Map<?, ?> map) {
           return null;
         }
-      }));
+      },
+      context == null ? null : context.getArguments()));
 
     // this is pretty ugly, but doing this so that we can pass the 'input' record into the transform function.
     // that is, we want people to implement

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ScriptContext.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ScriptContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.hydrator.plugin.transform;
 
+import co.cask.cdap.etl.api.Arguments;
 import co.cask.cdap.etl.api.LookupConfig;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.StageMetrics;
@@ -32,15 +33,15 @@ public class ScriptContext {
   private final StageMetrics metrics;
   private final ScriptLookupProvider lookup;
   private final JavaTypeConverters js;
+  private final Arguments arguments;
 
-  public ScriptContext(
-    Logger logger, StageMetrics metrics, LookupProvider lookup, @Nullable LookupConfig lookupConfig,
-    JavaTypeConverters js) {
-
+  public ScriptContext(Logger logger, StageMetrics metrics, LookupProvider lookup, @Nullable LookupConfig lookupConfig,
+                       JavaTypeConverters js, Arguments arguments) {
     this.logger = logger;
     this.metrics = metrics;
     this.lookup = new ScriptLookupProvider(lookup, lookupConfig);
     this.js = js;
+    this.arguments = arguments;
   }
 
   public Logger getLogger() {
@@ -53,5 +54,9 @@ public class ScriptContext {
 
   public ScriptLookup getLookup(String table) {
     return lookup.provide(table, js);
+  }
+
+  public Arguments getArguments() {
+    return arguments;
   }
 }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ValidatorScriptContext.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/transform/ValidatorScriptContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.hydrator.plugin.transform;
 
+import co.cask.cdap.etl.api.Arguments;
 import co.cask.cdap.etl.api.LookupConfig;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.StageMetrics;
@@ -33,8 +34,8 @@ public class ValidatorScriptContext extends ScriptContext {
 
   public ValidatorScriptContext(Logger logger, StageMetrics metrics, LookupProvider lookup,
                                 @Nullable LookupConfig lookupConfig, JavaTypeConverters js,
-                                Map<String, Object> validators) {
-    super(logger, metrics, lookup, lookupConfig, js);
+                                Map<String, Object> validators, Arguments arguments) {
+    super(logger, metrics, lookup, lookupConfig, js, arguments);
     this.validators = validators;
   }
 


### PR DESCRIPTION
Adding a way to get pipeline arguments from the context objects
exposed by the python and javascript transforms. Also updating
the docs to include examples of using arguments and emitting alerts.