### PR TITLE
Fix compilation by removing unused import of SparkCompat class.

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLInputFormat.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import java.io.IOException;
 import java.util.Map;

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToTextTransformer.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToTextTransformer.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.data.schema.Schema;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Creates Single String from StructuredRecord

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/BatchPluginsTestSuite.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/BatchPluginsTestSuite.java
@@ -17,7 +17,6 @@
 package co.cask.hydrator.plugin.batch;
 
 import co.cask.cdap.common.test.TestSuite;
-import co.cask.hydrator.plugin.batch.action.HDFSActionTestRun;
 import co.cask.hydrator.plugin.batch.aggregator.DedupTestRun;
 import co.cask.hydrator.plugin.batch.aggregator.GroupByTestRun;
 import org.junit.runner.RunWith;

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/action/EmailActionTestRun.java
@@ -16,7 +16,6 @@
 
 package co.cask.hydrator.plugin.batch.action;
 
-import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.datapipeline.SmartWorkflow;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
@@ -35,7 +34,6 @@ import com.dumbster.smtp.SimpleSmtpServer;
 import com.dumbster.smtp.SmtpMessage;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/TableSinkTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/TableSinkTest.java
@@ -33,14 +33,12 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
-import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.plugin.batch.ETLBatchTestBase;
 import co.cask.hydrator.plugin.common.Properties;
 import co.cask.hydrator.plugin.common.TableSinkConfig;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.HashMap;

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/PythonEvaluatorTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/transform/PythonEvaluatorTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
-import org.python.antlr.ast.Str;
 
 import java.util.List;
 import java.util.Map;

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/commons/HiveSchemaConverter.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/commons/HiveSchemaConverter.java
@@ -18,7 +18,6 @@ package co.cask.hydrator.plugin.batch.commons;
 
 import co.cask.cdap.api.data.schema.Schema;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;

--- a/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/dynamic/ScalaSparkCompute.java
+++ b/spark-plugins/src/main/java/co/cask/hydrator/plugin/spark/dynamic/ScalaSparkCompute.java
@@ -24,7 +24,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.spark.dynamic.CompilationFailureException;
-import co.cask.cdap.api.spark.dynamic.SparkCompiler;
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;

--- a/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/SparkPluginTest.java
+++ b/spark-plugins/src/test/java/co/cask/hydrator/plugin/spark/test/SparkPluginTest.java
@@ -24,7 +24,6 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.app.runtime.spark.SparkCompat;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.datapipeline.DataPipelineApp;
 import co.cask.cdap.datastreams.DataStreamsApp;

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/JSONParser.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/JSONParser.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;


### PR DESCRIPTION
[This CDAP PR](https://github.com/caskdata/cdap/pull/9617/files#diff-bdcb31e2a7b1ab3bb7f4d7e26f4c57d3) moved the package of the SparkCompat class.
SparkPluginsTest had an import for that class, which was causing compilation failures.
Removing these unused imports fixes those issues.