### PR TITLE
CDAP-12875 set parquet read schema

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/PathTrackingInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/PathTrackingInputFormat.java
@@ -67,6 +67,7 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
         AvroJob.setInputKeySchema(job, new org.apache.avro.Schema.Parser().parse(schema));
       } else if (format.equalsIgnoreCase("parquet")) {
         AvroWriteSupport.setSchema(conf, new org.apache.avro.Schema.Parser().parse(schema));
+        conf.set("parquet.avro.read.schema", schema);
       }
     } else if (format.equalsIgnoreCase("text")) {
       conf.set(SCHEMA, getTextOutputSchema(pathField).toString());


### PR DESCRIPTION
This works around an issue in CDAP versions prior to 5.0.0, where
avro classes where being exposed by the data-pipeline app. This
sets the avro read schema directly to avoid going down a code
path that would trigger the bug.