### PR TITLE
clean up docs db plugins

### DIFF
--- a/database-plugins/docs/Database-action.md
+++ b/database-plugins/docs/Database-action.md
@@ -14,29 +14,29 @@ For example, you may want to run a sql update command on a database before the p
 
 Properties
 ----------
-**query:** The database command to execute.
+**Plugin Name:** Name of the JDBC plugin to use. This is the value of the 'name' key
+defined in the JSON file for the JDBC plugin.
 
-**connectionString:** JDBC connection string including database name.
+**Plugin Type:** Type of the JDBC plugin to use. This is the value of the 'type' key
+defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
 
-**connectionArguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
+**Database Command:** The database command to execute.
+
+**Connection String:** JDBC connection string including database name.
+
+**Username:** User identity for connecting to the specified database. Required for databases that need
+authentication. Optional for databases that do not require authentication.
+
+**Password:** Password to use to connect to the specified database. Required for databases
+that need authentication. Optional for databases that do not require authentication.
+
+**Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies
 the key and value for the argument. For example, 'key1=value1;key2=value' specifies that the connection will be
 given arguments 'key1' mapped to 'value1' and the argument 'key2' mapped to 'value2'. (Macro-enabled)
 
-**user:** User identity for connecting to the specified database. Required for databases that need
-authentication. Optional for databases that do not require authentication.
-
-**password:** Password to use to connect to the specified database. Required for databases
-that need authentication. Optional for databases that do not require authentication.
-
-**jdbcPluginName:** Name of the JDBC plugin to use. This is the value of the 'name' key
-defined in the JSON file for the JDBC plugin.
-
-**jdbcPluginType:** Type of the JDBC plugin to use. This is the value of the 'type' key
-defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
-
-**enableAutoCommit:** Whether to enable auto-commit for queries run by this source. Defaults to 'false'.
+**Enable Auto-Commit:** Whether to enable auto-commit for queries run by this source. Defaults to 'false'.
 Normally this setting does not matter. It only matters if you are using a jdbc driver -- like the Hive
 driver -- that will error when the commit operation is run, or a driver that will error when auto-commit is
 set to false. For drivers like those, you will need to set this to 'true'.

--- a/database-plugins/docs/Database-batchsink.md
+++ b/database-plugins/docs/Database-batchsink.md
@@ -16,44 +16,44 @@ of the FileSet to a database table where it can be served to your users.
 
 Properties
 ----------
-**referenceName:** This will be used to uniquely identify this sink for lineage, annotating metadata, etc.
+**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**tableName:** Name of the table to export to. (Macro-enabled)
+**Plugin Name:** Name of the JDBC plugin to use. This is the value of the 'name' key
+defined in the JSON file for the JDBC plugin.
 
-**columns:** Comma-separated list of columns in the specified table to export to.
+**Plugin Type:** Type of the JDBC plugin to use. This is the value of the 'type' key
+defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
 
-**columnCase:** Sets the case of the column names returned by the column check query.
-Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
-the names returned from the database are used as-is. Note that setting this property provides predictability
-of column name cases across different databases but might result in column name conflicts if multiple column
-names are the same when the case is ignored (optional).
+**Connection String:** JDBC connection string including database name. (Macro-enabled)
 
-**connectionString:** JDBC connection string including database name. (Macro-enabled)
+**Table Name:** Name of the table to export to. (Macro-enabled)
 
-**connectionArguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
+**Columns:** Comma-separated list of columns in the specified table to export to.
+
+**Username:** User identity for connecting to the specified database. Required for databases that need
+authentication. Optional for databases that do not require authentication. (Macro-enabled)
+
+**Password:** Password to use to connect to the specified database. Required for databases
+that need authentication. Optional for databases that do not require authentication. (Macro-enabled)
+
+**Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies
 the key and value for the argument. For example, 'key1=value1;key2=value' specifies that the connection will be
 given arguments 'key1' mapped to 'value1' and the argument 'key2' mapped to 'value2'. (Macro-enabled)
 
-**user:** User identity for connecting to the specified database. Required for databases that need
-authentication. Optional for databases that do not require authentication. (Macro-enabled)
-
-**password:** Password to use to connect to the specified database. Required for databases
-that need authentication. Optional for databases that do not require authentication. (Macro-enabled)
-
-**jdbcPluginName:** Name of the JDBC plugin to use. This is the value of the 'name' key
-defined in the JSON file for the JDBC plugin.
-
-**jdbcPluginType:** Type of the JDBC plugin to use. This is the value of the 'type' key
-defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
-
-**enableAutoCommit:** Whether to enable auto-commit for queries run by this sink. Defaults to 'false'.
+**Enable Auto-Commit:** Whether to enable auto-commit for queries run by this sink. Defaults to 'false'.
 Normally this setting does not matter. It only matters if you are using a jdbc driver -- like the Hive
 driver -- that will error when the commit operation is run, or a driver that will error when auto-commit is
 set to false. For drivers like those, you will need to set this to 'true'.
 
