### PR TITLE
Revert "CDAP-12942 removing macro support for aggregates"

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/GroupByConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/GroupByConfig.java
@@ -45,6 +45,7 @@ import java.util.Set;
  */
 public class GroupByConfig extends AggregatorConfig {
 
+  @Macro
   @Description("Aggregates to compute on grouped records. " +
     "Supported aggregate functions are count, count(*), sum, avg, min, max, first, last. " +
     "A function must specify the field it should be applied on, as well as the name it should be called. " +

--- a/core-plugins/widgets/GroupByAggregate-batchaggregator.json
+++ b/core-plugins/widgets/GroupByAggregate-batchaggregator.json
@@ -26,25 +26,12 @@
           }
         },
         {
-          "widget-type": "function-dropdown-with-alias",
+          "widget-type": "csv",
           "label": "Aggregates",
           "name": "aggregates",
           "widget-attributes": {
-            "placeholders": {
-              "field": "field",
-              "alias": "alias"
-            },
-            "dropdownOptions": [
-              "Avg",
-              "Count",
-              "First",
-              "Last",
-              "Max",
-              "Min",
-              "Stddev",
-              "Sum",
-              "Variance"
-            ]
+            "delimiter": ",",
+            "value-placeholder": "Aggregate (ex: total:sum(price))"
           }
         },
         {


### PR DESCRIPTION
Reverts caskdata/hydrator-plugins#756

This can be merged into 1.8, since https://github.com/caskdata/cdap/pull/9830 is now available in CDAP release/4.3