### PR TITLE
Depend on cdap 5.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
     <commons-lang-version>2.6</commons-lang-version>
-    <cdap.version>5.1.0</cdap.version>
+    <cdap.version>5.1.1</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
     <es.version>1.6.0</es.version>


### PR DESCRIPTION
Depend on cdap 5.1.1. This is needed to run the ITN where cdap is bumped to 5.1.1 and we want hydrator to use 5.1.1 which has the [latest fix](https://github.com/caskdata/cdap/pull/10832) rather than fetching 5.1.0 from maven central.

Drop snapshot of hydrator will come in another PR later.