### PR TITLE
CDAP-13339 add guava as direct dependency

### DIFF
--- a/hdfs-plugins/pom.xml
+++ b/hdfs-plugins/pom.xml
@@ -52,6 +52,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <!-- change to hadoop-aws when hadoop dependency is updated to 2.6 -->
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>


### PR DESCRIPTION
HDFS sink directly uses guava, and should have it as a direct
dependency. At some point, it stopped getting bundled in the fat
jar since it was a transitive dependency.