### PR TITLE
Adding date/time support in database plugins

### DIFF
--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/sink/DBSink.java
@@ -42,15 +42,12 @@ import co.cask.hydrator.plugin.db.batch.TransactionIsolationLevel;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.lib.db.DBConfiguration;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -61,7 +58,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 
@@ -218,7 +214,6 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
       "and this setting is set to true. For drivers like that, this should be set to TRANSACTION_NONE.")
     @Macro
     public String transactionIsolationLevel;
-
   }
 
   private static class DBOutputFormatProvider implements OutputFormatProvider {

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -58,7 +58,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import javax.ws.rs.Path;

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSinkTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSinkTestRun.java
@@ -36,10 +36,16 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -78,6 +84,10 @@ public class DBSinkTestRun extends DatabasePluginTestBase {
       try (ResultSet resultSet = stmt.getResultSet()) {
         Assert.assertTrue(resultSet.next());
         users.add(resultSet.getString("NAME"));
+        Assert.assertEquals(new Date(CURRENT_TS).toString(), resultSet.getDate("DATE_COL").toString());
+        Assert.assertEquals(new Time(CURRENT_TS).toString(), resultSet.getTime("TIME_COL").toString());
+        Assert.assertEquals(new Timestamp(CURRENT_TS).toString(),
+                            resultSet.getTimestamp("TIMESTAMP_COL").toString());
         Assert.assertTrue(resultSet.next());
         users.add(resultSet.getString("NAME"));
         Assert.assertFalse(resultSet.next());
@@ -138,36 +148,37 @@ public class DBSinkTestRun extends DatabasePluginTestBase {
       Schema.Field.of("NUMERIC_COL", Schema.of(Schema.Type.DOUBLE)),
       Schema.Field.of("DECIMAL_COL", Schema.of(Schema.Type.DOUBLE)),
       Schema.Field.of("BIT_COL", Schema.of(Schema.Type.BOOLEAN)),
-      Schema.Field.of("DATE_COL", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("TIME_COL", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("DATE_COL", Schema.of(Schema.LogicalType.DATE)),
+      Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
+      Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
       Schema.Field.of("BINARY_COL", Schema.of(Schema.Type.BYTES)),
       Schema.Field.of("BLOB_COL", Schema.of(Schema.Type.BYTES)),
       Schema.Field.of("CLOB_COL", Schema.of(Schema.Type.STRING))
     );
     List<StructuredRecord> inputRecords = new ArrayList<>();
+    LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
     for (int i = 1; i <= 2; i++) {
       String name = "user" + i;
       inputRecords.add(StructuredRecord.builder(schema)
-        .set("ID", i)
-        .set("NAME", name)
-        .set("SCORE", 3.451f)
-        .set("GRADUATED", (i % 2 == 0))
-        .set("TINY", i + 1)
-        .set("SMALL", i + 2)
-        .set("BIG", 3456987L)
-        .set("FLOAT_COL", 3.456f)
-        .set("REAL_COL", 3.457f)
-        .set("NUMERIC_COL", 3.458d)
-        .set("DECIMAL_COL", 3.459d)
-        .set("BIT_COL", (i % 2 == 1))
-        .set("DATE_COL", CURRENT_TS)
-        .set("TIME_COL", CURRENT_TS)
-        .set("TIMESTAMP_COL", CURRENT_TS)
-        .set("BINARY_COL", name.getBytes(Charsets.UTF_8))
-        .set("BLOB_COL", name.getBytes(Charsets.UTF_8))
-        .set("CLOB_COL", CLOB_DATA)
-        .build());
+                         .set("ID", i)
+                         .set("NAME", name)
+                         .set("SCORE", 3.451f)
+                         .set("GRADUATED", (i % 2 == 0))
+                         .set("TINY", i + 1)
+                         .set("SMALL", i + 2)
+                         .set("BIG", 3456987L)
+                         .set("FLOAT_COL", 3.456f)
+                         .set("REAL_COL", 3.457f)
+                         .set("NUMERIC_COL", 3.458d)
+                         .set("DECIMAL_COL", 3.459d)
+                         .set("BIT_COL", (i % 2 == 1))
+                         .setDate("DATE_COL", localDateTime.toLocalDate())
+                         .setTime("TIME_COL", localDateTime.toLocalTime())
+                         .setTimestamp("TIMESTAMP_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
+                         .set("BINARY_COL", name.getBytes(Charsets.UTF_8))
+                         .set("BLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("CLOB_COL", CLOB_DATA)
+                         .build());
     }
     MockSource.writeInput(inputManager, inputRecords);
   }

--- a/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
+++ b/database-plugins/src/test/java/co/cask/hydrator/plugin/db/batch/sink/DBSourceTestRun.java
@@ -42,6 +42,11 @@ import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,15 +157,14 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
     // Verify time columns
     java.util.Date date = new java.util.Date(CURRENT_TS);
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-    long expectedDateTimestamp = Date.valueOf(sdf.format(date)).getTime();
+    LocalDate expectedDate = Date.valueOf(sdf.format(date)).toLocalDate();
     sdf = new SimpleDateFormat("H:mm:ss");
-    long expectedTimeTimestamp = Time.valueOf(sdf.format(date)).getTime();
-    Assert.assertEquals(expectedDateTimestamp, (long) row1.get("DATE_COL"));
-    Assert.assertEquals(expectedDateTimestamp, (long) row2.get("DATE_COL"));
-    Assert.assertEquals(expectedTimeTimestamp, (long) row1.get("TIME_COL"));
-    Assert.assertEquals(expectedTimeTimestamp, (long) row2.get("TIME_COL"));
-    Assert.assertEquals(CURRENT_TS, (long) row1.get("TIMESTAMP_COL"));
-    Assert.assertEquals(CURRENT_TS, (long) row2.get("TIMESTAMP_COL"));
+    LocalTime expectedTime = Time.valueOf(sdf.format(date)).toLocalTime();
+    ZonedDateTime expectedTs = date.toInstant().atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    Assert.assertEquals(expectedDate, row1.getDate("DATE_COL"));
+    Assert.assertEquals(expectedTime, row1.getTime("TIME_COL"));
+    Assert.assertEquals(expectedTs, row1.getTimestamp("TIMESTAMP_COL", ZoneId.ofOffset("UTC", ZoneOffset.UTC)));
+
     // verify binary columns
     Assert.assertEquals("user1", Bytes.toString(((ByteBuffer) row1.get("BINARY_COL")).array(), 0, 5));
     Assert.assertEquals("user2", Bytes.toString(((ByteBuffer) row2.get("BINARY_COL")).array(), 0, 5));
@@ -347,7 +351,7 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .build();
     ApplicationId appId = NamespaceId.DEFAULT.app("dbSourceNonExistingTest");
     assertRuntimeFailure(appId, etlConfig, "ETL Application with DB Source should have failed because of a " +
-      "non-existent source table.");
+      "non-existent source table.", 1);
 
     // Bad connection
     String badConnection = String.format("jdbc:hsqldb:hsql://localhost/%sWRONG", getDatabase());
@@ -370,6 +374,6 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .addConnection(sourceBadConn.getName(), sink.getName())
       .build();
     assertRuntimeFailure(appId, etlConfig, "ETL Application with DB Source should have failed because of a " +
-      "non-existent source database.");
+      "non-existent source database.", 2);
   }
 }


### PR DESCRIPTION
**Dependency of PR**
Depends on https://github.com/caskdata/cdap/pull/10549, can not merge before that.

Summary:

- Adding support for date/time in database source and sink 
- Fixed a flaky test: `testNonExistentDBTable` - The test was using `waitForRun` to verify programRunStatus. However, that api only blocks until first run record of given programRunStatus. Instead of that using `waitForRuns` api which blocks until given number of run records are available.
