### PR TITLE
Fix compilation, as per changes to MetadataAdmin

### DIFF
--- a/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/FileSinkTestRun.java
+++ b/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/FileSinkTestRun.java
@@ -52,6 +52,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -214,7 +215,7 @@ public class FileSinkTestRun extends ETLBatchTestBase {
     }
   }
 
-  private void validateDatasetSchema(FileFormat format) {
+  private void validateDatasetSchema(FileFormat format) throws IOException {
     // if a schema was provided for the sink verify that the external dataset has the given schema
     Map<String, String> metadataProperties =
       metadataAdmin.getProperties(MetadataScope.SYSTEM,


### PR DESCRIPTION
Fix compilation, as per changes in https://github.com/cdapio/cdap/pull/11090/files#diff-8591a9d33b9df8e8de7f8639786ea008R89

Otherwise, the following compilation will be encountered:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:testCompile (default-testCompile) on project core-plugins: Compilation failure
[ERROR] /data/git/artifacts/hydrator-plugins/core-plugins/src/test/java/co/cask/hydrator/plugin/batch/sink/FileSinkTestRun.java:[220,34] unreported exception java.io.IOException; must be caught or declared to be thrown
```