### PR TITLE
CDAP-14013: Record schema for external dataset

### DIFF
--- a/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchCassandraSource.java
+++ b/cassandra-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/BatchCassandraSource.java
@@ -80,10 +80,15 @@ public class BatchCassandraSource extends ReferenceBatchSource<Long, Row, Struct
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(config.schema), "Schema must be specified.");
     try {
-      Schema schema = Schema.parseJson(config.schema);
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(schema);
+      return Schema.parseJson(config.schema);
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid output schema: " + e.getMessage(), e);
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AbstractFileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AbstractFileBatchSource.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Abstract file batch source
@@ -101,14 +102,19 @@ public abstract class AbstractFileBatchSource<T extends FileSourceConfig>
     if (!config.containsMacro("timeTable") && config.timeTable != null) {
       pipelineConfigurer.createDataset(config.timeTable, KeyValueTable.class, DatasetProperties.EMPTY);
     }
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
     if (config.getSchema() != null) {
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(config.getSchema());
+      return config.getSchema();
     } else if ("text".equalsIgnoreCase(config.format)) {
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(PathTrackingInputFormat.getTextOutputSchema
-        (config.pathField));
-    } else {
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(null);
+      return PathTrackingInputFormat.getTextOutputSchema(config.pathField);
     }
+    //TODO: Should we return DEFAULT Schema here as that is what we emit record as
+    return null;
   }
 
   @Override

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
@@ -106,10 +106,16 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
     config.validate();
-    pipelineConfigurer.getStageConfigurer().setOutputSchema(DEFAULT_XML_SCHEMA);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
     if (!config.containsMacro("tableName") && !Strings.isNullOrEmpty(config.tableName)) {
       pipelineConfigurer.createDataset(config.tableName, KeyValueTable.class.getName());
     }
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
+    return DEFAULT_XML_SCHEMA;
   }
 
   @Override

--- a/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/co/cask/hydrator/plugin/db/batch/source/DBSource.java
@@ -87,9 +87,16 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
     super.configurePipeline(pipelineConfigurer);
     dbManager.validateJDBCPluginPipeline(pipelineConfigurer, getJDBCPluginId());
     sourceConfig.validate();
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
     if (!Strings.isNullOrEmpty(sourceConfig.schema)) {
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(sourceConfig.getSchema());
+      return sourceConfig.getSchema();
     }
+    return null;
   }
 
   class GetSchemaRequest {

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.hbase.mapreduce.MutationSerialization;
 import org.apache.hadoop.hbase.mapreduce.ResultSerialization;
 import org.apache.hadoop.hbase.mapreduce.TableInputFormat;
 
+import javax.annotation.Nullable;
+
 /**
  *
  */
@@ -77,8 +79,14 @@ public class HBaseSource extends ReferenceBatchSource<ImmutableBytesWritable, Re
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
     try {
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(config.schema));
+      return Schema.parseJson(config.schema);
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid output schema: " + e.getMessage(), e);
     }

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveBatchSource.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveBatchSource.java
@@ -44,6 +44,9 @@ import org.apache.hive.service.auth.HiveAuthFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import javax.annotation.Nullable;
+
 
 /**
  * Batch source for Hive.
@@ -65,12 +68,18 @@ public class HiveBatchSource extends ReferenceBatchSource<WritableComparable, HC
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-    if (config.schema != null) {
-      try {
-        pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(config.schema));
-      } catch (Exception e) {
-        throw new IllegalArgumentException("Invalid output schema: " + e.getMessage(), e);
-      }
+    if (getSchema() != null) {
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
+    }
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
+    try {
+      return config.schema == null ? null : Schema.parseJson(config.schema);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid output schema: " + e.getMessage(), e);
     }
   }
 

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/ReferenceBatchSink.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/ReferenceBatchSink.java
@@ -16,8 +16,13 @@
 
 package co.cask.hydrator.common;
 
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchSink;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A {@link BatchSink} that verifies referenceName property
@@ -38,5 +43,14 @@ public abstract class ReferenceBatchSink<IN, KEY_OUT, VAL_OUT> extends BatchSink
     super.configurePipeline(pipelineConfigurer);
     // Verify that reference name meets dataset id constraints
     IdUtils.validateId(config.referenceName);
+    // create the external dataset this is done in the configure pipeline stage so that the external dataset with or
+    // without the schema is created when the pipeline is deployed itself.
+    Schema externalSchema = pipelineConfigurer.getStageConfigurer().getInputSchema();
+    Map<String, String> dsProperties = Collections.emptyMap();
+    if (externalSchema != null) {
+      dsProperties = Collections.singletonMap(DatasetProperties.SCHEMA, externalSchema.toString());
+    }
+    pipelineConfigurer.createDataset(config.referenceName, Constants.EXTERNAL_DATASET_TYPE,
+                                     DatasetProperties.of(dsProperties));
   }
 }

--- a/mongodb-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/MongoDBBatchSource.java
+++ b/mongodb-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/MongoDBBatchSource.java
@@ -65,9 +65,15 @@ public class MongoDBBatchSource extends ReferenceBatchSource<Object, BSONObject,
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.getStageConfigurer().setOutputSchema(getSchema());
+  }
+
+  @Nullable
+  @Override
+  public Schema getSchema() {
     try {
       BSONConverter.validateSchema(Schema.parseJson(config.schema));
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(config.schema));
+      return Schema.parseJson(config.schema);
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid output schema : " + e.getMessage(), e);
     }


### PR DESCRIPTION
### Summary
- Record Schema for External Datasets
- To record the Schema the dataset creation is done with the schema which is indexed by the metadata store as the schema of the external dataset.
- The creation is done in configurePipeline stage rather than prepareRun so that the external dataset is created when the pipeline is deployed and not when the run is started. 
- The Field Level Lineage uses the schema stored in the metadata store to return the schema of the dataset so this will now allow FLL to display the schema of external datasets.