### PR TITLE
CDAP-14480 set filesystem conf before using it

### DIFF
--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSource.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSource.java
@@ -118,6 +118,11 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
                     schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
 
+    // set entries here, before FileSystem is used
+    for (Map.Entry<String, String> entry : getFileSystemProperties(context).entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
+    }
+
     Path path = new Path(config.getPath());
     FileSystem pathFileSystem = FileSystem.get(path.toUri(), conf);
     FileStatus[] fileStatus = pathFileSystem.globStatus(path);
@@ -141,10 +146,11 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
       }
     }
 
-    // set entries here, in case they need to override anything this base class does
+    // set entries here again, in case anything set by PathTrackingInputFormat should be overridden
     for (Map.Entry<String, String> entry : getFileSystemProperties(context).entrySet()) {
       conf.set(entry.getKey(), entry.getValue());
     }
+
     context.setInput(Input.of(config.getReferenceName(), new SourceInputFormatProvider(inputFormatClass, conf)));
   }
 


### PR DESCRIPTION
Fixes a bug in GCP plugins where the filesystem implementation
is not set in the configuration before the Filesystem tries to
use it.