### PR TITLE
Remove reference to StreamFormatter.

### DIFF
--- a/transform-plugins/README.rst
+++ b/transform-plugins/README.rst
@@ -10,7 +10,6 @@ This project is a collection of useful transformations of data. These plugins ar
 - CSV Formatter
 - JSON Parser
 - Clone Record
-- Stream Formatter
 - Compressor
 - Decompressor
 - Encoder
@@ -123,24 +122,6 @@ Clone Record
   Makes a copy of every input record received for a configured number of times on the output. This transform does not change any record fields or types. It's an identity transform.
 :Configuration:
   **copies:** Specifies the numbers of copies of the input record that are to be emitted
-
-Stream Formatter
-----------------
-:ID:
-  **StreamFormatter**
-:Type:
-  Transform
-:Mode:
-  Batch and
-  Realtime
-:Description:
-  Formats a Structured Record as Stream format. Plugin will convert the Structured Record to Stream format.
-  It will include a header and body configurations. The body of the Stream event can be either type CSV or JSON.
-:Configuration:
-  - **body:** Specifies the input Structured Record fields that should be included in the body of the Stream event
-  - **header:** Specifies the input Structured Record fields that should be included in the header of the Stream event
-  - **format:** Specifies the format of the body. Currently supported formats are JSON, CSV, TSV, and PSV
-  - **schema:** Specifies the output schema; the output schema can have only two fields: one of type ``STRING`` and the other of type ``MAP<STRING, STRING>``
 
 Compressor
 ----------


### PR DESCRIPTION
StreamFormatter was removed in https://github.com/cdapio/hydrator-plugins/pull/839.