### PR TITLE
CDAP-14355 Validate referenceName during pipeline deployment

### DIFF
--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSinkConfig.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSinkConfig.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.hydrator.common.IdUtils;
 import co.cask.hydrator.format.FileFormat;
 
 import java.io.IOException;
@@ -58,6 +59,7 @@ public abstract class AbstractFileSinkConfig extends PluginConfig implements Fil
   private String schema;
 
   public void validate() {
+    IdUtils.validateId(referenceName);
     if (suffix != null && !containsMacro("suffix")) {
       new SimpleDateFormat(suffix);
     }

--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSourceConfig.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.hydrator.common.IdUtils;
 import co.cask.hydrator.format.FileFormat;
 
 import java.util.regex.Pattern;
@@ -97,6 +98,7 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   }
 
   public void validate() {
+    IdUtils.validateId(referenceName);
     FileFormat fileFormat = null;
     if (!containsMacro("format")) {
       fileFormat = getFormat();


### PR DESCRIPTION
- Validate referenceName in configurePipeline stage.
- This is done in the validate which is being called in configurePipeline. 
- This validation is also done in ReferenceBatchSource so a plugin which extends it will have the validation. If a plugin does not extend it then the plugin must perform the validation.
- The validation here applies to all the file source/sink which uses this common format. 