### PR TITLE
HbaseSource check Row field Type Error

### DIFF
--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/RowRecordTransformer.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/RowRecordTransformer.java
@@ -37,7 +37,7 @@ public class RowRecordTransformer {
       rowField = schema.getField(rowFieldName);
       // if row field was given, it must be present in the schema and it must be a simple type
       Preconditions.checkArgument(rowField != null, "Row field must be present in the schema.");
-      Preconditions.checkArgument(rowField.getSchema().getType().isSimpleType(), "Row field must be a simple type.");
+      Preconditions.checkArgument(rowField.getSchema().isNullableSimple(), "Row field must be a simple type.");
     } else {
       rowField = null;
     }


### PR DESCRIPTION
When Schema Type is UNION with null and other simple type. It will run
into an Exception about ‘Row field must be a simple type’