### PR TITLE
CDAP-12843 set orc sink schema as a dataset property

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/common/FileSetUtil.java
@@ -129,6 +129,7 @@ public class FileSetUtil {
       .setEnableExploreOnCreate(true)
       .setInputProperty("orc.mapred.output.schema", orcSchema)
       .setOutputProperty("orc.mapred.output.schema", orcSchema)
+      .add(DatasetProperties.SCHEMA, configuredSchema)
       .build();
   }
 


### PR DESCRIPTION
this will allow the UI to auto-populate a schema if the dataset
is used in some other pipeline.