### PR TITLE
Changes input field in splitter plugins' widget json to be of type input-field-selector

### DIFF
--- a/transform-plugins/widgets/NullFieldSplitter-splittertransform.json
+++ b/transform-plugins/widgets/NullFieldSplitter-splittertransform.json
@@ -6,7 +6,7 @@
     {
       "properties": [
         {
-          "widget-type": "textbox",
+          "widget-type": "input-field-selector",
           "label": "Field to Split on",
           "name": "field",
           "plugin-function": {

--- a/transform-plugins/widgets/UnionSplitter-splittertransform.json
+++ b/transform-plugins/widgets/UnionSplitter-splittertransform.json
@@ -7,7 +7,7 @@
       "label": "Union Splitter",
       "properties": [
         {
-          "widget-type": "textbox",
+          "widget-type": "input-field-selector",
           "label": "Union field to split on",
           "name": "unionField",
           "plugin-function": {


### PR DESCRIPTION
Since the field to split on in these plugins must always be a field from the input schema, I have changed the widget type from `textbox` to `input-field-selector` (which is a dropdown of fields in the input schema).