### PR TITLE
CDAP-14013: Record schema for external datasets

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileSourceConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileSourceConfig.java
@@ -203,12 +203,10 @@ public abstract class FileSourceConfig extends ReferencePluginConfig {
     }
   }
 
+  @Nullable
   protected Schema getSchema() {
     try {
-      if (schema == null) {
-        return null;
-      }
-      return Schema.parseJson(schema);
+      return schema == null ? null : Schema.parseJson(schema);
     } catch (Exception e) {
       throw new IllegalArgumentException("Unable to parse schema with error: " + e.getMessage(), e);
     }

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/XMLReaderBatchSource.java
@@ -32,6 +32,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.hydrator.common.LineageRecorder;
 import co.cask.hydrator.common.ReferenceBatchSource;
 import co.cask.hydrator.common.ReferencePluginConfig;
 import co.cask.hydrator.common.SourceInputFormatProvider;
@@ -146,6 +147,9 @@ public class XMLReaderBatchSource extends ReferenceBatchSource<LongWritable, Obj
 
     XMLInputFormat.setInputPathFilter(job, BatchXMLFileFilter.class);
     XMLInputFormat.addInputPath(job, new Path(config.path));
+    // create the external dataset with the given schema
+    LineageRecorder lineageRecorder = new LineageRecorder(context, config.referenceName);
+    lineageRecorder.createExternalDataset(DEFAULT_XML_SCHEMA);
     context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(XMLInputFormat.class, conf)));
   }
 

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/HBaseConfig.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/HBaseConfig.java
@@ -18,10 +18,12 @@ package co.cask.hydrator.plugin;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.hydrator.common.ReferencePluginConfig;
 import co.cask.hydrator.plugin.sink.HBaseSink;
 import co.cask.hydrator.plugin.source.HBaseSource;
 
+import java.io.IOException;
 import javax.annotation.Nullable;
 
 /**
@@ -57,5 +59,21 @@ public class HBaseConfig extends ReferencePluginConfig {
     this.tableName = tableName;
     this.rowField = rowField;
     this.schema = schema;
+  }
+
+  /**
+   * @return {@link Schema} of the dataset if one was given
+   * @throws IllegalArgumentException if the schema is null or not as valid JSON
+   */
+  public Schema getSchema() {
+    if (schema == null) {
+      throw new IllegalArgumentException("Schema cannot be null");
+    }
+    try {
+      return Schema.parseJson(schema);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(String.format("Unable to parse schema '%s'. Reason: %s",
+                                                       schema, e.getMessage()), e);
+    }
   }
 }

--- a/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
+++ b/hbase-plugins/src/main/java/co/cask/hydrator/plugin/source/HBaseSource.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.hydrator.common.LineageRecorder;
 import co.cask.hydrator.common.ReferenceBatchSource;
 import co.cask.hydrator.common.SourceInputFormatProvider;
 import co.cask.hydrator.plugin.HBaseConfig;
@@ -71,6 +72,8 @@ public class HBaseSource extends ReferenceBatchSource<ImmutableBytesWritable, Re
     conf.setStrings(ioSerializations,
                     MutationSerialization.class.getName(), ResultSerialization.class.getName(),
                     KeyValueSerialization.class.getName());
+    LineageRecorder lineageRecorder = new LineageRecorder(context, config.referenceName);
+    lineageRecorder.createExternalDataset(config.getSchema());
     context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(HBaseTableInputFormat.class, conf)));
   }
 

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveSinkConfig.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/sink/HiveSinkConfig.java
@@ -18,8 +18,10 @@ package co.cask.hydrator.plugin.batch.sink;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.hydrator.plugin.batch.HiveConfig;
 
+import java.io.IOException;
 import javax.annotation.Nullable;
 
 /**
@@ -41,4 +43,17 @@ public class HiveSinkConfig extends HiveConfig {
     "schema of the table will be used and it should match the schema of the data being written.")
   @Nullable
   public String schema;
+
+  /**
+   * @return {@link Schema} of the dataset if one was given else null
+   */
+  @Nullable
+  public Schema getSchema() {
+    try {
+      return schema == null ? null : Schema.parseJson(schema);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(String.format("Unable to parse schema '%s'. Reason: %s",
+                                                       schema, e.getMessage()), e);
+    }
+  }
 }

--- a/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveSourceConfig.java
+++ b/hive-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/HiveSourceConfig.java
@@ -18,8 +18,10 @@ package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.hydrator.plugin.batch.HiveConfig;
 
