### PR TITLE
remove xerces as a dependency so it isn't bundled with the jars

### DIFF
--- a/format-common/pom.xml
+++ b/format-common/pom.xml
@@ -55,11 +55,5 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <!-- Workaround for CDAP-14562, otherwise formats can't be used with s3 filesystems -->
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>2.9.1</version>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This somehow didn't get merged from the release/2.1 branch.
Removing xerces since the XML parser should be picked up from the
environment and not bundled in the jar. This prevents the system
from trying to use an XML parser that it shouldn't be using.