### PR TITLE
CDAP-14321 add formats to file source

### DIFF
--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -35,9 +35,14 @@ an inputFormatClass is given.
 **filenameOnly:** If true and a pathField is specified, only the filename will be used.
 If false, the full URI will be used. Defaults to false.
 
-**format:** Format of the file. Must be "text", "avro" or "parquet". Defaults to "text".
+**Format:** Format of the data to read.
+The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', or 'tsv'.
+If the format is 'blob', every input file will be read into a separate record.
+The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
+If the format is 'text', the schema must contain a field named 'offset' of type 'long' and a field
+named 'body' of type 'string'. (Macro-enabled)
 
-**schema:** Schema for the source.
+**schema:** Schema of the data to read.
 
 **maxSplitSize:** Maximum split-size for each mapper in the MapReduce Job. Defaults to 128MB. (Macro-enabled)
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
@@ -21,10 +21,11 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.hydrator.format.FileFormat;
-import co.cask.hydrator.format.input.PathTrackingInputFormat;
+import co.cask.hydrator.format.input.TextInputProvider;
 import co.cask.hydrator.format.plugin.AbstractFileSource;
 import co.cask.hydrator.format.plugin.FileSourceProperties;
 import com.google.common.reflect.TypeToken;
@@ -64,7 +65,7 @@ public class FTPBatchSource extends AbstractFileSource {
    * Config class that contains all the properties needed for FTP Batch Source.
    */
   @SuppressWarnings("unused")
-  public static class FTPBatchSourceConfig implements FileSourceProperties {
+  public static class FTPBatchSourceConfig extends PluginConfig implements FileSourceProperties {
     private static final Gson GSON = new Gson();
     private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
@@ -152,7 +153,7 @@ public class FTPBatchSource extends AbstractFileSource {
     @Nullable
     @Override
     public Schema getSchema() {
-      return PathTrackingInputFormat.getTextOutputSchema(null);
+      return TextInputProvider.getSchema(null);
     }
 
     Map<String, String> getFileSystemProperties() {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.hydrator.format.input.PathTrackingInputFormat;
+import co.cask.hydrator.format.input.TextInputProvider;
 import co.cask.hydrator.format.plugin.AbstractFileSource;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -49,7 +50,7 @@ import java.util.regex.Pattern;
 @Name("File")
 @Description("Batch source for File Systems")
 public class FileBatchSource extends AbstractFileSource {
-  public static final Schema DEFAULT_SCHEMA = PathTrackingInputFormat.getTextOutputSchema(null);
+  public static final Schema DEFAULT_SCHEMA = TextInputProvider.getSchema(null);
   static final String INPUT_NAME_CONFIG = "input.path.name";
   static final String INPUT_REGEX_CONFIG = "input.path.regex";
   static final String LAST_TIME_READ = "last.time.read";

--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -28,11 +28,21 @@
           "widget-attributes": {
             "values": [
               "avro",
+              "blob",
+              "csv",
+              "delimited",
+              "json",
               "parquet",
-              "text"
+              "text",
+              "tsv"
             ],
             "default": "text"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Delimiter",
+          "name": "delimiter"
         },
         {
           "widget-type": "textbox",

--- a/format-common/src/main/java/co/cask/hydrator/format/input/AvroInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/AvroInputFormatter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.hydrator.format.AvroToStructuredTransformer;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapreduce.AvroKeyInputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Reads avro into StructuredRecords.
+ */
+public class AvroInputFormatter implements FileInputFormatter {
+  private final Schema schema;
+
+  AvroInputFormatter(@Nullable Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public Map<String, String> getFormatConfig() {
+    Map<String, String> properties = new HashMap<>();
+    if (schema != null) {
+      properties.put("avro.schema.input.key", schema.toString());
+    }
+    return properties;
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context)
+    throws IOException, InterruptedException {
+    Configuration hConf = context.getConfiguration();
+    String pathField = hConf.get(PathTrackingInputFormat.PATH_FIELD);
+    RecordReader<AvroKey<GenericRecord>, NullWritable> delegate = (new AvroKeyInputFormat<GenericRecord>())
+      .createRecordReader(split, context);
+    return new AvroRecordReader(delegate, schema, pathField);
+  }
+
+  /**
+   * Transforms GenericRecords into StructuredRecord.
+   */
+  static class AvroRecordReader extends RecordReader<NullWritable, StructuredRecord.Builder> {
+    private final RecordReader<AvroKey<GenericRecord>, NullWritable> delegate;
+    private final AvroToStructuredTransformer recordTransformer;
+    private final String pathField;
+    private Schema schema;
+
+    AvroRecordReader(RecordReader<AvroKey<GenericRecord>, NullWritable> delegate, @Nullable Schema schema,
+                     @Nullable String pathField) {
+      this.delegate = delegate;
+      this.schema = schema;
+      this.pathField = pathField;
+      this.recordTransformer = new AvroToStructuredTransformer();
+    }
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+      delegate.initialize(split, context);
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+      return delegate.nextKeyValue();
+    }
+
+    @Override
+    public NullWritable getCurrentKey() {
+      return NullWritable.get();
+    }
+
+    @Override
+    public StructuredRecord.Builder getCurrentValue() throws IOException, InterruptedException {
+      GenericRecord genericRecord = delegate.getCurrentKey().datum();
+      // if schema is null, but we're still able to read, that means the file contains the schema information
+      // set the schema based on the schema of the record
+      if (schema == null) {
+        if (pathField == null) {
+          schema = Schema.parseJson(genericRecord.getSchema().toString());
+        } else {
+          // if there is a path field, add the path as a field in the schema
+          Schema schemaWithoutPath = Schema.parseJson(genericRecord.getSchema().toString());
+          List<Schema.Field> fields = new ArrayList<>(schemaWithoutPath.getFields().size() + 1);
+          fields.addAll(schemaWithoutPath.getFields());
+          fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+          schema = Schema.recordOf(schemaWithoutPath.getRecordName(), fields);
+        }
+      }
+      return recordTransformer.transform(genericRecord, schema, pathField);
+    }
+
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+      return delegate.getProgress();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/AvroInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/AvroInputProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides Avro formatters.
+ */
+public class AvroInputProvider implements FileInputFormatterProvider {
+
+  @Override
+  public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
+    return new AvroInputFormatter(schema);
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputFormatter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.io.ByteStreams;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Reads the entire contents of a File into a single record
+ */
+public class BlobInputFormatter implements FileInputFormatter {
+  private final Schema schema;
+
+  BlobInputFormatter(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public Map<String, String> getFormatConfig() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context) {
+    if (split.getLength() > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Blob format cannot be used with files larger than 2GB");
+    }
+    return new RecordReader<NullWritable, StructuredRecord.Builder>() {
+      boolean hasNext;
+      byte[] val;
+
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) {
+        hasNext = true;
+        val = null;
+      }
+
+      @Override
+      public boolean nextKeyValue() throws IOException {
+        if (!hasNext) {
+          return false;
+        }
+
+        Path path = split.getPath();
+        FileSystem fs = path.getFileSystem(context.getConfiguration());
+        try (FSDataInputStream input = fs.open(path)) {
+          val = new byte[(int) split.getLength()];
+          ByteStreams.readFully(input, val);
+        }
+        hasNext = false;
+        return true;
+      }
+
+      @Override
+      public NullWritable getCurrentKey() {
+        return NullWritable.get();
+      }
+
+      @Override
+      public StructuredRecord.Builder getCurrentValue() {
+        String fieldName = schema.getFields().iterator().next().getName();
+        return StructuredRecord.builder(schema).set(fieldName, val);
+      }
+
+      @Override
+      public float getProgress() {
+        return 0.0f;
+      }
+
+      @Override
+      public void close() {
+        // no-op
+      }
+    };
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides Blob formatters.
+ */
+public class BlobInputProvider implements FileInputFormatterProvider {
+
+  @Override
+  public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
+    if (schema != null) {
+      Schema.Field bodyField = schema.getField("body");
+      if (bodyField == null) {
+        throw new IllegalArgumentException("Schema for blob format must have a field named 'body'");
+      }
+      Schema bodySchema = bodyField.getSchema();
+      Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
+      if (bodyType != Schema.Type.BYTES) {
+        throw new IllegalArgumentException("Type of 'body' field must be 'bytes', but found + " + bodyType);
+      }
+    }
+    return new BlobInputFormatter(schema);
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/DelimitedInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/DelimitedInputProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides Delimited formatters.
+ */
+public class DelimitedInputProvider implements FileInputFormatterProvider {
+  private final String constantDelimiter;
+
+  public DelimitedInputProvider(@Nullable String constantDelimiter) {
+    this.constantDelimiter = constantDelimiter;
+  }
+
+  @Override
+  public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
+    if (schema == null) {
+      throw new IllegalArgumentException("Delimited format cannot be used without specifying a schema.");
+    }
+    String delimiter = constantDelimiter == null ? properties.getOrDefault("delimiter", ",") : constantDelimiter;
+    return new DelimitedTextInputFormatter(schema, delimiter);
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/DelimitedTextInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/DelimitedTextInputFormatter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.base.Splitter;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Reads delimited text into StructuredRecords.
+ */
+public class DelimitedTextInputFormatter implements FileInputFormatter {
+  private final Schema schema;
+  private final String delimiter;
+
+  DelimitedTextInputFormatter(Schema schema, String delimiter) {
+    this.schema = schema;
+    this.delimiter = delimiter;
+  }
+
+  @Override
+  public Map<String, String> getFormatConfig() {
+    Map<String, String> config = new HashMap<>();
+    config.put("delimiter", delimiter);
+    return config;
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context) {
+    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    String delimiter = context.getConfiguration().get("delimiter");
+
+    return new RecordReader<NullWritable, StructuredRecord.Builder>() {
+
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        delegate.initialize(split, context);
+      }
+
+      @Override
+      public boolean nextKeyValue() throws IOException, InterruptedException {
+        return delegate.nextKeyValue();
+      }
+
+      @Override
+      public NullWritable getCurrentKey() {
+        return NullWritable.get();
+      }
+
+      @Override
+      public StructuredRecord.Builder getCurrentValue() throws IOException, InterruptedException {
+        String delimitedString = delegate.getCurrentValue().toString();
+
+        StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+        Iterator<Schema.Field> fields = schema.getFields().iterator();
+
+        for (String part : Splitter.on(delimiter).split(delimitedString)) {
+          if (part.isEmpty()) {
+            builder.set(fields.next().getName(), null);
+          } else {
+            builder.convertAndSet(fields.next().getName(), part);
+          }
+        }
+        return builder;
+      }
+
+      @Override
+      public float getProgress() throws IOException, InterruptedException {
+        return delegate.getProgress();
+      }
+
+      @Override
+      public void close() throws IOException {
+        delegate.close();
+      }
+    };
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/FileInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/FileInputFormatter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Functionality required to read from a Hadoop InputFormat into StructuredRecords
+ */
+public interface FileInputFormatter {
+
+  /**
+   * Get the configuration required by the Hadoop InputFormat. Anything returned in this map will be available
+   * through the Hadoop Configuration in {@link #create(FileSplit, TaskAttemptContext)}.
+   */
+  Map<String, String> getFormatConfig();
+
+  /**
+   * Creates a RecordReader that will read the raw data and transform it into a StructuredRecord
+   *
+   * @param split the input split to read
+   * @param context the task context
+   * @return a RecordReader for reading and transforming raw input
+   */
+  RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context)
+    throws IOException, InterruptedException;
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/FileInputFormatterProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/FileInputFormatterProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Creates FileInputFormatters.
+ */
+public interface FileInputFormatterProvider {
+
+  /**
+   * Creates a FileInputFormatter.
+   */
+  FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema);
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/JsonInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/JsonInputFormatter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Reads json into StructuredRecords.
+ */
+public class JsonInputFormatter implements FileInputFormatter {
+  private final Schema schema;
+
+  JsonInputFormatter(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public Map<String, String> getFormatConfig() {
+    return Collections.emptyMap();
+  }
+
+  private Schema getModifiedSchema(@Nullable String pathField) {
+    // if the path field is set, it might not be nullable
+    // if it's not nullable, decoding a string into a StructuredRecord will fail because a non-nullable
+    // field will have a null value.
+    // so in these cases, a modified schema is used where the path field is nullable
+    if (pathField == null) {
+      return schema;
+    }
+    List<Schema.Field> fieldCopies = new ArrayList<>(schema.getFields().size());
+    for (Schema.Field field : schema.getFields()) {
+      if (field.getName().equals(pathField) && !field.getSchema().isNullable()) {
+        fieldCopies.add(Schema.Field.of(field.getName(), Schema.nullableOf(field.getSchema())));
+      } else {
+        fieldCopies.add(field);
+      }
+    }
+    return Schema.recordOf(schema.getRecordName(), fieldCopies);
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context) {
+    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    Configuration hConf = context.getConfiguration();
+    String pathField = hConf.get(PathTrackingInputFormat.PATH_FIELD);
+    Schema modifiedSchema = getModifiedSchema(pathField);
+
+    return new RecordReader<NullWritable, StructuredRecord.Builder>() {
+
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        delegate.initialize(split, context);
+      }
+
+      @Override
+      public boolean nextKeyValue() throws IOException, InterruptedException {
+        return delegate.nextKeyValue();
+      }
+
+      @Override
+      public NullWritable getCurrentKey() {
+        return NullWritable.get();
+      }
+
+      @Override
+      public StructuredRecord.Builder getCurrentValue() throws IOException, InterruptedException {
+        String json = delegate.getCurrentValue().toString();
+        StructuredRecord record = StructuredRecordStringConverter.fromJsonString(json, modifiedSchema);
+        StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+        for (Schema.Field field : schema.getFields()) {
+          builder.set(field.getName(), record.get(field.getName()));
+        }
+        return builder;
+      }
+
+      @Override
+      public float getProgress() throws IOException, InterruptedException {
+        return delegate.getProgress();
+      }
+
+      @Override
+      public void close() throws IOException {
+        delegate.close();
+      }
+    };
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/JsonInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/JsonInputProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides json formatters.
+ */
+public class JsonInputProvider implements FileInputFormatterProvider {
+
+  @Override
+  public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
+    if (schema == null) {
+      throw new IllegalArgumentException("Json format cannot be used without specifying a schema.");
+    }
+    return new JsonInputFormatter(schema);
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/ParquetInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/ParquetInputFormatter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.hydrator.format.AvroToStructuredTransformer;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.parquet.avro.AvroParquetInputFormat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Reads parquet into StructuredRecords.
+ */
+public class ParquetInputFormatter implements FileInputFormatter {
+  private final Schema schema;
+
+  ParquetInputFormatter(@Nullable Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public Map<String, String> getFormatConfig() {
+    Map<String, String> properties = new HashMap<>();
+    if (schema != null) {
+      properties.put("parquet.avro.schema", schema.toString());
+    }
+    return properties;
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context)
+    throws IOException, InterruptedException {
+    Configuration hConf = context.getConfiguration();
+    String pathField = hConf.get(PathTrackingInputFormat.PATH_FIELD);
+    RecordReader<Void, GenericRecord> delegate = (new AvroParquetInputFormat<GenericRecord>())
+      .createRecordReader(split, context);
+    return new ParquetRecordReader(delegate, schema, pathField);
+  }
+
+  /**
+   * Transforms GenericRecords into StructuredRecord.
+   */
+  static class ParquetRecordReader extends RecordReader<NullWritable, StructuredRecord.Builder> {
+    private final RecordReader<Void, GenericRecord> delegate;
+    private final AvroToStructuredTransformer recordTransformer;
+    private final String pathField;
+    private Schema schema;
+
+    ParquetRecordReader(RecordReader<Void, GenericRecord> delegate, @Nullable Schema schema,
+                        @Nullable String pathField) {
+      this.delegate = delegate;
+      this.schema = schema;
+      this.pathField = pathField;
+      this.recordTransformer = new AvroToStructuredTransformer();
+    }
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+      delegate.initialize(split, context);
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+      return delegate.nextKeyValue();
+    }
+
+    @Override
+    public NullWritable getCurrentKey() {
+      return NullWritable.get();
+    }
+
+    @Override
+    public StructuredRecord.Builder getCurrentValue() throws IOException, InterruptedException {
+      GenericRecord genericRecord = delegate.getCurrentValue();
+      // if schema is null, but we're still able to read, that means the file contains the schema information
+      // set the schema based on the schema of the record
+      if (schema == null) {
+        if (pathField == null) {
+          schema = Schema.parseJson(genericRecord.getSchema().toString());
+        } else {
+          // if there is a path field, add the path as a field in the schema
+          Schema schemaWithoutPath = Schema.parseJson(genericRecord.getSchema().toString());
+          List<Schema.Field> fields = new ArrayList<>(schemaWithoutPath.getFields().size() + 1);
+          fields.addAll(schemaWithoutPath.getFields());
+          fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+          schema = Schema.recordOf(schemaWithoutPath.getRecordName(), fields);
+        }
+      }
+      return recordTransformer.transform(genericRecord, schema, pathField);
+    }
+
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+      return delegate.getProgress();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/ParquetInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/ParquetInputProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides Parquet formatters.
+ */
+public class ParquetInputProvider implements FileInputFormatterProvider {
+
+  @Override
+  public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
+    return new ParquetInputFormatter(schema);
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/PathTrackingInputFormat.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/PathTrackingInputFormat.java
@@ -18,31 +18,24 @@ package co.cask.hydrator.format.input;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.hydrator.format.AvroToStructuredTransformer;
 import co.cask.hydrator.format.FileFormat;
 import co.cask.hydrator.format.plugin.FileSourceProperties;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.mapred.AvroKey;
-import org.apache.avro.mapreduce.AvroJob;
-import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
-import org.apache.parquet.avro.AvroParquetInputFormat;
-import org.apache.parquet.avro.AvroWriteSupport;
-import org.apache.parquet.io.InvalidRecordException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -62,7 +55,7 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
    * there is a proper solution in wrangler.
    */
   public static final String COPY_HEADER = "path.tracking.copy.header";
-  private static final String PATH_FIELD = "path.tracking.path.field";
+  static final String PATH_FIELD = "path.tracking.path.field";
   private static final String FILENAME_ONLY = "path.tracking.filename.only";
   private static final String FORMAT = "path.tracking.format";
   private static final String SCHEMA = "path.tracking.schema";
@@ -70,7 +63,7 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
   /**
    * Configure the input format to use the specified schema and optional path field.
    */
-  public static void configure(Job job, FileSourceProperties properties) {
+  public static void configure(Job job, FileSourceProperties properties, Map<String, String> pluginProperties) {
     Configuration conf = job.getConfiguration();
     String pathField = properties.getPathField();
     if (pathField != null) {
@@ -78,37 +71,30 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
     }
     conf.setBoolean(FILENAME_ONLY, properties.useFilenameAsPath());
     FileFormat format = properties.getFormat();
+    if (format == null) {
+      throw new IllegalArgumentException("A format must be specified.");
+    }
     conf.set(FORMAT, format.name());
     Schema schema = properties.getSchema();
-
     if (schema != null) {
       conf.set(SCHEMA, schema.toString());
-      if (format == FileFormat.AVRO) {
-        AvroJob.setInputKeySchema(job, new org.apache.avro.Schema.Parser().parse(schema.toString()));
-      } else if (format == FileFormat.PARQUET) {
-        AvroWriteSupport.setSchema(conf, new org.apache.avro.Schema.Parser().parse(schema.toString()));
-      }
-    } else if (format == FileFormat.TEXT) {
-      conf.set(SCHEMA, getTextOutputSchema(pathField).toString());
+    }
+
+    FileInputFormatter inputFormatter = format.getFileInputFormatter(pluginProperties, schema);
+    for (Map.Entry<String, String> entry : inputFormatter.getFormatConfig().entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
     }
   }
 
+  @Override
+  protected boolean isSplitable(JobContext context, Path filename) {
+    FileFormat fileFormat = FileFormat.valueOf(context.getConfiguration().get(FORMAT));
+    return fileFormat != FileFormat.BLOB;
+  }
+
+  @Deprecated
   public static Schema getTextOutputSchema(@Nullable String pathField) {
-    List<Schema.Field> fields = new ArrayList<>();
-    fields.add(Schema.Field.of("offset", Schema.of(Schema.Type.LONG)));
-    fields.add(Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
-    if (pathField != null) {
-      fields.add(Schema.Field.of(pathField, Schema.nullableOf(Schema.of(Schema.Type.STRING))));
-    }
-    return Schema.recordOf("file.record", fields);
-  }
-
-  private static Schema addFieldToSchema(Schema schema, String addFieldKey) {
-    List<Schema.Field> newFields = new ArrayList<>(schema.getFields().size() + 1);
-    newFields.addAll(schema.getFields());
-    Schema.Field newField = Schema.Field.of(addFieldKey, Schema.of(Schema.Type.STRING));
-    newFields.add(newField);
-    return Schema.recordOf(schema.getRecordName(), newFields);
+    return TextInputProvider.getSchema(pathField);
   }
 
   @Override
@@ -124,38 +110,25 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
     Configuration hConf = context.getConfiguration();
     String pathField = hConf.get(PATH_FIELD);
     boolean filenameOnly = hConf.getBoolean(FILENAME_ONLY, false);
-    String format = hConf.get(FORMAT);
+    FileFormat format = FileFormat.valueOf(hConf.get(FORMAT));
     String path = filenameOnly ? fileSplit.getPath().getName() : fileSplit.getPath().toUri().toString();
     String schema = hConf.get(SCHEMA);
     Schema parsedSchema = schema == null ? null : Schema.parseJson(schema);
-    if ("avro".equalsIgnoreCase(format)) {
-      RecordReader<AvroKey<GenericRecord>, NullWritable> delegate = (new AvroKeyInputFormat<GenericRecord>())
-        .createRecordReader(split, context);
-      return new TrackingAvroRecordReader(delegate, pathField, path, parsedSchema);
-    } else if ("parquet".equalsIgnoreCase(format)) {
-      RecordReader<Void, GenericRecord> delegate = (new AvroParquetInputFormat<GenericRecord>())
-        .createRecordReader(split, context);
-      return new TrackingParquetRecordReader(delegate, pathField, path, parsedSchema);
-    } else {
-      // this is set by CombinePathTrackingInputFormat.createRecordReader()
-      String header = hConf.get(CombinePathTrackingInputFormat.HEADER);
-      RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
-      return new TrackingTextRecordReader(delegate, pathField, path, parsedSchema, header);
-    }
+    FileInputFormatter inputFormatter = format.getFileInputFormatter(Collections.emptyMap(), parsedSchema);
+    RecordReader<NullWritable, StructuredRecord.Builder> reader = inputFormatter.create(fileSplit, context);
+    return new TrackingRecordReader(reader, pathField, path);
   }
 
-  private abstract static class TrackingRecordReader<K, V> extends RecordReader<NullWritable, StructuredRecord> {
-    protected final RecordReader<K, V> delegate;
-    protected final Schema schema;
-    protected final String pathField;
-    protected final String path;
+  static class TrackingRecordReader extends RecordReader<NullWritable, StructuredRecord> {
+    private final RecordReader<NullWritable, StructuredRecord.Builder> delegate;
+    private final String pathField;
+    private final String path;
 
-    protected TrackingRecordReader(RecordReader<K, V> delegate, @Nullable String pathField,
-                                   String path, Schema schema) {
+    TrackingRecordReader(RecordReader<NullWritable, StructuredRecord.Builder> delegate,
+                         @Nullable String pathField, String path) {
       this.delegate = delegate;
       this.pathField = pathField;
       this.path = path;
-      this.schema = schema;
     }
 
     @Override
@@ -168,11 +141,9 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
       return NullWritable.get();
     }
 
-    protected abstract StructuredRecord.Builder startCurrentValue() throws IOException, InterruptedException;
-
     @Override
     public StructuredRecord getCurrentValue() throws IOException, InterruptedException {
-      StructuredRecord.Builder recordBuilder = startCurrentValue();
+      StructuredRecord.Builder recordBuilder = delegate.getCurrentValue();
       if (pathField != null) {
         recordBuilder.set(pathField, path);
       }
@@ -195,111 +166,4 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
     }
   }
 
-  private static class TrackingTextRecordReader extends TrackingRecordReader<LongWritable, Text> {
-    private boolean emittedHeader;
-    private String header;
-
-    private TrackingTextRecordReader(RecordReader<LongWritable, Text> delegate, @Nullable String pathField,
-                                     String path, Schema schema, @Nullable String header) {
-      super(delegate, pathField, path, schema);
-      this.header = header;
-    }
-
-    @Override
-    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
-      super.initialize(split, context);
-      emittedHeader = false;
-    }
-
-    public StructuredRecord.Builder startCurrentValue() throws IOException, InterruptedException {
-      StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
-      if (header != null && !emittedHeader) {
-        emittedHeader = true;
-        recordBuilder.set("offset", 0L);
-        recordBuilder.set("body", header);
-      } else {
-        recordBuilder.set("offset", delegate.getCurrentKey().get());
-        recordBuilder.set("body", delegate.getCurrentValue().toString());
-      }
-      return recordBuilder;
-    }
-
-    @Override
-    public boolean nextKeyValue() throws IOException, InterruptedException {
-      if (header != null && !emittedHeader) {
-        return true;
-      }
-
-      if (delegate.nextKeyValue()) {
-        // if this record is the actual header and we've already emitted the copied header,
-        // skip this record so that the header is not emitted twice.
-        if (emittedHeader && delegate.getCurrentKey().get() == 0L) {
-          return delegate.nextKeyValue();
-        }
-        return true;
-      }
-      return false;
-    }
-  }
-
-  private static class TrackingAvroRecordReader extends TrackingRecordReader<AvroKey<GenericRecord>, NullWritable> {
-    private static AvroToStructuredTransformer recordTransformer;
-
-    private TrackingAvroRecordReader(RecordReader<AvroKey<GenericRecord>, NullWritable> delegate,
-                                     @Nullable String pathField, String path, Schema schema) {
-      super(delegate, pathField, path, schema);
-    }
-
-    @Override
-    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException,
-      InterruptedException {
-      super.initialize(split, context);
-      recordTransformer = new AvroToStructuredTransformer();
-    }
-
-    public StructuredRecord.Builder startCurrentValue() throws IOException, InterruptedException {
-      GenericRecord genericRecord = delegate.getCurrentKey().datum();
-      Schema recordSchema = schema;
-      if (recordSchema == null) {
-        recordSchema = recordTransformer.convertSchema(genericRecord.getSchema());
-        if (pathField != null) {
-          recordSchema = addFieldToSchema(recordSchema, pathField);
-        }
-      }
-      return recordTransformer.transform(genericRecord, recordSchema, pathField);
-    }
-  }
-
-  private static class TrackingParquetRecordReader extends TrackingRecordReader<Void, GenericRecord> {
-    private AvroToStructuredTransformer recordTransformer;
-
-    private TrackingParquetRecordReader(RecordReader<Void, GenericRecord> delegate, @Nullable String pathField,
-                                        String path, Schema schema) {
-      super(delegate, pathField, path, schema);
-    }
-
-    @Override
-    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
-      try {
-        super.initialize(split, context);
-      } catch (InvalidRecordException e) {
-        // TODO: (CDAP-13140) remove
-        throw new RuntimeException("There is a mismatch between read and write schema. " +
-                                     "Please modify the plugin schema to include all fields in the write schema.", e);
-      }
-      recordTransformer = new AvroToStructuredTransformer();
-    }
-
-    public StructuredRecord.Builder startCurrentValue() throws IOException, InterruptedException {
-      GenericRecord genericRecord = delegate.getCurrentValue();
-      Schema recordSchema = schema;
-      if (recordSchema == null) {
-        recordSchema = recordTransformer.convertSchema(genericRecord.getSchema());
-        if (pathField != null) {
-          recordSchema = addFieldToSchema(recordSchema, pathField);
-        }
-      }
-      return recordTransformer.transform(genericRecord, recordSchema, pathField);
-    }
-  }
 }

--- a/format-common/src/main/java/co/cask/hydrator/format/input/TextInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/TextInputFormatter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Input reading logic for text files.
+ */
+public class TextInputFormatter implements FileInputFormatter {
+  private final Schema schema;
+
+  TextInputFormatter(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public Map<String, String> getFormatConfig() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public RecordReader<NullWritable, StructuredRecord.Builder> create(FileSplit split, TaskAttemptContext context) {
+    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    String header = context.getConfiguration().get(CombinePathTrackingInputFormat.HEADER);
+    return new TextRecordReader(delegate, schema, header);
+  }
+
+  /**
+   * Text record reader
+   */
+  static class TextRecordReader extends RecordReader<NullWritable, StructuredRecord.Builder> {
+    private final RecordReader<LongWritable, Text> delegate;
+    private final Schema schema;
+    private final String header;
+    private boolean emittedHeader;
+
+    TextRecordReader(RecordReader<LongWritable, Text> delegate, Schema schema, @Nullable String header) {
+      this.delegate = delegate;
+      this.schema = schema;
+      this.header = header;
+    }
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+      delegate.initialize(split, context);
+      emittedHeader = false;
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+      if (header != null && !emittedHeader) {
+        return true;
+      }
+
+      if (delegate.nextKeyValue()) {
+        // if this record is the actual header and we've already emitted the copied header,
+        // skip this record so that the header is not emitted twice.
+        if (emittedHeader && delegate.getCurrentKey().get() == 0L) {
+          return delegate.nextKeyValue();
+        }
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public NullWritable getCurrentKey() {
+      return NullWritable.get();
+    }
+
+    @Override
+    public StructuredRecord.Builder getCurrentValue() throws IOException, InterruptedException {
+      StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
+      if (header != null && !emittedHeader) {
+        emittedHeader = true;
+        recordBuilder.set("offset", 0L);
+        recordBuilder.set("body", header);
+      } else {
+        recordBuilder.set("offset", delegate.getCurrentKey().get());
+        recordBuilder.set("body", delegate.getCurrentValue().toString());
+      }
+      return recordBuilder;
+    }
+
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+      return delegate.getProgress();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.format.input;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides Parquet formatters.
+ */
+public class TextInputProvider implements FileInputFormatterProvider {
+
+  @Override
+  public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
+    if (schema != null) {
+      Schema.Field offsetField = schema.getField("offset");
+      if (offsetField == null) {
+        throw new IllegalArgumentException("Schema for text format must have a field named 'offset'");
+      }
+      Schema offsetSchema = offsetField.getSchema();
+      Schema.Type offsetType = offsetSchema.isNullable() ? offsetSchema.getNonNullable().getType() :
+        offsetSchema.getType();
+      if (offsetType != Schema.Type.LONG) {
+        throw new IllegalArgumentException("Type of 'offset' field must be 'long', but found " + offsetType);
+      }
+
+      Schema.Field bodyField = schema.getField("body");
+      if (bodyField == null) {
+        throw new IllegalArgumentException("Schema for text format must have a field named 'body'");
+      }
+      Schema bodySchema = bodyField.getSchema();
+      Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
+      if (bodyType != Schema.Type.STRING) {
+        throw new IllegalArgumentException("Type of 'body' field must be 'string', but found + " + bodyType);
+      }
+    }
+
+    if (schema == null) {
+      schema = getSchema(properties.get("pathField"));
+    }
+    return new TextInputFormatter(schema);
+  }
+
+  public static Schema getSchema(@Nullable String pathField) {
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.add(Schema.Field.of("offset", Schema.of(Schema.Type.LONG)));
+    fields.add(Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    if (pathField != null) {
+      fields.add(Schema.Field.of(pathField, Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    }
+    return Schema.recordOf("textfile", fields);
+  }
+}

--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSourceConfig.java
@@ -45,8 +45,8 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
 
   @Macro
   @Nullable
-  @Description("Format of the data to read. Supported formats are 'text', 'avro' or 'parquet'. "
-    + "The default value is 'text'.")
+  @Description("Format of the data to read. Supported formats are 'avro', 'blob', 'csv', 'delimited', 'json', "
+    + "'parquet', 'text', or 'tsv'. ")
   private String format;
 
   @Nullable
@@ -62,7 +62,7 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   private Boolean ignoreNonExistingFolders;
 
   @Nullable
-  @Description("Whether to recursively read directories within in the input directory. The default is false.")
+  @Description("Whether to recursively read directories within the input directory. The default is false.")
   private Boolean recursive;
 
   @Nullable
@@ -80,6 +80,12 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   @Description("Output schema for the source. Formats like 'avro' and 'parquet' require a schema in order to "
     + "read the data.")
   private String schema;
+
+  @Macro
+  @Nullable
+  @Description("The delimiter to use if the format is 'delimited'. The delimiter will be ignored if the format "
+    + "is anything other than 'delimited'.")
+  private String delimiter;
 
   // this is a hidden property that only exists for wrangler's parse-as-csv that uses the header as the schema
   // when this is true and the format is text, the header will be the first record returned by every record reader


### PR DESCRIPTION
Added csv, tsv, delimited, json, and blob formats to the file
source. This is to mirror the formats that are available in
the sink, so that whatever content is written by a File sink
can also be read by a File source.

Refactored much of the input format logic to be similar to what
is done for output formats. This mostly amounted to moving the
inner static record readers from PathTrackingInputFormat into
their own classes, and creating hooks to get the record reader
directly from the FileFormat enum.