### PR TITLE
CDAP-13527 macro enable dbsink properties

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/DBConfig.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.hydrator.common.Constants;
@@ -38,6 +39,7 @@ public class DBConfig extends ConnectionConfig {
     "of column name cases across different databases but might result in column name conflicts if multiple column " +
     "names are the same when the case is ignored.")
   @Nullable
+  @Macro
   public String columnNameCase;
 
   public Boolean getEnableAutoCommit() {

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
@@ -202,6 +202,7 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
 
     @Name(COLUMNS)
     @Description("Comma-separated list of columns in the specified table to export to.")
+    @Macro
     public String columns;
 
     @Name(TABLE_NAME)

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSinkTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSinkTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -41,6 +41,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -61,14 +62,14 @@ public class DBSinkTestRun extends DatabasePluginTestBase {
                                          BatchSink.PLUGIN_TYPE,
                                          ImmutableMap.of(DBConfig.CONNECTION_STRING, getConnectionURL(),
                                                          DBSink.DBSinkConfig.TABLE_NAME, "MY_DEST_TABLE",
-                                                         DBSink.DBSinkConfig.COLUMNS, cols,
+                                                         DBSink.DBSinkConfig.COLUMNS, "${col-macro}",
                                                          DBConfig.JDBC_PLUGIN_NAME, "hypersql",
                                                          Constants.Reference.REFERENCE_NAME, "DBTest"),
                                          null);
     ApplicationManager appManager = deployETL(sourceConfig, sinkConfig, "testDBSink");
     createInputData(inputDatasetName);
 
-    runETLOnce(appManager);
+    runETLOnce(appManager, Collections.singletonMap("col-macro", cols));
 
     try (Connection conn = getConnection();
          Statement stmt = conn.createStatement()) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13527
Build: https://builds.cask.co/browse/HYP-BAD436

These variables are not used in configurePipeline() method, so they can be macro-enabled