### PR TITLE
remove file submodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <module>transform-plugins</module>
     <module>wrangler-transform</module>
     <module>condition-plugins</module>
-    <module>file</module>
   </modules>
 
   <licenses>


### PR DESCRIPTION
https://github.com/caskdata/hydrator-plugins/pull/801 was an incomplete revert of https://github.com/caskdata/hydrator-plugins/pull/799. This completes that revert.