### PR TITLE
remove usage of StreamEvent

### DIFF
--- a/spark-plugins/docs/File-streamingsource.md
+++ b/spark-plugins/docs/File-streamingsource.md
@@ -20,7 +20,7 @@ Properties
 **path:** The path of the directory to monitor. Files must be written to the monitored directory by
 "moving" them from another location within the same file system. File names starting with . are ignored. (Macro-enabled)
 
-**format:** Format of files in the directory. Supported formats are 'text', 'csv', 'tsv', 'clf', 'grok', and 'syslog'.
+**format:** Format of files in the directory. Supported formats are 'csv', 'json', 'text', and 'tsv'.
 The default format is 'text'. (Macro-enabled)
 
 **schema:** Schema of files in the directory.

--- a/spark-plugins/widgets/File-streamingsource.json
+++ b/spark-plugins/widgets/File-streamingsource.json
@@ -41,10 +41,8 @@
           "name": "format",
           "widget-attributes": {
             "values": [
-              "clf",
               "csv",
-              "grok",
-              "syslog",
+              "json",
               "text",
               "tsv"
             ],


### PR DESCRIPTION
StreamEvent was a flowlet class and was being abused in the
FileStreamingSource. Removed usage of the stream based formats
and switched to more standard formats.

This is a backwards incompatible change, as clf, grok, and syslog
are no longer supported, but those formats weren't seeing much
use anyway.

Longer term, sources like this should find a way to hook into
the format plugins that were done for the batch file sources.