-**transactionIsolationLevel:** The transaction isolation level for queries run by this sink.
+**Column Name Case:** Sets the case of the column names returned by the column check query.
+Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
+the names returned from the database are used as-is. Note that setting this property provides predictability
+of column name cases across different databases but might result in column name conflicts if multiple column
+names are the same when the case is ignored (optional).
+
+**Transaction Isolation Level:** The transaction isolation level for queries run by this sink.
 Defaults to TRANSACTION_SERIALIZABLE. See java.sql.Connection#setTransactionIsolation for more details.
 The Phoenix jdbc driver will throw an exception if the Phoenix database does not have transactions enabled
 and this setting is set to true. For drivers like that, this should be set to TRANSACTION_NONE.

--- a/database-plugins/docs/Database-batchsource.md
+++ b/database-plugins/docs/Database-batchsource.md
@@ -16,58 +16,58 @@ a TimePartitionedFileSet.
 
 Properties
 ----------
-**referenceName:** This will be used to uniquely identify this source for lineage, annotating metadata, etc.
+**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**importQuery:** The SELECT query to use to import data from the specified table.
+**Plugin Name:** Name of the JDBC plugin to use. This is the value of the 'name' key
+defined in the JSON file for the JDBC plugin.
+
+**Plugin Type:** Type of the JDBC plugin to use. This is the value of the 'type' key
+defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
+
+**Connection String:** JDBC connection string including database name. (Macro-enabled)
+
+**Import Query:** The SELECT query to use to import data from the specified table.
 You can specify an arbitrary number of columns to import, or import all columns using \*. The Query should
 contain the '$CONDITIONS' string. For example, 'SELECT * FROM table WHERE $CONDITIONS'.
 The '$CONDITIONS' string will be replaced by 'splitBy' field limits specified by the bounding query.
 The '$CONDITIONS' string is not required if numSplits is set to one. (Macro-enabled)
 
-**boundingQuery:** Bounding Query should return the min and max of the values of the 'splitBy' field.
+**Bounding Query:** Bounding Query should return the min and max of the values of the 'splitBy' field.
 For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is set to one. (Macro-enabled)
 
-**splitBy:** Field Name which will be used to generate splits. Not required if numSplits is set to one. (Macro-enabled)
+**Split-By Field Name:** Field Name which will be used to generate splits. Not required if numSplits is set to one. (Macro-enabled)
 
-**numSplits:** Number of splits to generate. (Macro-enabled)
+**Number of Splits to Generate:** Number of splits to generate. (Macro-enabled)
 
-**columnCase:** Sets the case of the column names returned from the query.
-Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
-the names returned from the database are used as-is. Note that setting this property provides predictability
-of column name cases across different databases but might result in column name conflicts if multiple column
-names are the same when the case is ignored (optional).
+**Username:** User identity for connecting to the specified database. Required for databases that need
+authentication. Optional for databases that do not require authentication. (Macro-enabled)
 
-**connectionString:** JDBC connection string including database name. (Macro-enabled)
+**Password:** Password to use to connect to the specified database. Required for databases
+that need authentication. Optional for databases that do not require authentication. (Macro-enabled)
 
-**connectionArguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
+**Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies
 the key and value for the argument. For example, 'key1=value1;key2=value' specifies that the connection will be
 given arguments 'key1' mapped to 'value1' and the argument 'key2' mapped to 'value2'. (Macro-enabled)
 
-**user:** User identity for connecting to the specified database. Required for databases that need
-authentication. Optional for databases that do not require authentication. (Macro-enabled)
-
-**password:** Password to use to connect to the specified database. Required for databases
-that need authentication. Optional for databases that do not require authentication. (Macro-enabled)
-
-**jdbcPluginName:** Name of the JDBC plugin to use. This is the value of the 'name' key
-defined in the JSON file for the JDBC plugin.
-
-**jdbcPluginType:** Type of the JDBC plugin to use. This is the value of the 'type' key
-defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
-
-**enableAutoCommit:** Whether to enable auto-commit for queries run by this source. Defaults to 'false'.
+**Enable Auto-Commit:** Whether to enable auto-commit for queries run by this source. Defaults to 'false'.
 Normally this setting does not matter. It only matters if you are using a jdbc driver -- like the Hive
 driver -- that will error when the commit operation is run, or a driver that will error when auto-commit is
 set to false. For drivers like those, you will need to set this to 'true'.
 
