### PR TITLE
Adds outputSchema plugin function to widget json of Splitter plugins

### DIFF
--- a/transform-plugins/widgets/NullFieldSplitter-splittertransform.json
+++ b/transform-plugins/widgets/NullFieldSplitter-splittertransform.json
@@ -8,7 +8,16 @@
         {
           "widget-type": "textbox",
           "label": "Field to Split on",
-          "name": "field"
+          "name": "field",
+          "plugin-function": {
+            "method": "POST",
+            "label": "Generate Schema",
+            "widget": "outputSchema",
+            "output-property": "schema",
+            "plugin-method": "outputSchema",
+            "position": "bottom",
+            "button-class": "btn-hydrator"
+          }
         },
         {
           "widget-type": "select",

--- a/transform-plugins/widgets/UnionSplitter-splittertransform.json
+++ b/transform-plugins/widgets/UnionSplitter-splittertransform.json
@@ -9,7 +9,16 @@
         {
           "widget-type": "textbox",
           "label": "Union field to split on",
-          "name": "unionField"
+          "name": "unionField",
+          "plugin-function": {
+            "method": "POST",
+            "label": "Generate Schema",
+            "widget": "outputSchema",
+            "output-property": "schema",
+            "plugin-method": "outputSchema",
+            "position": "bottom",
+            "button-class": "btn-hydrator"
+          }
         },
         {
           "widget-type": "select",


### PR DESCRIPTION
This is needed to fetch the new output schemas after the user has specified the field to split on.