### PR TITLE
CDAP-12852 add a property to copy headers of text files

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AbstractFileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/AbstractFileBatchSource.java
@@ -179,7 +179,7 @@ public abstract class AbstractFileBatchSource<T extends FileSourceConfig>
       }
       if (CombinePathTrackingInputFormat.class.getName().equals(config.inputFormatClass)) {
         PathTrackingInputFormat.configure(job, conf, config.pathField, config.filenameOnly,
-            config.format, config.schema);
+            config.format, config.schema, config.shouldCopyHeader());
       }
       recordLineage(context);
       context.setInput(Input.of(config.referenceName, new SourceInputFormatProvider(config.inputFormatClass, conf)));

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/CombineHeaderFileSplit.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/CombineHeaderFileSplit.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.source;
+
+import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link CombineFileSplit} that also contains the header for the files in the split. This must extend
+ * CombineFileSplit because {@link CombineFileRecordReader} expects a CombineFileSplit.
+ */
+public class CombineHeaderFileSplit extends CombineFileSplit {
+  private String header;
+
+  public CombineHeaderFileSplit() {
+    // exists for Hadoop deserialization
+  }
+
+  public CombineHeaderFileSplit(CombineFileSplit split, @Nullable String header) throws IOException {
+    super(split.getPaths(), split.getStartOffsets(), split.getLengths(), split.getLocations());
+    this.header = header;
+  }
+
+  @Nullable
+  public String getHeader() {
+    return header;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    out.writeBoolean(header != null);
+    if (header != null) {
+      out.writeUTF(header);
+    }
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    if (in.readBoolean()) {
+      header = in.readUTF();
+    }
+  }
+
+}

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/CombinePathTrackingInputFormat.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/CombinePathTrackingInputFormat.java
@@ -17,8 +17,12 @@
 package co.cask.hydrator.plugin.batch.source;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
@@ -26,24 +30,97 @@ import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Similar to CombineTextInputFormat except it uses PathTrackingInputFormat to keep track of filepaths that
  * records were read from.
+ *
+ * This class is tightly coupled with {@link PathTrackingInputFormat}.
+ * TODO: (CDAP-14406) clean up File input formats.
  */
 public class CombinePathTrackingInputFormat extends CombineFileInputFormat<NullWritable, StructuredRecord> {
+  static final String HEADER = "combine.path.tracking.header";
 
+  /**
+   * Converts the CombineFileSplits derived by CombineFileInputFormat into CombineHeaderFileSplits
+   * that optionally keep track of the header for each file.
+   *
+   * It is assumed that every file has the same header. It would be possible to read the header for each individual
+   * file, but the use case for that is unclear and it could potentially add a decent amount of overhead if there
+   * are a bunch of small files.
+   */
   @Override
-  public RecordReader<NullWritable, StructuredRecord> createRecordReader(InputSplit split, TaskAttemptContext context)
-    throws IOException {
-    return new CombineFileRecordReader<>((CombineFileSplit) split, context, RecordReaderWrapper.class);
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    List<InputSplit> fileSplits = super.getSplits(job);
+    Configuration hConf = job.getConfiguration();
+
+    boolean copyHeader = hConf.getBoolean(PathTrackingInputFormat.COPY_HEADER, false);
+    List<InputSplit> splits = new ArrayList<>(fileSplits.size());
+
+    if (!copyHeader) {
+      for (InputSplit split : fileSplits) {
+        splits.add(new CombineHeaderFileSplit((CombineFileSplit) split, null));
+      }
+      return splits;
+    }
+
+    String header = null;
+    for (InputSplit split : fileSplits) {
+      CombineFileSplit combineFileSplit = (CombineFileSplit) split;
+
+      Path[] paths = combineFileSplit.getPaths();
+      // read the header from one of the files if the header hasn't been determined yet
+      // if the split has no paths for some reason, it is ok for the header to remain null,
+      // as no records would be read from that split anyway.
+      if (header == null) {
+        for (Path path : paths) {
+          header = getHeader(path.getFileSystem(hConf), path);
+          if (header != null) {
+            break;
+          }
+        }
+      }
+      splits.add(new CombineHeaderFileSplit(combineFileSplit, header));
+    }
+
+    return splits;
+  }
+
+  @Nullable
+  private String getHeader(FileSystem fs, Path path) throws IOException {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(path), StandardCharsets.UTF_8))) {
+      return reader.readLine();
+    }
   }
 
   /**
-   * Required because CombineFileRecordReader expects a specific constructor signature.
+   * Creates a RecordReader that delegates to some other RecordReader for each path in the input split.
+   * The header for each file is set in the context Configuration to make it available to the delegate RecordReaders.
+   */
+  @Override
+  public RecordReader<NullWritable, StructuredRecord> createRecordReader(InputSplit split, TaskAttemptContext context)
+    throws IOException {
+    CombineHeaderFileSplit combineSplit = (CombineHeaderFileSplit) split;
+    if (combineSplit.getHeader() != null) {
+      context.getConfiguration().set(HEADER, combineSplit.getHeader());
+    }
+    return new CombineFileRecordReader<>(combineSplit, context, RecordReaderWrapper.class);
+  }
+
+  /**
+   * This is just a wrapper that's responsible for delegating to a corresponding RecordReader in
+   * {@link PathTrackingInputFormat}. All it does is pick the i'th path in the CombineFileSplit to create a
+   * FileSplit and use the delegate RecordReader to read that split.
    */
   private static class RecordReaderWrapper extends CombineFileRecordReaderWrapper<NullWritable, StructuredRecord> {
+
     // this constructor signature is required by CombineFileRecordReader
     RecordReaderWrapper(CombineFileSplit split, TaskAttemptContext context,
                         Integer idx) throws IOException, InterruptedException {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileSourceConfig.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileSourceConfig.java
@@ -112,6 +112,11 @@ public abstract class FileSourceConfig extends ReferencePluginConfig {
   @Description("Schema for the source")
   public String schema;
 
+  // this is a hidden property that only exists for wrangler's parse-as-csv that uses the header as the schema
+  // when this is true and the format is text, the header will be the first record returned by every record reader
+  @Nullable
+  private Boolean copyHeader;
+
   public FileSourceConfig() {
     this(null, null, null, null, null, null, null, null, null, null, null, null);
   }
@@ -137,6 +142,7 @@ public abstract class FileSourceConfig extends ReferencePluginConfig {
     this.filenameOnly = fileNameOnly == null ? false : fileNameOnly;
     this.pathField = pathField;
     this.schema = schema;
+    this.copyHeader = false;
   }
 
   protected void validate() {
@@ -213,4 +219,8 @@ public abstract class FileSourceConfig extends ReferencePluginConfig {
   }
 
   protected abstract String getPath();
+
+  boolean shouldCopyHeader() {
+    return copyHeader;
+  }
 }

--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -104,6 +104,10 @@
           "widget-type": "textbox",
           "label": "Time Table",
           "name": "timeTable"
+        },
+        {
+          "widget-type": "hidden",
+          "name": "copyHeader"
         }
       ]
     }


### PR DESCRIPTION
This is a hack to allow wrangler's parse-as-csv to operate
correctly when a file is split into parts. Each record reader will
emit the header as its first record, which will allow an attached
wrangler transform to parse-as-csv with a header correctly.

The property is hidden, and is only expected to be set by the
dataprep service.