### PR TITLE
Correctly mark schema as a required field for avro output format

### DIFF
--- a/format-avro/src/main/java/co/cask/format/avro/output/AvroOutputFormatProvider.java
+++ b/format-avro/src/main/java/co/cask/format/avro/output/AvroOutputFormatProvider.java
@@ -95,7 +95,7 @@ public class AvroOutputFormatProvider implements OutputFormatProvider {
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    properties.put("schema", new PluginPropertyField("schema", Conf.SCHEMA_DESC, "string", false, true));
+    properties.put("schema", new PluginPropertyField("schema", Conf.SCHEMA_DESC, "string", true, true));
     properties.put("compressionCodec",
                    new PluginPropertyField("compressionCodec", Conf.CODEC_DESC, "string", false, true));
     return new PluginClass("outputformat", NAME, DESC, AvroOutputFormatProvider.class.getName(),


### PR DESCRIPTION
This prevents a duplicate key exception when CDAP inspects the
artifact, by ensuring that the values are exactly the same.