### PR TITLE
CDAP-12226 add delimiter property to HDFS sink

### DIFF
--- a/hdfs-plugins/docs/HDFS-batchsink.md
+++ b/hdfs-plugins/docs/HDFS-batchsink.md
@@ -29,6 +29,8 @@ Properties
 year-month-day-hour-minute format, and append that to the path to get the final output directory.
 If not specified, no suffix is used.
 
+**delimiter:** Delimiter used to concatenate record fields. Defaults to a comma ','. (Macro-enabled)
+
 **jobProperties:** Advanced feature to specify any additional properties that should be used with the sink,
 specified as a JSON object of string to string. These properties are set on the job at runtime. (Macro-enabled)
 

--- a/hdfs-plugins/widgets/HDFS-batchsink.json
+++ b/hdfs-plugins/widgets/HDFS-batchsink.json
@@ -28,6 +28,11 @@
           "name": "suffix"
         },
         {
+          "widget-type": "textbox",
+          "label": "Delimiter",
+          "name": "delimiter"
+        },
+        {
           "widget-type": "json-editor",
           "label": "Job Properties",
           "name": "jobProperties"


### PR DESCRIPTION
Adding an optional delimiter property to the HDFS sink that allows
users to configure the delimiter used to concatenate fields.