### PR TITLE
Bump all submodules to the same version as parent submodule (a few were missing).

### DIFF
--- a/solrsearch-plugins/pom.xml
+++ b/solrsearch-plugins/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Solr Search Plugins</name>

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.hydrator</groupId>
     <artifactId>hydrator-plugins</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Transform Plugins</name>


### PR DESCRIPTION
In https://github.com/caskdata/hydrator-plugins/pull/816, not all of the submodule pom files were updated.