-**transactionIsolationLevel:** The transaction isolation level for queries run by this sink.
+**Column Name Case:** Sets the case of the column names returned from the query.
+Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
+the names returned from the database are used as-is. Note that setting this property provides predictability
+of column name cases across different databases but might result in column name conflicts if multiple column
+names are the same when the case is ignored (optional).
+
+**Transaction Isolation Level:** The transaction isolation level for queries run by this sink.
 Defaults to TRANSACTION_SERIALIZABLE. See java.sql.Connection#setTransactionIsolation for more details.
 The Phoenix jdbc driver will throw an exception if the Phoenix database does not have transactions enabled
 and this setting is set to true. For drivers like that, this should be set to TRANSACTION_NONE.
 
-**schema:** The schema of records output by the source. This will be used in place of whatever schema comes
+**Schema:** The schema of records output by the source. This will be used in place of whatever schema comes
 back from the query. However, it must match the schema that comes back from the query,
 except it can mark fields as nullable and can contain a subset of the fields.
 

--- a/database-plugins/docs/DatabaseQuery-postaction.md
+++ b/database-plugins/docs/DatabaseQuery-postaction.md
@@ -17,28 +17,34 @@ that was read from the table.
 
 Properties
 ----------
-**runCondition:** When to run the action. Must be 'completion', 'success', or 'failure'. Defaults to 'success'.
+**Run Condition:** When to run the action. Must be 'completion', 'success', or 'failure'. Defaults to 'success'.
 If set to 'completion', the action will be executed regardless of whether the pipeline run succeeded or failed.
 If set to 'success', the action will only be executed if the pipeline run succeeded.
 If set to 'failure', the action will only be executed if the pipeline run failed.
 
-**query:** The query to run.
-
-**connectionString:** JDBC connection string including database name.
-
-**user:** User identity for connecting to the specified database. Required for databases that need
-authentication. Optional for databases that do not require authentication.
-
-**password:** Password to use to connect to the specified database. Required for databases
-that need authentication. Optional for databases that do not require authentication.
-
-**jdbcPluginName:** Name of the JDBC plugin to use. This is the value of the 'name' key
+**Plugin Name:** Name of the JDBC plugin to use. This is the value of the 'name' key
 defined in the JSON file for the JDBC plugin.
 
-**jdbcPluginType:** Type of the JDBC plugin to use. This is the value of the 'type' key
+**Plugin Type:** Type of the JDBC plugin to use. This is the value of the 'type' key
 defined in the JSON file for the JDBC plugin. Defaults to 'jdbc'.
 
-**enableAutoCommit:** Whether to enable auto-commit for queries run by this source. Defaults to 'false'.
+**Query:** The query to run.
+
+**Connection String:** JDBC connection string including database name.
+
+**Username:** User identity for connecting to the specified database. Required for databases that need
+authentication. Optional for databases that do not require authentication.
+
+**Password:** Password to use to connect to the specified database. Required for databases
+that need authentication. Optional for databases that do not require authentication.
+
+**Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
+will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
+This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies
+the key and value for the argument. For example, 'key1=value1;key2=value' specifies that the connection will be
+given arguments 'key1' mapped to 'value1' and the argument 'key2' mapped to 'value2'. (Macro-enabled)
+
+**Enable Auto-Commit:** Whether to enable auto-commit for queries run by this source. Defaults to 'false'.
 Normally this setting does not matter. It only matters if you are using a jdbc driver -- like the Hive
 driver -- that will error when the commit operation is run, or a driver that will error when auto-commit is
 set to false. For drivers like those, you will need to set this to 'true'.

