### PR TITLE
fix avro export

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -190,6 +190,7 @@
               co.cask.hydrator.plugin.transform.*;
               co.cask.hydrator.plugin.validator.*;
               co.cask.hydrator.plugin.error.*;
+              org.apache.avro.mapred.*;
               org.apache.avro.mapreduce;
               org.apache.parquet.avro.*;
               org.apache.parquet.hadoop.*;


### PR DESCRIPTION
AvroKey is in the mapred package and not the mapreduce package,
so need to export that too. Previously it was working because
the app used to expose its own avro classes, which was wrong and
removed in 5.0.