### PR TITLE
CDAP-14845 remove file source get schema button

### DIFF
--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -38,12 +38,6 @@
               "tsv"
             ],
             "default": "text"
-          },
-          "plugin-function": {
-            "method": "POST",
-            "widget": "outputSchema",
-            "output-property": "schema",
-            "plugin-method": "getSchema"
           }
         },
         {


### PR DESCRIPTION
The button is only useful for getting the fixed schemas for
certain formats, like blob or text. Users were mistaking it for
something that actually reads the files and auto determines the
schema from the file and format, so removing the button for now.