### PR TITLE
bump the netty http version to get race condition fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <json-path.version>2.2.0</json-path.version>
     <json.version>20160212</json.version>
     <netty.version>4.1.16.Final</netty.version>
-    <netty-http.version>1.0.0</netty-http.version>
+    <netty-http.version>1.1.0-SNAPSHOT</netty-http.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This will fix flaky test problems where apps sometimes fail to
deploy due to CDAP internal dataset service calls.