### PR TITLE
Fix RunningStats#stddev

### DIFF
--- a/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/function/RunningStats.java
+++ b/core-plugins/src/main/java/co/cask/hydrator/plugin/batch/aggregator/function/RunningStats.java
@@ -22,25 +22,26 @@ package co.cask.hydrator.plugin.batch.aggregator.function;
  * http://www.johndcook.com/blog/skewness_kurtosis/
  */
 public final class RunningStats  {
-  private long entries = 0L;
+  private long numEntries = 0L;
   private double mean1, mean2, mean3, mean4 = 0d;
 
   /**
-   * Pushes a number into machinary that computes a lot of statistics.
+   * Pushes a number into machinery that computes a lot of statistics.
    * @param x number to be added to computing statistics.
    */
   public void push(double x) {
     double delta, deltaN, deltaN2, term1;
 
-    long n1 = entries;
-    entries++;
+    long n1 = numEntries;
+    numEntries++;
     delta = x - mean1;
-    deltaN = delta / entries;
+    deltaN = delta / numEntries;
     deltaN2 = deltaN * deltaN;
     term1 = delta * deltaN * n1;
     mean1 += deltaN;
-    mean4 += term1 * deltaN2 * (entries * entries - 3 * entries + 3) + 6 * deltaN2 * mean2 - 4 * deltaN * mean3;
-    mean3 += term1 * deltaN * (entries - 2) - 3 * deltaN * mean2;
+    mean4 +=
+      term1 * deltaN2 * (numEntries * numEntries - 3 * numEntries + 3) + 6 * deltaN2 * mean2 - 4 * deltaN * mean3;
+    mean3 += term1 * deltaN * (numEntries - 2) - 3 * deltaN * mean2;
     mean2 += term1;
   }
 
@@ -55,7 +56,10 @@ public final class RunningStats  {
    * @return Variance of all numbers.
    */
   public double variance() {
-    return mean2 / (entries - 1.0d);
+    if (numEntries == 0) {
+      return 0;
+    }
+    return mean2 / numEntries;
   }
 
   /**
@@ -69,13 +73,13 @@ public final class RunningStats  {
    * @return Skewness of all numbers.
    */
   public double skewness() {
-    return Math.sqrt((double) entries) * mean3 / Math.pow(mean2, 1.5d);
+    return Math.sqrt((double) numEntries) * mean3 / Math.pow(mean2, 1.5d);
   }
 
   /**
    * @return Kurtosis of all numbers.
    */
   public double kurtosis() {
-    return (double) entries * mean4 / (mean2 * mean2) - 3.0;
+    return (double) numEntries * mean4 / (mean2 * mean2) - 3.0;
   }
 }

--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/function/RunningStatsTest.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/aggregator/function/RunningStatsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.plugin.batch.aggregator.function;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RunningStatsTest {
+
+  @Test
+  public void testMean() {
+    RunningStats runningStats = new RunningStats();
+    runningStats.push(0.0d);
+    runningStats.push(40.0d);
+    runningStats.push(100.0d);
+    runningStats.push(100.0d);
+    Assert.assertEquals(60.0d, runningStats.mean(), 0.001);
+  }
+
+  @Test
+  public void testMeanWithOneEntry() {
+    RunningStats runningStats = new RunningStats();
+    runningStats.push(5.2d);
+    Assert.assertEquals(5.2d, runningStats.mean(), 0.001);
+  }
+
+  @Test
+  public void testMeanWithNoEntry() {
+    RunningStats runningStats = new RunningStats();
+    Assert.assertEquals(0.0d, runningStats.mean(), 0.001);
+  }
+
+  @Test
+  public void testVariance() {
+    RunningStats runningStats = new RunningStats();
+    runningStats.push(5);
+    runningStats.push(6);
+    runningStats.push(10);
+    runningStats.push(14);
+    runningStats.push(15);
+
+    Assert.assertEquals(4.04969, runningStats.stddev(), 0.001);
+  }
+
+  @Test
+  public void testVarianceWithOneEntry() {
+    RunningStats runningStats = new RunningStats();
+    runningStats.push(5);
+    Assert.assertEquals(0.0d, runningStats.stddev(), 0.001);
+  }
+
+  @Test
+  public void testVarianceWithNoEntry() {
+    RunningStats runningStats = new RunningStats();
+    Assert.assertEquals(0.0d, runningStats.stddev(), 0.001);
+  }
+}


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14857

If there is only one entry, then the current implementation doesn't handle that well (divide by 0 error).
The standard deviation of a single element is defined as 0, so making the implementation reflect that.

Also adding unit tests for the RunningStats class, which fails without the fix to the class.