### PR TITLE
CDAP-14560 remove lzo as a compression option

### DIFF
--- a/core-plugins/docs/SnapshotParquet-batchsink.md
+++ b/core-plugins/docs/SnapshotParquet-batchsink.md
@@ -36,7 +36,7 @@ The format is expected to be a number followed by an 's', 'm', 'h', or 'd' speci
 and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015. (Macro-enabled)
 
 **compressionCodec:** Optional parameter to determine the compression codec to use on the resulting data. 
-Valid values are None, Snappy, GZip, and LZO.
+Valid values are None, Snappy, GZip.
 
 
 Example

--- a/core-plugins/docs/TPFSParquet-batchsink.md
+++ b/core-plugins/docs/TPFSParquet-batchsink.md
@@ -44,7 +44,7 @@ The format is expected to be a number followed by an 's', 'm', 'h', or 'd' speci
 and this property is set to 7d, the sink will delete any partitions for time partitions older than midnight Dec 25, 2015. (Macro-enabled)
 
 **compressionCodec:** Optional parameter to determine the compression codec to use on the resulting data. 
-Valid values are None, Snappy, GZip, and LZO.
+Valid values are None, Snappy, GZip.
 
 Example
 -------

--- a/core-plugins/widgets/SnapshotParquet-batchsink.json
+++ b/core-plugins/widgets/SnapshotParquet-batchsink.json
@@ -36,8 +36,7 @@
             "values": [
               "None",
               "Snappy",
-              "GZip",
-              "LZO"
+              "GZip"
             ],
             "default": "None"
           }

--- a/core-plugins/widgets/TPFSParquet-batchsink.json
+++ b/core-plugins/widgets/TPFSParquet-batchsink.json
@@ -46,8 +46,7 @@
             "values": [
               "None",
               "Snappy",
-              "GZip",
-              "LZO"
+              "GZip"
             ],
             "default": "None"
           }


### PR DESCRIPTION
LZO is not packaged in the plugins due to licensing issues and
should not be listed as a compression option, as it is guaranteed
to break.