### PR TITLE
temporarily change group by aggregates widget

### DIFF
--- a/core-plugins/widgets/GroupByAggregate-batchaggregator.json
+++ b/core-plugins/widgets/GroupByAggregate-batchaggregator.json
@@ -26,25 +26,12 @@
           }
         },
         {
-          "widget-type": "function-dropdown-with-alias",
+          "widget-type": "csv",
           "label": "Aggregates",
           "name": "aggregates",
           "widget-attributes": {
-            "placeholders": {
-              "field": "field",
-              "alias": "alias"
-            },
-            "dropdownOptions": [
-              "Avg",
-              "Count",
-              "First",
-              "Last",
-              "Max",
-              "Min",
-              "Stddev",
-              "Sum",
-              "Variance"
-            ]
+            "delimiter": ",",
+            "value-placeholder": "Aggregate (ex: total:sum(price))"
           }
         },
         {


### PR DESCRIPTION
Changing the aggregate widget to be a csv widget in order to
support the macro use case. This is temporary until
function-dropdown-with-alias has support for macros.