+import java.io.IOException;
 import javax.annotation.Nullable;
 
 /**
@@ -39,4 +41,17 @@ public class HiveSourceConfig extends HiveConfig {
     "a source then you should provide a schema here with non-primitive fields dropped else your pipeline will fail.")
   @Nullable
   public String schema;
+
+  /**
+   * @return {@link Schema} of the dataset if one was given else null
+   */
+  @Nullable
+  public Schema getSchema() {
+    try {
+      return schema == null ? null : Schema.parseJson(schema);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(String.format("Unable to parse schema '%s'. Reason: %s",
+                                                       schema, e.getMessage()), e);
+    }
+  }
 }

--- a/hydrator-common/src/main/java/co/cask/hydrator/common/LineageRecorder.java
+++ b/hydrator-common/src/main/java/co/cask/hydrator/common/LineageRecorder.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.hydrator.common;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceConflictException;
+import co.cask.cdap.api.lineage.field.EndPoint;
+import co.cask.cdap.api.lineage.field.ReadOperation;
+import co.cask.cdap.api.lineage.field.WriteOperation;
+import co.cask.cdap.etl.api.batch.BatchContext;
+import co.cask.cdap.etl.api.lineage.field.FieldReadOperation;
+import co.cask.cdap.etl.api.lineage.field.FieldWriteOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * A helper class for creating external dataset and recording it's lineage
+ */
+public class LineageRecorder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LineageRecorder.class);
+
+  private final BatchContext context;
+  private final String dataset;
+
+  public LineageRecorder(BatchContext context, String dataset) {
+    this.context = context;
+    this.dataset = dataset;
+  }
+
+  /**
+   * Creates an external dataset if a dataset with the given {@link LineageRecorder#dataset} name does not already
+   * exists. If a non null schema is provided then the external dataset will have the given schema upon creation.
+   *
+   * @param schema the schema of the external dataset
+   * @throws RuntimeException if the dataset creation fails
+   */
+  public void createExternalDataset(@Nullable Schema schema) {
+    DatasetProperties datasetProperties;
+    if (schema == null) {
+      datasetProperties = DatasetProperties.EMPTY;
+    } else {
+      datasetProperties = DatasetProperties.of(Collections.singletonMap(DatasetProperties.SCHEMA, schema.toString()));
+    }
+    try {
+      if (!context.datasetExists(dataset)) {
+        // if the dataset does not already exists then create it with the given schema. If it does exists then there is
+        // no need to create it.
+        context.createDataset(dataset, Constants.EXTERNAL_DATASET_TYPE, datasetProperties);
+      }
+    } catch (InstanceConflictException e) {
+      // This will happen when multiple pipelines run simultaneously and are trying to create the same
+      // external dataset. Both might enter the if block after checking for existence and try to create the dataset.
+      // One will succeed and another will receive a InstanceConflictException. This exception can be ignored.
+      return;
+    } catch (DatasetManagementException e) {
+      throw new RuntimeException(String.format("Failed to create dataset %s with schema %s.", dataset, schema), e);
+    }
+  }
+
+  /**
+   * Records a {@link ReadOperation}
+   *
+   * @param operationName the name of the operation
+   * @param operationDescription description for the operation
+   * @param fields output fields of this read operation
+   */
+  public void recordRead(String operationName, String operationDescription, List<String> fields) {
+    context.record(Collections.singletonList(new FieldReadOperation(operationName,
+                                                                    operationDescription,
+                                                                    EndPoint.of(context.getNamespace(), dataset),
+                                                                    fields)));
+  }
+
+  /**
+   * Records a {@link WriteOperation}
+   *
+   * @param operationName the name of the operation
+   * @param operationDescription description for the operation
+   * @param fields input fields of this read operation
+   */
+  public void recordWrite(String operationName, String operationDescription, List<String> fields) {
+    context.record(Collections.singletonList(new FieldWriteOperation(operationName,
+                                                                     operationDescription,
+                                                                     EndPoint.of(context.getNamespace(), dataset),
+                                                                     fields)));
+  }
+}


### PR DESCRIPTION
### Summary
- Record Schema for External Datasets
- To record the Schema the dataset creation is done with the schema which is indexed by the metadata store as the schema of the external dataset.
- The Field Level Lineage uses the schema stored in the metadata store to return the schema of the dataset so this will now allow FLL to display the schema of external datasets.