### PR TITLE
Fix compilation on develop branch.

### DIFF
--- a/format-common/pom.xml
+++ b/format-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
All of the other modules on develop are 2.2.0-SNAPSHOT.
The `format-common` module was still 2.1.0-SNAPSHOT, because it was introduced on the release/2.1 branch (after develop was already bumped).

Without this change:
```
[INFO] Scanning for projects...
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project co.cask.hydrator:format-common:2.1.0-SNAPSHOT (/data/git/artifacts/hydrator-plugins/format-common/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact co.cask.hydrator:hydrator-plugins:pom:2.1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 21, column 11 ->
 [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```