--- a/database-plugins/widgets/Database-action.json
+++ b/database-plugins/widgets/Database-action.json
@@ -5,7 +5,35 @@
   "display-name": "Database",
   "configuration-groups": [
     {
-      "label": "General",
+      "label": "Basic",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Plugin Name",
+          "name": "jdbcPluginName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Plugin Type",
+          "name": "jdbcPluginType",
+          "widget-attributes": {
+            "default": "jdbc"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Connection String",
+          "name": "connectionString"
+        },
+        {
+          "widget-type": "textarea",
+          "label": "Database Command",
+          "name": "query"
+        }
+      ]
+    },
+    {
+      "label": "Credentials",
       "properties": [
         {
           "widget-type": "textbox",
@@ -16,32 +44,12 @@
           "widget-type": "password",
           "label": "Password",
           "name": "password"
-        },
-        {
-          "widget-type": "textarea",
-          "label": "Database command",
-          "name": "query"
         }
       ]
     },
     {
-      "label": "JDBC Information",
+      "label": "Advanced",
       "properties": [
-        {
-          "widget-type": "textbox",
-          "label": "Plugin Name",
-          "name": "jdbcPluginName"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Plugin Type",
-          "name": "jdbcPluginType"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Connection String",
-          "name": "connectionString"
-        },
         {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
@@ -55,15 +63,22 @@
           }
         },
         {
-          "widget-type": "select",
+          "widget-type": "radio-group",
           "label": "Enable Auto-Commit",
           "name": "enableAutoCommit",
           "widget-attributes": {
-            "values": [
-              "true",
-              "false"
-            ],
-            "default": "false"
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
           }
         }
       ]

--- a/database-plugins/widgets/Database-batchsink.json
+++ b/database-plugins/widgets/Database-batchsink.json
@@ -5,13 +5,49 @@
   "display-name": "Database",
   "configuration-groups": [
     {
-      "label": "General",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "textbox",
           "label": "Reference Name",
           "name": "referenceName"
         },
+        {
+          "widget-type": "textbox",
+          "label": "Plugin Name",
+          "name": "jdbcPluginName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Plugin Type",
+          "name": "jdbcPluginType",
+          "widget-attributes": {
+            "default": "jdbc"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Connection String",
+          "name": "connectionString"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Table Name",
+          "name": "tableName"
+        },
+        {
+          "widget-type": "csv",
+          "label": "Columns",
+          "name": "columns",
+          "widget-attributes": {
+            "delimiter": ","
+          }
+        }
+      ]
+    },
+    {
+      "label": "Credentials",
+      "properties": [
         {
           "widget-type": "textbox",
           "label": "Username",
@@ -21,32 +57,12 @@
           "widget-type": "password",
           "label": "Password",
           "name": "password"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Table Name",
-          "name": "tableName"
         }
       ]
     },
     {
-      "label": "JDBC Information",
+      "label": "Advanced",
       "properties": [
-        {
-          "widget-type": "textbox",
-          "label": "Plugin Name",
-          "name": "jdbcPluginName"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Plugin Type",
-          "name": "jdbcPluginType"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Connection String",
-          "name": "connectionString"
-        },
         {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
@@ -60,15 +76,35 @@
           }
         },
         {
-          "widget-type": "select",
+          "widget-type": "radio-group",
           "label": "Enable Auto-Commit",
           "name": "enableAutoCommit",
           "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Column Name Case",
+          "name": "columnNameCase",
+          "widget-attributes": {
             "values": [
-              "true",
-              "false"
+              "UPPER",
+              "lower",
+              "No change"
             ],
-            "default": "false"
+            "default": "No change"
           }
         },
         {
@@ -84,32 +120,6 @@
               "TRANSACTION_SERIALIZABLE"
             ],
             "default": "TRANSACTION_SERIALIZABLE"
-          }
-        }
-      ]
-    },
-    {
-      "label": "Table Properties",
-      "properties": [
-        {
-          "widget-type": "select",
-          "label": "Column Name Case",
-          "name": "columnNameCase",
-          "widget-attributes": {
-            "values": [
-              "UPPER",
-              "lower",
-              "No change"
-            ],
-            "default": "No change"
-          }
-        },
-        {
-          "widget-type": "csv",
-          "label": "Columns",
-          "name": "columns",
-          "widget-attributes": {
-            "delimiter": ","
           }
         }
       ]

--- a/database-plugins/widgets/Database-batchsource.json
+++ b/database-plugins/widgets/Database-batchsource.json
@@ -5,7 +5,7 @@
   "display-name": "Database",
   "configuration-groups": [
     {
-      "label": "General",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "textbox",
@@ -14,78 +14,22 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Username",
-          "name": "user"
-        },
-        {
-          "widget-type": "password",
-          "label": "Password",
-          "name": "password"
-        }
-      ]
-    },
-    {
-      "label": "JDBC Information",
-      "properties": [
-        {
-          "widget-type": "textbox",
           "label": "Plugin Name",
           "name": "jdbcPluginName"
         },
         {
           "widget-type": "textbox",
           "label": "Plugin Type",
-          "name": "jdbcPluginType"
+          "name": "jdbcPluginType",
+          "widget-attributes": {
+            "default": "jdbc"
+          }
         },
         {
           "widget-type": "textbox",
           "label": "Connection String",
           "name": "connectionString"
         },
-        {
-          "widget-type": "keyvalue",
-          "label": "Connection Arguments",
-          "name": "connectionArguments",
-          "widget-attributes": {
-            "showDelimiter": "false",
-            "key-placeholder": "Key",
-            "value-placeholder": "Value",
-            "kv-delimiter" : "=",
-            "delimiter" : ";"
-          }
-        },
-        {
-          "widget-type": "select",
-          "label": "Enable Auto-Commit",
-          "name": "enableAutoCommit",
-          "widget-attributes": {
-            "values": [
-              "true",
-              "false"
-            ],
-            "default": "false"
-          }
-        },
-        {
-          "widget-type": "select",
-          "label": "Transaction Isolation Level",
-          "name": "transactionIsolationLevel",
-          "widget-attributes": {
-            "values": [
-              "TRANSACTION_NONE",
-              "TRANSACTION_READ_UNCOMMITTED",
-              "TRANSACTION_READ_COMMITTED",
-              "TRANSACTION_REPEATABLE_READ",
-              "TRANSACTION_SERIALIZABLE"
-            ],
-            "default": "TRANSACTION_SERIALIZABLE"
-          }
-        }
-      ]
-    },
-    {
-      "label": "Database Properties",
-      "properties": [
         {
           "widget-type": "textarea",
           "label": "Import Query",
@@ -117,6 +61,57 @@
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
           "name": "numSplits"
+        }
+      ]
+    },
+    {
+      "label": "Credentials",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Username",
+          "name": "user"
+        },
+        {
+          "widget-type": "password",
+          "label": "Password",
+          "name": "password"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "keyvalue",
+          "label": "Connection Arguments",
+          "name": "connectionArguments",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "key-placeholder": "Key",
+            "value-placeholder": "Value",
+            "kv-delimiter" : "=",
+            "delimiter" : ";"
+          }
+        },
+        {
+          "widget-type": "radio-group",
+          "label": "Enable Auto-Commit",
+          "name": "enableAutoCommit",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
+          }
         },
         {
           "widget-type": "select",
@@ -129,6 +124,21 @@
               "No change"
             ],
             "default": "No change"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_NONE",
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
           }
         }
       ]

