### PR TITLE
CDAP-14823 improve error handling for null fields

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
@@ -25,9 +25,25 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 public class AvroToStructuredTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullValueForNonNullableField() throws IOException {
+    AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();
+
+    org.apache.avro.Schema avroSchema = convertSchema(
+      Schema.recordOf("nullable", Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.INT)))));
+    GenericRecord avroRecord = new GenericRecordBuilder(avroSchema)
+      .set("x", null)
+      .build();
+
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    avroToStructuredTransformer.transform(avroRecord, schema);
+  }
+
   @Test
   public void testAvroToStructuredConversionForNested() throws Exception {
     AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
@@ -43,7 +43,7 @@ public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, 
     StructuredRecord.Builder builder = StructuredRecord.builder(structuredSchema);
     for (Schema.Field field : structuredSchema.getFields()) {
       String fieldName = field.getName();
-      builder.set(fieldName, convertField(genericRecord.get(fieldName), field.getSchema()));
+      builder.set(fieldName, convertField(genericRecord.get(fieldName), field));
     }
     return builder.build();
   }
@@ -54,7 +54,7 @@ public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, 
     for (Schema.Field field : structuredSchema.getFields()) {
       String fieldName = field.getName();
       if (!fieldName.equals(skipField)) {
-        builder.set(fieldName, convertField(genericRecord.get(fieldName), field.getSchema()));
+        builder.set(fieldName, convertField(genericRecord.get(fieldName), field));
       }
     }
 

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/StructuredToAvroTransformer.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/StructuredToAvroTransformer.java
@@ -61,7 +61,7 @@ public class StructuredToAvroTransformer extends RecordConverter<StructuredRecor
       if (schemaField == null) {
         throw new IllegalArgumentException("Input record does not contain the " + fieldName + " field.");
       }
-      recordBuilder.set(fieldName, convertField(structuredRecord.get(fieldName), schemaField.getSchema()));
+      recordBuilder.set(fieldName, convertField(structuredRecord.get(fieldName), schemaField));
     }
     return recordBuilder.build();
   }


### PR DESCRIPTION
Improve the error message when a non-nullable field is given a
null value. Instead of a NullPointerException, explicitly mention
the field name and that a null value was found for a non-nullable
type.