### PR TITLE
CDAP-13339 add guava as direct dependency.

### DIFF
--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015-2016 Cask Data, Inc.
+  Copyright © 2015-2018 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -33,18 +33,23 @@
       <artifactId>cdap-etl-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.cask.hydrator</groupId>
+      <artifactId>hydrator-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>hydrator-test</artifactId>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-pipeline</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>co.cask.hydrator</groupId>
-      <artifactId>hydrator-common</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
DBSink directly uses guava, and should have it as a direct
dependency. At some point, it stopped getting bundled in the fat
jar since it was a transitive dependency.

Similar to this PR: https://github.com/caskdata/hydrator-plugins/pull/786