--- a/database-plugins/widgets/DatabaseQuery-postaction.json
+++ b/database-plugins/widgets/DatabaseQuery-postaction.json
@@ -4,7 +4,7 @@
   },
   "configuration-groups": [
     {
-      "label": "General",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "select",
@@ -21,13 +21,21 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Username",
-          "name": "user"
+          "label": "Plugin Name",
+          "name": "jdbcPluginName"
         },
         {
-          "widget-type": "password",
-          "label": "Password",
-          "name": "password"
+          "widget-type": "textbox",
+          "label": "Plugin Type",
+          "name": "jdbcPluginType",
+          "widget-attributes": {
+            "default": "jdbc"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Connection String",
+          "name": "connectionString"
         },
         {
           "widget-type": "textarea",
@@ -40,33 +48,52 @@
       ]
     },
     {
-      "label": "JDBC Information",
+      "label": "Credentials",
       "properties": [
         {
           "widget-type": "textbox",
-          "label": "Plugin Name",
-          "name": "jdbcPluginName"
+          "label": "Username",
+          "name": "user"
         },
         {
-          "widget-type": "textbox",
-          "label": "Plugin Type",
-          "name": "jdbcPluginType"
+          "widget-type": "password",
+          "label": "Password",
+          "name": "password"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "keyvalue",
+          "label": "Connection Arguments",
+          "name": "connectionArguments",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "key-placeholder": "Key",
+            "value-placeholder": "Value",
+            "kv-delimiter" : "=",
+            "delimiter" : ";"
+          }
         },
         {
-          "widget-type": "textbox",
-          "label": "Connection String",
-          "name": "connectionString"
-        },
-        {
-          "widget-type": "select",
+          "widget-type": "radio-group",
           "label": "Enable Auto-Commit",
           "name": "enableAutoCommit",
           "widget-attributes": {
-            "values": [
-              "true",
-              "false"
-            ],
-            "default": "false"
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "True"
+              },
+              {
+                "id": "false",
+                "label": "False"
+              }
+            ]
           }
         }
       ]


### PR DESCRIPTION
Clean up widgets and docs of db plugins: 
1. Capitalize first character in labels and make reference docs to use label name 
2. Change all widgets to have `Basic`, `Credentials`, `Advanced` sections
3. Change widget type for true/false selection
4. Reorder variables in reference docs to be same as widget file