### PR TITLE
CDAP-12807 making field name for union splitter required

### DIFF
--- a/transform-plugins/docs/UnionSplitter-splittertransform.md
+++ b/transform-plugins/docs/UnionSplitter-splittertransform.md
@@ -17,8 +17,8 @@ be the schema type in lowercase ('null', 'bool', 'bytes', 'int', 'long', 'float'
 
 Properties
 ----------
-**unionField:** The union field to split on. If specified, the schema for the field must be a union of
-supported schemas. All schemas except maps, arrays, unions, and enums are supported. Note that nulls are supported,
+**unionField:** The union field to split on. The schema for the field must be a union of supported schemas.
+All schemas except maps, arrays, unions, and enums are supported. Note that nulls are supported,
 which means all nulls will get sent to the 'null' port.
 
 **modifySchema:** Whether to modify the output schema to remove the union. For example, suppose the field 'x'
@@ -27,46 +27,8 @@ the 'int' port and just a long for the 'long' port. If modifySchema is false, th
 will be the same as the input schema. Defaults to true.
 
 
-Example 1: Splitting on the entire record
------------------------------------------
-Suppose the union splitter is configured to split on the entire record:
-
-    {
-        "name": "UnionSplitter",
-        "type": "splittertransform",
-        "properties": { }
-    }
-
-Suppose the splitter receives records with two possible schemas.
-The first possible schema is 'itemMeta':
-
-    +================+
-    | name  | type   |
-    +================+
-    | id    | long   |
-    | desc  | string |
-    +================+
-
-The second possible schema is 'itemDetail', which includes a couple additional fields:
-
-
-    +================+
-    | name  | type   |
-    +================+
-    | id    | long   |
-    | desc  | string |
-    | label | string |
-    | price | double |
-    +================+
-
-If the union splitter receives a record with the 'itemMeta' schema, that record will be emitted to port 'itemMeta'.
-If it receives a record with the 'itemDetail' schema, that record will be emitted to port 'itemDetail'.
-This allows the pipeline to send each type of record to different stages to be handled differently.
-Note that since the schema name is used as the output port, this means that if the plugin receives records
-that have the same schema name, but different schemas, those records will all still go to the same output port.
-
-Example 2: Splitting on a field
--------------------------------
+Example
+-------
 Suppose the union splitter is configured to split on the 'item' field:
 
     {

--- a/transform-plugins/src/main/java/co/cask/hydrator/plugin/UnionSplitter.java
+++ b/transform-plugins/src/main/java/co/cask/hydrator/plugin/UnionSplitter.java
@@ -232,12 +232,9 @@ public class UnionSplitter extends SplitterTransform<StructuredRecord, Structure
    * Plugin conf
    */
   public static class Conf extends PluginConfig {
-    @Nullable
     @Description("The union field to split on. Each possible schema in the union will be emitted to a different " +
       "port. Only unions of records and simple types are supported. In other words, " +
-      "enums, maps, and arrays in the union are not supported. If no union field is specified, " +
-      "it is assumed that the records with multiple schemas can be input to this stage. " +
-      "In that scenario, each record will be emitted to a port based on its schema. ")
+      "enums, maps, and arrays in the union are not supported.")
     protected String unionField;
 
     @Nullable

--- a/transform-plugins/src/test/java/co/cask/hydrator/plugin/UnionSplitterTest.java
+++ b/transform-plugins/src/test/java/co/cask/hydrator/plugin/UnionSplitterTest.java
@@ -293,33 +293,4 @@ public class UnionSplitterTest {
     Map<String, List<Object>> actual = mockEmitter.getEmitted();
     Assert.assertEquals(expected, actual);
   }
-
-  @Test
-  public void testSplitOnRecord() throws Exception {
-    Schema schema1 = Schema.recordOf("s1",
-                                     Schema.Field.of("x", Schema.of(Schema.Type.LONG)),
-                                     Schema.Field.of("y", Schema.of(Schema.Type.INT)));
-    Schema schema2 = Schema.recordOf("s2",
-                                     Schema.Field.of("y", Schema.of(Schema.Type.STRING)),
-                                     Schema.Field.of("z", Schema.of(Schema.Type.STRING)));
-
-    StructuredRecord r1 = StructuredRecord.builder(schema1).set("x", 1L).set("y", 5).build();
-    StructuredRecord r2 = StructuredRecord.builder(schema1).set("x", 2L).set("y", 3).build();
-    StructuredRecord r3 = StructuredRecord.builder(schema2).set("y", "why").set("z", "zee").build();
-    StructuredRecord r4 = StructuredRecord.builder(schema2).set("y", "wye").set("z", "zea").build();
-
-    UnionSplitter unionSplitter = new UnionSplitter(new UnionSplitter.Conf(null, true));
-    unionSplitter.initialize(new MockTransformContext());
-    MockMultiOutputEmitter<StructuredRecord> mockEmitter = new MockMultiOutputEmitter<>();
-
-    unionSplitter.transform(r1, mockEmitter);
-    unionSplitter.transform(r2, mockEmitter);
-    unionSplitter.transform(r3, mockEmitter);
-    unionSplitter.transform(r4, mockEmitter);
-
-    Map<String, List<StructuredRecord>> expected = ImmutableMap.<String, List<StructuredRecord>>of(
-      "s1", ImmutableList.of(r1, r2), "s2", ImmutableList.of(r3, r4));
-    Map<String, List<Object>> actual = mockEmitter.getEmitted();
-    Assert.assertEquals(expected, actual);
-  }
 }


### PR DESCRIPTION
Removing the capability to split on the entire record, as that
is not a use case we are targeting any more, and it is hard to
explain and convey in the UI.