### PR TITLE
CDAP-12731 Fix HBase sink classloader issue, that fails for Spark execution engine

### DIFF
--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -145,9 +145,7 @@
             <_exportcontents>
               co.cask.hydrator.plugin.*;
               org.apache.commons.lang;
-              org.apache.hadoop.hbase.mapreduce.*;
-              org.apache.hadoop.hbase.client.*;
-              org.apache.hadoop.hbase.io.*;
+              org.apache.hadoop.hbase.mapreduce;
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/HBaseSink.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/HBaseSink.java
@@ -35,6 +35,7 @@ import co.cask.hydrator.common.ReferenceBatchSink;
 import co.cask.hydrator.common.SchemaValidator;
 import co.cask.hydrator.common.batch.JobUtils;
 import co.cask.hydrator.plugin.HBaseConfig;
+import co.cask.hydrator.plugin.sink.mapreduce.HBaseTableOutputFormat;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.hadoop.conf.Configuration;
@@ -123,7 +124,7 @@ public class HBaseSink extends ReferenceBatchSink<StructuredRecord, NullWritable
 
     @Override
     public String getOutputFormatClassName() {
-      return TableOutputFormat.class.getName();
+      return HBaseTableOutputFormat.class.getName();
     }
 
     @Override

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/mapreduce/HBaseTableOutputFormat.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/sink/mapreduce/HBaseTableOutputFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.sink.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
+
+/**
+ * A wrapper class around TableOutputFormat, that sets the current class's classloader as the classloader of the
+ * Configuration object used by TableOutputFormat.
+ *
+ * @param <KEY> Type of Key
+ */
+public class HBaseTableOutputFormat<KEY> extends TableOutputFormat<KEY> {
+
+  @Override
+  public void setConf(Configuration otherConf) {
+    // To resolve CDAP-12731, set the current class's classloader to the thread's context classloader,
+    // so that it gets picked up when the super.setConf() calls HBaseConfiguration.create(Configuration)
+    ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+    try {
+      super.setConf(otherConf);
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+}

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
@@ -31,6 +31,7 @@ import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.hydrator.common.ReferenceBatchSource;
 import co.cask.hydrator.common.SourceInputFormatProvider;
 import co.cask.hydrator.plugin.HBaseConfig;
+import co.cask.hydrator.plugin.source.mapreduce.HBaseTableInputFormat;
 import com.google.common.base.Strings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Result;
@@ -70,7 +71,7 @@ public class HBaseSource extends ReferenceBatchSource<ImmutableBytesWritable, Re
     conf.setStrings(ioSerializations,
                     MutationSerialization.class.getName(), ResultSerialization.class.getName(),
                     KeyValueSerialization.class.getName());
-    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(TableInputFormat.class, conf)));
+    context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(HBaseTableInputFormat.class, conf)));
   }
 
   @Override

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/mapreduce/HBaseTableInputFormat.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/mapreduce/HBaseTableInputFormat.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.source.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.mapreduce.TableInputFormat;
+
+/**
+ * A wrapper class around TableInputFormat, that sets the current class's classloader as the classloader of the
+ * Configuration object used by TableInputFormat.
+ */
+public class HBaseTableInputFormat extends TableInputFormat {
+
+  @Override
+  public void setConf(Configuration otherConf) {
+    // To resolve CDAP-12731, set the current class's classloader to the Configuration object that is used
+    // Note that the approach here is different than in HBaseTableOutputFormat, due to how the parent classes
+    // use the Configuration object passed in
+    Configuration clonedConf = new Configuration(otherConf);
+    clonedConf.setClassLoader(getClass().getClassLoader());
+    super.setConf(clonedConf);
+  }
+}

--- a/hbase-plugins/src/test/java/co/cask/hydrator/plugin/HBaseTest.java
+++ b/hbase-plugins/src/test/java/co/cask/hydrator/plugin/HBaseTest.java
@@ -43,7 +43,9 @@ import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.hydrator.common.Constants;
 import co.cask.hydrator.plugin.sink.HBaseSink;
+import co.cask.hydrator.plugin.sink.mapreduce.HBaseTableOutputFormat;
 import co.cask.hydrator.plugin.source.HBaseSource;
+import co.cask.hydrator.plugin.source.mapreduce.HBaseTableInputFormat;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.MiniHBaseCluster;
@@ -56,7 +58,6 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.mapreduce.TableInputFormat;
-import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -114,7 +115,7 @@ public class HBaseTest extends HydratorTestBase {
     // add artifact for batch sources and sinks
     addPluginArtifact(NamespaceId.DEFAULT.artifact("batch-plugins", "1.0.0"), BATCH_APP_ARTIFACT_ID,
                       HBaseSource.class, HBaseSink.class,
-                      TableInputFormat.class, TableOutputFormat.class,
+                      HBaseTableInputFormat.class, TableInputFormat.class, HBaseTableOutputFormat.class,
                       Result.class, ImmutableBytesWritable.class,
                       Put.class, Mutation.class);
   }


### PR DESCRIPTION
[CDAP-12731](https://issues.cask.co/browse/CDAP-12731) Fix HBase sink classloader issue, that fails for Spark execution engine.

https://builds.cask.co/browse/HYP-BAD372-5