### PR TITLE
CDAP-12852 move file source validation logic

### DIFF
--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSource.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSource.java
@@ -27,6 +27,7 @@ import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.hydrator.common.LineageRecorder;
 import co.cask.hydrator.common.SourceInputFormatProvider;
 import co.cask.hydrator.common.batch.JobUtils;
+import co.cask.hydrator.format.FileFormat;
 import co.cask.hydrator.format.RegexPathFilter;
 import co.cask.hydrator.format.input.CombinePathTrackingInputFormat;
 import co.cask.hydrator.format.input.EmptyInputFormat;
@@ -66,6 +67,48 @@ public abstract class AbstractFileSource extends BatchSource<NullWritable, Struc
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     properties.validate();
+
+    Schema schema = properties.getSchema();
+    FileFormat fileFormat = properties.getFormat();
+    if (fileFormat == FileFormat.TEXT && schema != null) {
+      Schema.Field offsetField = schema.getField("offset");
+      if (offsetField == null) {
+        throw new IllegalArgumentException("Schema for text format must have a field named 'offset'");
+      }
+      Schema offsetSchema = offsetField.getSchema();
+      Schema.Type offsetType = offsetSchema.isNullable() ? offsetSchema.getNonNullable().getType() :
+        offsetSchema.getType();
+      if (offsetType != Schema.Type.LONG) {
+        throw new IllegalArgumentException("Type of 'offset' field must be 'long', but found " + offsetType);
+      }
+
+      Schema.Field bodyField = schema.getField("body");
+      if (bodyField == null) {
+        throw new IllegalArgumentException("Schema for text format must have a field named 'body'");
+      }
+      Schema bodySchema = bodyField.getSchema();
+      Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
+      if (bodyType != Schema.Type.STRING) {
+        throw new IllegalArgumentException("Type of 'body' field must be 'string', but found + " + bodyType);
+      }
+    }
+
+    String pathField = properties.getPathField();
+    if (pathField != null && schema != null) {
+      Schema.Field schemaPathField = schema.getField(pathField);
+      if (schemaPathField == null) {
+        throw new IllegalArgumentException(
+          String.format("Path field '%s' is not present in the schema. Please add it to the schema as a string field.",
+                        pathField));
+      }
+      Schema pathFieldSchema = schemaPathField.getSchema();
+      Schema.Type pathFieldType = pathFieldSchema.isNullable() ? pathFieldSchema.getNonNullable().getType() :
+        pathFieldSchema.getType();
+      if (pathFieldType != Schema.Type.STRING) {
+        throw new IllegalArgumentException(
+          String.format("Path field '%s' must be of type 'string', but found '%s'.", pathField, pathFieldType));
+      }
+    }
     pipelineConfigurer.getStageConfigurer().setOutputSchema(properties.getSchema());
   }
 

--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/FileSourceProperties.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/FileSourceProperties.java
@@ -49,6 +49,7 @@ public interface FileSourceProperties {
   /**
    * Get the format of the data to read.
    */
+  @Nullable
   FileFormat getFormat();
 
   /**


### PR DESCRIPTION
Moving validation logic from the config to the source. This is
to ensure that validation is performed when plugins don't
extend the AbstractFileSourceConfig and just implement the
FileSourceProperties interface.