### PR TITLE
Fix error messages' formatting

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/HDFSMoveAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/HDFSMoveAction.java
@@ -67,7 +67,7 @@ public class HDFSMoveAction extends Action {
       try {
         if (!fileSystem.rename(source, dest)) {
           if (!config.continueOnError) {
-            throw new IOException(String.format("Failed to rename file {} to {}", source.toString(), dest.toString()));
+            throw new IOException(String.format("Failed to rename file %s to %s", source.toString(), dest.toString()));
           }
           LOG.error("Failed to move file {} to {}", source.toString(), dest.toString());
         }
@@ -117,7 +117,7 @@ public class HDFSMoveAction extends Action {
       try {
         if (!fileSystem.rename(source, dest)) {
           if (!config.continueOnError) {
-            throw new IOException(String.format("Failed to rename file {} to {}", source.toString(), dest.toString()));
+            throw new IOException(String.format("Failed to rename file %s to %s", source.toString(), dest.toString()));
           }
           LOG.error("Failed to move file {} to {}", source.toString(), dest.toString());
         }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/HDFSMoveAction.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/action/HDFSMoveAction.java
@@ -67,15 +67,15 @@ public class HDFSMoveAction extends Action {
       try {
         if (!fileSystem.rename(source, dest)) {
           if (!config.continueOnError) {
-            throw new IOException(String.format("Failed to rename file %s to %s", source.toString(), dest.toString()));
+            throw new IOException(String.format("Failed to rename file %s to %s", source, dest));
           }
-          LOG.error("Failed to move file {} to {}", source.toString(), dest.toString());
+          LOG.error("Failed to move file {} to {}", source, dest);
         }
       } catch (IOException e) {
         if (!config.continueOnError) {
           throw e;
         }
-        LOG.error("Failed to move file {} to {}", source.toString(), dest.toString(), e);
+        LOG.error("Failed to move file {} to {}", source, dest, e);
       }
       return;
     }
@@ -117,15 +117,15 @@ public class HDFSMoveAction extends Action {
       try {
         if (!fileSystem.rename(source, dest)) {
           if (!config.continueOnError) {
-            throw new IOException(String.format("Failed to rename file %s to %s", source.toString(), dest.toString()));
+            throw new IOException(String.format("Failed to rename file %s to %s", source, dest));
           }
-          LOG.error("Failed to move file {} to {}", source.toString(), dest.toString());
+          LOG.error("Failed to move file {} to {}", source, dest);
         }
       } catch (IOException e) {
         if (!config.continueOnError) {
           throw e;
         }
-        LOG.error("Failed to move file {} to {}", source.toString(), dest.toString(), e);
+        LOG.error("Failed to move file {} to {}", source, dest, e);
       }
     }
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeUtils.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeUtils.java
@@ -41,15 +41,15 @@ public final class CubeUtils {
       if (split.length != 2) {
         //should not happen
         throw new IllegalArgumentException(
-          String.format("For Property %s Parameter {}, name or value is empty, please check config", property, group));
+          String.format("For Property %s Parameter %s, name or value is empty, please check config", property, group));
       }
       if (Strings.isNullOrEmpty(split[0])) {
         throw new IllegalArgumentException(
-          String.format("Empty key/value is not allowed in %s", property));
+          String.format("Empty key/value is not allowed in property %s, group %s", property, group));
       }
       if (Strings.isNullOrEmpty(split[1])) {
         throw new IllegalArgumentException(
-          String.format("Empty key/value is not allowed in %s", property));
+          String.format("Empty key/value is not allowed in property %s, group %s", property, group));
       }
       result.put(keyFunction.apply(split[0]), split[1]);
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeUtils.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/CubeUtils.java
@@ -41,15 +41,15 @@ public final class CubeUtils {
       if (split.length != 2) {
         //should not happen
         throw new IllegalArgumentException(
-          String.format("For Property {} Parameter {} , name or value is empty, please check config", property, group));
+          String.format("For Property %s Parameter {}, name or value is empty, please check config", property, group));
       }
       if (Strings.isNullOrEmpty(split[0])) {
         throw new IllegalArgumentException(
-          String.format("Empty key/value is not allowed in {}", property));
+          String.format("Empty key/value is not allowed in %s", property));
       }
       if (Strings.isNullOrEmpty(split[1])) {
         throw new IllegalArgumentException(
-          String.format("Empty key/value is not allowed in {}", property));
+          String.format("Empty key/value is not allowed in %s", property));
       }
       result.put(keyFunction.apply(split[0]), split[1]);
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
@@ -203,7 +203,6 @@ public class FileSetUtil {
       HiveSchemaConverter.appendType(builder, schemaObj);
       return builder.toString();
     } catch (IOException e) {
-      LOG.debug("{} is not a valid schema", configuredSchema, e);
       throw new IllegalArgumentException(String.format("%s is not a valid schema", configuredSchema), e);
     } catch (UnsupportedTypeException e) {
       throw new IllegalArgumentException(String.format("Could not create hive schema from %s", configuredSchema), e);

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
@@ -197,17 +197,16 @@ public class FileSetUtil {
   }
 
   private static String parseOrcSchema(String configuredSchema) {
-    co.cask.cdap.api.data.schema.Schema schemaObj = null;
     try {
-      schemaObj = co.cask.cdap.api.data.schema.Schema.parseJson(configuredSchema);
+      co.cask.cdap.api.data.schema.Schema schemaObj = co.cask.cdap.api.data.schema.Schema.parseJson(configuredSchema);
       StringBuilder builder = new StringBuilder();
       HiveSchemaConverter.appendType(builder, schemaObj);
       return builder.toString();
     } catch (IOException e) {
       LOG.debug("{} is not a valid schema", configuredSchema, e);
-      throw new IllegalArgumentException(String.format("{} is not a valid schema", configuredSchema), e);
+      throw new IllegalArgumentException(String.format("%s is not a valid schema", configuredSchema), e);
     } catch (UnsupportedTypeException e) {
-      throw new IllegalArgumentException(String.format("Could not create hive schema from {}", configuredSchema), e);
+      throw new IllegalArgumentException(String.format("Could not create hive schema from %s", configuredSchema), e);
     }
   }
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToOrcTransformer.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToOrcTransformer.java
@@ -76,7 +76,7 @@ public class StructuredToOrcTransformer extends RecordConverter<StructuredRecord
       try {
         HiveSchemaConverter.appendType(builder, inputSchema);
       } catch (UnsupportedTypeException e) {
-        throw new IllegalArgumentException(String.format("Not a valid Schema %s", inputSchema.toString()), e);
+        throw new IllegalArgumentException(String.format("Not a valid Schema %s", inputSchema), e);
       }
       TypeDescription schema = TypeDescription.fromString(builder.toString());
       orcRecord = (OrcStruct) OrcStruct.createValue(schema);

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToOrcTransformer.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToOrcTransformer.java
@@ -60,7 +60,7 @@ public class StructuredToOrcTransformer extends RecordConverter<StructuredRecord
         orcRecord.setFieldValue(fields.get(i).getName(), writable);
       } catch (UnsupportedTypeException e) {
         LOG.debug("{} is not a supported type", field.getName(), e);
-        throw new IllegalArgumentException(String.format("{} is not a supported type", field.getName()), e);
+        throw new IllegalArgumentException(String.format("%s is not a supported type", field.getName()), e);
       }
     }
     return orcRecord;
