### PR TITLE
Move HTTPPollerSource dependency under io.cdap.plugin.spark

### DIFF
--- a/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPConfig.java
+++ b/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPConfig.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.common.http;
+package io.cdap.plugin.spark;
 
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;

--- a/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPPollConfig.java
+++ b/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPPollConfig.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.common.http;
+package io.cdap.plugin.spark;
 
 import com.google.common.base.Charsets;
 import io.cdap.cdap.api.annotation.Description;

--- a/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPPollerSource.java
+++ b/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPPollerSource.java
@@ -22,8 +22,6 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
-import io.cdap.plugin.common.http.HTTPPollConfig;
-import io.cdap.plugin.common.http.HTTPRequestor;
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.receiver.Receiver;

--- a/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPRequestor.java
+++ b/spark-plugins/src/main/java/io/cdap/plugin/spark/HTTPRequestor.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.common.http;
+package io.cdap.plugin.spark;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-15412

These classes are not used by any other plugin and does not serve any purpose for being in commons.