### PR TITLE
[CDAP-15262] Fixes Database batch source to copy importQuery to query while fetching schema 

### DIFF
--- a/database-plugins/widgets/Database-batchsource.json
+++ b/database-plugins/widgets/Database-batchsource.json
@@ -55,6 +55,7 @@
             "add-properties": [
               {
                 "name": "query",
+                "plugin-property-for-value": "importQuery",
                 "widget-type": "textarea",
                 "label": "Query",
                 "widget-attributes": {


### PR DESCRIPTION
Adds 'plugin-property-for-value' field to add-properties under plugin-function for database plugin to copy importQuery to get schema query

JIRA: https://issues.cask.co/browse/CDAP-15262