### PR TITLE
CDAP-14481 check for extra schema fields

### DIFF
--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -37,6 +37,12 @@
               "tsv"
             ],
             "default": "text"
+          },
+          "plugin-function": {
+            "method": "POST",
+            "widget": "outputSchema",
+            "output-property": "schema",
+            "plugin-method": "getSchema"
           }
         },
         {

--- a/format-common/src/main/java/co/cask/hydrator/format/FileFormat.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/FileFormat.java
@@ -106,6 +106,21 @@ public enum FileFormat {
   }
 
   /**
+   * Return the schema for this format, if the format requires a specific schema. Returns null if the format does
+   * not require a specific schema. Should only be called for formats that can read.
+   *
+   * @param pathField the field of the file path, if it exists.
+   * @return the schema required by the format, if it exists
+   */
+  @Nullable
+  public Schema getSchema(@Nullable String pathField) {
+    if (inputProvider == null) {
+      throw new IllegalArgumentException(String.format("Format '%s' cannot be used for reading.", this.name()));
+    }
+    return inputProvider.getSchema(pathField);
+  }
+
+  /**
    * Get a FileFormat from the specified string. This is similar to the valueOf method except that the error
    * message will contain the full set of valid values. It also supports filtering which enum values are valid.
    * This can be used to only get FileFormats that can be used for reading or only get formats that can be used

--- a/format-common/src/main/java/co/cask/hydrator/format/input/AvroInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/AvroInputProvider.java
@@ -26,6 +26,12 @@ import javax.annotation.Nullable;
  */
 public class AvroInputProvider implements FileInputFormatterProvider {
 
+  @Nullable
+  @Override
+  public Schema getSchema(@Nullable String pathField) {
+    return null;
+  }
+
   @Override
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
     return new AvroInputFormatter(schema);

--- a/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputFormatter.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputFormatter.java
@@ -67,6 +67,10 @@ public class BlobInputFormatter implements FileInputFormatter {
         if (!hasNext) {
           return false;
         }
+        hasNext = false;
+        if (split.getLength() == 0) {
+          return false;
+        }
 
         Path path = split.getPath();
         FileSystem fs = path.getFileSystem(context.getConfiguration());
@@ -74,7 +78,6 @@ public class BlobInputFormatter implements FileInputFormatter {
           val = new byte[(int) split.getLength()];
           ByteStreams.readFully(input, val);
         }
-        hasNext = false;
         return true;
       }
 

--- a/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/BlobInputProvider.java
@@ -17,7 +17,10 @@
 package co.cask.hydrator.format.input;
 
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.hydrator.format.plugin.FileSourceProperties;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -26,19 +29,52 @@ import javax.annotation.Nullable;
  */
 public class BlobInputProvider implements FileInputFormatterProvider {
 
+  @Nullable
+  @Override
+  public Schema getSchema(@Nullable String pathField) {
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.add(Schema.Field.of("body", Schema.of(Schema.Type.BYTES)));
+    if (pathField != null && !pathField.isEmpty()) {
+      fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+    }
+    return Schema.recordOf("blob", fields);
+  }
+
   @Override
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
-    if (schema != null) {
-      Schema.Field bodyField = schema.getField("body");
-      if (bodyField == null) {
-        throw new IllegalArgumentException("Schema for blob format must have a field named 'body'");
-      }
-      Schema bodySchema = bodyField.getSchema();
-      Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
-      if (bodyType != Schema.Type.BYTES) {
-        throw new IllegalArgumentException("Type of 'body' field must be 'bytes', but found + " + bodyType);
+    String pathField = properties.get(FileSourceProperties.PATH_FIELD);
+    if (schema == null) {
+      return new BlobInputFormatter(getSchema(pathField));
+    }
+
+    Schema.Field bodyField = schema.getField("body");
+    if (bodyField == null) {
+      throw new IllegalArgumentException("The schema for the 'blob' format must have a field named 'body'");
+    }
+    Schema bodySchema = bodyField.getSchema();
+    Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
+    if (bodyType != Schema.Type.BYTES) {
+      throw new IllegalArgumentException(String.format("The 'body' field must be of type 'bytes', but found '%s'",
+                                                       bodyType.name().toLowerCase()));
+    }
+
+    // blob must contain 'body' as type 'bytes'.
+    // it can optionally contain a path field of type 'string'
+    int numExpectedFields = pathField == null ? 1 : 2;
+    int numFields = schema.getFields().size();
+    if (numFields > numExpectedFields) {
+      int numExtra = numFields - numExpectedFields;
+      if (pathField == null) {
+        throw new IllegalArgumentException(
+          String.format("The schema for the 'blob' format must only contain the 'body' field, "
+                          + "but found %d other field%s.", numFields - 1, numExtra > 1 ? "s" : ""));
+      } else {
+        throw new IllegalArgumentException(
+          String.format("The schema for the 'blob' format must only contain the 'body' field and the '%s' field, "
+                          + "but found %d other field%s.", pathField, numFields - 2, numExtra > 1 ? "s" : ""));
       }
     }
+
     return new BlobInputFormatter(schema);
   }
 }

--- a/format-common/src/main/java/co/cask/hydrator/format/input/DelimitedInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/DelimitedInputProvider.java
@@ -31,6 +31,12 @@ public class DelimitedInputProvider implements FileInputFormatterProvider {
     this.constantDelimiter = constantDelimiter;
   }
 
+  @Nullable
+  @Override
+  public Schema getSchema(@Nullable String pathField) {
+    return null;
+  }
+
   @Override
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
     if (schema == null) {

--- a/format-common/src/main/java/co/cask/hydrator/format/input/FileInputFormatterProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/FileInputFormatterProvider.java
@@ -27,6 +27,12 @@ import javax.annotation.Nullable;
 public interface FileInputFormatterProvider {
 
   /**
+   * Get the schema that the format requires, if it requires a specific schema.
+   */
+  @Nullable
+  Schema getSchema(@Nullable String pathField);
+
+  /**
    * Creates a FileInputFormatter.
    */
   FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema);

--- a/format-common/src/main/java/co/cask/hydrator/format/input/JsonInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/JsonInputProvider.java
@@ -26,6 +26,12 @@ import javax.annotation.Nullable;
  */
 public class JsonInputProvider implements FileInputFormatterProvider {
 
+  @Nullable
+  @Override
+  public Schema getSchema(@Nullable String pathField) {
+    return null;
+  }
+
   @Override
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
     if (schema == null) {

--- a/format-common/src/main/java/co/cask/hydrator/format/input/ParquetInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/ParquetInputProvider.java
@@ -26,6 +26,12 @@ import javax.annotation.Nullable;
  */
 public class ParquetInputProvider implements FileInputFormatterProvider {
 
+  @Nullable
+  @Override
+  public Schema getSchema(@Nullable String pathField) {
+    return null;
+  }
+
   @Override
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
     return new ParquetInputFormatter(schema);

--- a/format-common/src/main/java/co/cask/hydrator/format/input/PathTrackingInputFormat.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/PathTrackingInputFormat.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -112,7 +113,12 @@ public class PathTrackingInputFormat extends FileInputFormat<NullWritable, Struc
     String path = filenameOnly ? fileSplit.getPath().getName() : fileSplit.getPath().toUri().toString();
     String schema = hConf.get(SCHEMA);
     Schema parsedSchema = schema == null ? null : Schema.parseJson(schema);
-    FileInputFormatter inputFormatter = format.getFileInputFormatter(Collections.emptyMap(), parsedSchema);
+
+    Map<String, String> properties = new HashMap<>();
+    if (pathField != null) {
+      properties.put(FileSourceProperties.PATH_FIELD, pathField);
+    }
+    FileInputFormatter inputFormatter = format.getFileInputFormatter(properties, parsedSchema);
     RecordReader<NullWritable, StructuredRecord.Builder> reader = inputFormatter.create(fileSplit, context);
     return new TrackingRecordReader(reader, pathField, path);
   }

--- a/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/input/TextInputProvider.java
@@ -17,6 +17,7 @@
 package co.cask.hydrator.format.input;
 
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.hydrator.format.plugin.FileSourceProperties;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,42 +29,83 @@ import javax.annotation.Nullable;
  */
 public class TextInputProvider implements FileInputFormatterProvider {
 
+  @Nullable
+  @Override
+  public Schema getSchema(@Nullable String pathField) {
+    return getDefaultSchema(pathField);
+  }
+
   @Override
   public FileInputFormatter create(Map<String, String> properties, @Nullable Schema schema) {
-    if (schema != null) {
-      Schema.Field offsetField = schema.getField("offset");
-      if (offsetField != null) {
-        Schema offsetSchema = offsetField.getSchema();
-        Schema.Type offsetType = offsetSchema.isNullable() ? offsetSchema.getNonNullable().getType() :
-          offsetSchema.getType();
-        if (offsetType != Schema.Type.LONG) {
-          throw new IllegalArgumentException("Type of 'offset' field must be 'long', but found " + offsetType);
-        }
-      }
-
-      Schema.Field bodyField = schema.getField("body");
-      if (bodyField == null) {
-        throw new IllegalArgumentException("Schema for text format must have a field named 'body'");
-      }
-      Schema bodySchema = bodyField.getSchema();
-      Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
-      if (bodyType != Schema.Type.STRING) {
-        throw new IllegalArgumentException("Type of 'body' field must be 'string', but found + " + bodyType);
-      }
-    }
-
+    String pathField = properties.get(FileSourceProperties.PATH_FIELD);
     if (schema == null) {
-      schema = getDefaultSchema(properties.get("pathField"));
+      return new TextInputFormatter(getSchema(pathField));
     }
+
+    // text must contain 'body' as type 'string'.
+    // it can optionally contain a 'offset' field of type 'long'
+    // it can optionally contain a path field of type 'string'
+    Schema.Field offsetField = schema.getField("offset");
+    if (offsetField != null) {
+      Schema offsetSchema = offsetField.getSchema();
+      Schema.Type offsetType = offsetSchema.isNullable() ? offsetSchema.getNonNullable().getType() :
+        offsetSchema.getType();
+      if (offsetType != Schema.Type.LONG) {
+        throw new IllegalArgumentException(String.format("The 'offset' field must be of type 'long', but found '%s'",
+                                                         offsetType.name().toLowerCase()));
+      }
+    }
+
+    Schema.Field bodyField = schema.getField("body");
+    if (bodyField == null) {
+      throw new IllegalArgumentException("The schema for the 'text' format must have a field named 'body'");
+    }
+    Schema bodySchema = bodyField.getSchema();
+    Schema.Type bodyType = bodySchema.isNullable() ? bodySchema.getNonNullable().getType() : bodySchema.getType();
+    if (bodyType != Schema.Type.STRING) {
+      throw new IllegalArgumentException(String.format("The 'body' field must be of type 'string', but found '%s'",
+                                                       bodyType.name().toLowerCase()));
+    }
+
+    // fields should be body (required), offset (optional), [pathfield] (optional)
+    boolean expectOffset = schema.getField("offset") != null;
+    boolean expectPath = pathField != null;
+    int numExpectedFields = 1;
+    if (expectOffset) {
+      numExpectedFields++;
+    }
+    if (expectPath) {
+      numExpectedFields++;
+    }
+    int maxExpectedFields = pathField == null ? 2 : 3;
+    int numFields = schema.getFields().size();
+    if (numFields > numExpectedFields) {
+      String expectedFields;
+      if (expectOffset && expectPath) {
+        expectedFields = String.format("'offset', 'body', and '%s' fields", pathField);
+      } else if (expectOffset) {
+        expectedFields = "'offset' and 'body' fields";
+      } else if (expectPath) {
+        expectedFields = String.format("'body' and '%s' fields", pathField);
+      } else {
+        expectedFields = "'body' field";
+      }
+
+      int numExtraFields = numFields - maxExpectedFields;
+      throw new IllegalArgumentException(
+        String.format("The schema for the 'text' format must only contain the %s, but found %d other field%s",
+                      expectedFields, numExtraFields, numExtraFields > 1 ? "s" : ""));
+    }
+
     return new TextInputFormatter(schema);
   }
 
   public static Schema getDefaultSchema(@Nullable String pathField) {
     List<Schema.Field> fields = new ArrayList<>();
     fields.add(Schema.Field.of("offset", Schema.of(Schema.Type.LONG)));
-    fields.add(Schema.Field.of("body", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
-    if (pathField != null) {
-      fields.add(Schema.Field.of(pathField, Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    fields.add(Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
+    if (pathField != null && !pathField.isEmpty()) {
+      fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
     }
     return Schema.recordOf("textfile", fields);
   }

--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/AbstractFileSourceConfig.java
@@ -18,6 +18,7 @@ package co.cask.hydrator.format.plugin;
 
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.hydrator.common.IdUtils;
@@ -66,6 +67,7 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   @Description("Whether to recursively read directories within the input directory. The default is false.")
   private Boolean recursive;
 
+  @Name(FileSourceProperties.PATH_FIELD)
   @Nullable
   @Description("Output field to place the path of the file that the record was read from. "
     + "If not specified, the file path will not be included in output records. "

--- a/format-common/src/main/java/co/cask/hydrator/format/plugin/FileSourceProperties.java
+++ b/format-common/src/main/java/co/cask/hydrator/format/plugin/FileSourceProperties.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
  * PluginConfig, or in case there is some class hierarchy that does not allow it.
  */
 public interface FileSourceProperties {
+  String PATH_FIELD = "pathField";
 
   /**
    * Validates the properties, throwing an IllegalArgumentException if anything is invalid.


### PR DESCRIPTION
Usability improvements to the file source to check if there are
extra fields in the schema that are not supported when using the
text or blob formats. This is to address user behavior where
the format is changed but schema is not changed, resulting in a
invalid schema.

Also adding a get schema button to help users generate the correct
schema when changing formats.