@@ -76,7 +76,7 @@ public class StructuredToOrcTransformer extends RecordConverter<StructuredRecord
       try {
         HiveSchemaConverter.appendType(builder, inputSchema);
       } catch (UnsupportedTypeException e) {
-        throw new IllegalArgumentException(String.format("Not a valid Schema {}", inputSchema.toString()), e);
+        throw new IllegalArgumentException(String.format("Not a valid Schema %s", inputSchema.toString()), e);
       }
       TypeDescription schema = TypeDescription.fromString(builder.toString());
       orcRecord = (OrcStruct) OrcStruct.createValue(schema);
@@ -120,7 +120,7 @@ public class StructuredToOrcTransformer extends RecordConverter<StructuredRecord
           return new BytesWritable(Bytes.getBytes((ByteBuffer) fieldVal));
         }
       default:
-        throw new UnsupportedTypeException(String.format("{} type is currently not supported in ORC",
+        throw new UnsupportedTypeException(String.format("%s type is currently not supported in ORC",
                                                          field.getSchema().getType().name()));
     }
   }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToOrcTransformer.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/StructuredToOrcTransformer.java
@@ -59,7 +59,6 @@ public class StructuredToOrcTransformer extends RecordConverter<StructuredRecord
         WritableComparable writable = convertToWritable(field, input);
         orcRecord.setFieldValue(fields.get(i).getName(), writable);
       } catch (UnsupportedTypeException e) {
-        LOG.debug("{} is not a supported type", field.getName(), e);
         throw new IllegalArgumentException(String.format("%s is not a supported type", field.getName()), e);
       }
     }
@@ -120,8 +119,8 @@ public class StructuredToOrcTransformer extends RecordConverter<StructuredRecord
           return new BytesWritable(Bytes.getBytes((ByteBuffer) fieldVal));
         }
       default:
-        throw new UnsupportedTypeException(String.format("%s type is currently not supported in ORC",
-                                                         field.getSchema().getType().name()));
+        throw new UnsupportedTypeException(String.format("Type '%s' of field '%s' is currently not supported in ORC",
+                                                         fieldType.name(), field.getName()));
     }
   }
 


### PR DESCRIPTION
Otherwise, there are error messages like the following, which make debugging difficult:

```
co.cask.cdap.api.data.schema.UnsupportedTypeException: {} type is currently not supported in ORC
    at co.cask.hydrator.plugin.common.StructuredToOrcTransformer.convertToWritable(StructuredToOrcTransformer.java:122) ~[1509581904569-0/:na]
...
```