### PR TITLE
CDAP-14470 make offset optional when reading with text format

### DIFF
--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -39,8 +39,7 @@ If false, the full URI will be used. Defaults to false.
 The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', or 'tsv'.
 If the format is 'blob', every input file will be read into a separate record.
 The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
-If the format is 'text', the schema must contain a field named 'offset' of type 'long' and a field
-named 'body' of type 'string'. (Macro-enabled)
+If the format is 'text', the schema must contain a field named 'body' of type 'string'. (Macro-enabled)
 
 **schema:** Schema of the data to read.
 

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FTPBatchSource.java
@@ -153,7 +153,7 @@ public class FTPBatchSource extends AbstractFileSource {
     @Nullable
     @Override
     public Schema getSchema() {
-      return TextInputProvider.getSchema(null);
+      return TextInputProvider.getDefaultSchema(null);
     }
 
     Map<String, String> getFileSystemProperties() {

--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/source/FileBatchSource.java
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
 @Name("File")
 @Description("Batch source for File Systems")
 public class FileBatchSource extends AbstractFileSource {
-  public static final Schema DEFAULT_SCHEMA = TextInputProvider.getSchema(null);
+  public static final Schema DEFAULT_SCHEMA = TextInputProvider.getDefaultSchema(null);
   static final String INPUT_NAME_CONFIG = "input.path.name";
   static final String INPUT_REGEX_CONFIG = "input.path.regex";
   static final String LAST_TIME_READ = "last.time.read";

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/FileBatchSourceTest.java
@@ -237,7 +237,7 @@ public class FileBatchSourceTest extends HydratorTestBase {
 
     DataSetManager<Table> outputManager = getDataset(outputDatasetName);
 
-    Schema schema = TextInputProvider.getSchema("file");
+    Schema schema = TextInputProvider.getDefaultSchema("file");
     Set<StructuredRecord> expected = ImmutableSet.of(
       StructuredRecord.builder(schema).set("offset", 0L).set("body", "Hello,World").set("file", "test1.txt").build(),
       StructuredRecord.builder(schema).set("offset", 0L).set("body", "CDAP,Platform").set("file", "test3.txt").build());

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/source/FileBatchSourceTest.java
@@ -647,6 +647,37 @@ public class FileBatchSourceTest extends HydratorTestBase {
   }
 
   @Test
+  public void testTextFormatWithoutOffset() throws Exception {
+    File fileText = new File(temporaryFolder.newFolder(), "test.txt");
+    String outputDatasetName = UUID.randomUUID().toString();
+
+    Schema textSchema = Schema.recordOf("file.record",
+                                        Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                        Schema.Field.of("file", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+
+    String appName = UUID.randomUUID().toString();
+    ApplicationManager appManager = createSourceAndDeployApp(appName, fileText, "text", outputDatasetName, textSchema);
+
+    FileUtils.writeStringToFile(fileText, "Hello,World!");
+
+    appManager.getWorkflowManager(SmartWorkflow.NAME)
+      .startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    List<StructuredRecord> expected = ImmutableList.of(
+      StructuredRecord.builder(textSchema)
+        .set("body", "Hello,World!")
+        .set("file", fileText.toURI().toString())
+        .build()
+    );
+
+    DataSetManager<Table> outputManager = getDataset(outputDatasetName);
+    List<StructuredRecord> output = MockSink.readOutput(outputManager);
+
+    Assert.assertEquals(expected, output);
+  }
+
+
+  @Test
   public void testFileBatchInputFormatText() throws Exception {
     File fileText = new File(temporaryFolder.newFolder(), "test.txt");
     String outputDatasetName = "test-filesource-text";
@@ -654,8 +685,7 @@ public class FileBatchSourceTest extends HydratorTestBase {
     Schema textSchema = Schema.recordOf("file.record",
                                         Schema.Field.of("offset", Schema.of(Schema.Type.LONG)),
                                         Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
-                                        Schema.Field.of("file", Schema.nullableOf(Schema.of(
-                                          Schema.Type.STRING))));
+                                        Schema.Field.of("file", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
 
     String appName = "FileSourceText";
     ApplicationManager appManager = createSourceAndDeployApp(appName, fileText, "text", outputDatasetName, textSchema);

--- a/format-common/src/main/java/co/cask/hydrator/format/input/PathTrackingInputFormat.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/PathTrackingInputFormat.java
@@ -32,9 +32,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -94,7 +92,7 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
 
   @Deprecated
   public static Schema getTextOutputSchema(@Nullable String pathField) {
-    return TextInputProvider.getSchema(pathField);
+    return TextInputProvider.getDefaultSchema(pathField);
   }
 
   @Override

--- a/format-common/src/main/java/co/cask/hydrator/format/input/TextInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/TextInputFormatter.java
@@ -61,12 +61,14 @@ public class TextInputFormatter implements FileInputFormatter {
     private final RecordReader<LongWritable, Text> delegate;
     private final Schema schema;
     private final String header;
+    private final boolean setOffset;
     private boolean emittedHeader;
 
     TextRecordReader(RecordReader<LongWritable, Text> delegate, Schema schema, @Nullable String header) {
       this.delegate = delegate;
       this.schema = schema;
       this.header = header;
+      this.setOffset = schema.getField("offset") != null;
     }
 
     @Override
@@ -102,10 +104,14 @@ public class TextInputFormatter implements FileInputFormatter {
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
       if (header != null && !emittedHeader) {
         emittedHeader = true;
-        recordBuilder.set("offset", 0L);
+        if (setOffset) {
+          recordBuilder.set("offset", 0L);
+        }
         recordBuilder.set("body", header);
       } else {
-        recordBuilder.set("offset", delegate.getCurrentKey().get());
+        if (setOffset) {
+          recordBuilder.set("offset", delegate.getCurrentKey().get());
+        }
         recordBuilder.set("body", delegate.getCurrentValue().toString());
       }
       return recordBuilder;

--- a/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
@@ -53,12 +53,12 @@ public class TextInputProvider implements FileInputFormatterProvider {
     }
 
     if (schema == null) {
-      schema = getSchema(properties.get("pathField"));
+      schema = getDefaultSchema(properties.get("pathField"));
     }
     return new TextInputFormatter(schema);
   }
 
-  public static Schema getSchema(@Nullable String pathField) {
+  public static Schema getDefaultSchema(@Nullable String pathField) {
     List<Schema.Field> fields = new ArrayList<>();
     fields.add(Schema.Field.of("offset", Schema.of(Schema.Type.LONG)));
     fields.add(Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))));

--- a/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
@@ -32,14 +32,13 @@ public class TextInputProvider implements FileInputFormatterProvider {
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
     if (schema != null) {
       Schema.Field offsetField = schema.getField("offset");
-      if (offsetField == null) {
-        throw new IllegalArgumentException("Schema for text format must have a field named 'offset'");
-      }
-      Schema offsetSchema = offsetField.getSchema();
-      Schema.Type offsetType = offsetSchema.isNullable() ? offsetSchema.getNonNullable().getType() :
-        offsetSchema.getType();
-      if (offsetType != Schema.Type.LONG) {
-        throw new IllegalArgumentException("Type of 'offset' field must be 'long', but found " + offsetType);
+      if (offsetField != null) {
+        Schema offsetSchema = offsetField.getSchema();
+        Schema.Type offsetType = offsetSchema.isNullable() ? offsetSchema.getNonNullable().getType() :
+          offsetSchema.getType();
+        if (offsetType != Schema.Type.LONG) {
+          throw new IllegalArgumentException("Type of 'offset' field must be 'long', but found " + offsetType);
+        }
       }
 
       Schema.Field bodyField = schema.getField("body");


### PR DESCRIPTION
Makes the offset field optional for the file source. It will be
there by default, but users can remove it if they don't want it.

This is also required to fix issues with wrangler, where it
makes assumptions about column numbering and ends up creating
bad data if the offset field is there.