### PR TITLE
[CDAP-12883] Adds emit-errors and emit-alerts properties to widget json of Javascript, Python, and Scala editors

### DIFF
--- a/core-plugins/widgets/JavaScript-transform.json
+++ b/core-plugins/widgets/JavaScript-transform.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "spec-version": "1.0"
+    "spec-version": "1.6"
   },
   "configuration-groups": [
     {
@@ -22,6 +22,8 @@
       ]
     }
   ],
+  "emit-alerts": true,
+  "emit-errors": true,
   "errorDataset": {
     "errorDatasetTooltip": "Dataset that collects error messages from emitter. Please check reference section for usage."
   },

--- a/core-plugins/widgets/PythonEvaluator-transform.json
+++ b/core-plugins/widgets/PythonEvaluator-transform.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "spec-version": "1.5"
+    "spec-version": "1.6"
   },
   "display-name" : "Python",
   "configuration-groups": [
@@ -18,6 +18,8 @@
       ]
     }
   ],
+  "emit-alerts": true,
+  "emit-errors": true,
   "errorDataset": {
     "errorDatasetTooltip": "Dataset that collects error messages from emitter. Please check reference section for usage."
   },

--- a/spark-plugins/widgets/ScalaSparkCompute-sparkcompute.json
+++ b/spark-plugins/widgets/ScalaSparkCompute-sparkcompute.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "spec-version": "1.0"
+    "spec-version": "1.6"
   },
   "configuration-groups": [
     {
@@ -17,6 +17,8 @@
       ]
     }
   ],
+  "emit-alerts": true,
+  "emit-errors": true,
   "outputs": [
     {
       "name": "schema",


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12883

This lets the UI know that these plugins can emit alerts and errors. On-hold until ~~https://github.com/caskdata/cdap/pull/9817 is merged.~~ we know for sure this is how we want to surface this information.