### PR TITLE
CDAP-15767 add support for reading int96 fields

### DIFF
--- a/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
+++ b/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
@@ -52,7 +52,7 @@ public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<
   protected void addFormatProperties(Map<String, String> properties) {
     Schema schema = conf.getSchema();
     if (schema != null) {
-      properties.put("parquet.avro.schema", schema.toString());
+      properties.put("parquet.avro.read.schema", schema.toString());
     }
   }
 }

--- a/format-parquet/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
+++ b/format-parquet/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
@@ -1,0 +1,584 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.avro;
+
+import java.lang.reflect.Constructor;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.specific.SpecificData;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+/**
+ * This {@link Converter} class materializes records as Avro
+ * {@link IndexedRecord} instances. This is replaced by
+ * {@link AvroRecordConverter}, but is included for backward-compatibility.
+ *
+ * This is a copy of Parquet's class, except with special logic for int96.
+ *
+ * @param <T> a subclass of Avro's IndexedRecord
+ */
+class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter {
+  // These constants are added
+  // see http://stackoverflow.com/questions/466321/convert-unix-timestamp-to-julian
+  // it's 2440587.5, rounding up to compatible with Hive
+  private static final int JULIAN_DAY_OF_EPOCH = 2440588;
+  private static final long SECONDS_PER_DAY = 24 * 60 * 60;
+  // end of added constants
+
+  private final ParentValueContainer parent;
+  protected T currentRecord;
+  private final Converter[] converters;
+
+  private final Schema avroSchema;
+  private final Class<? extends IndexedRecord> specificClass;
+
+  private final GenericData model;
+  private final Map<Schema.Field, Object> recordDefaults = new HashMap<Schema.Field, Object>();
+
+  public AvroIndexedRecordConverter(MessageType parquetSchema, Schema avroSchema) {
+    this(parquetSchema, avroSchema, SpecificData.get());
+  }
+
+  public AvroIndexedRecordConverter(MessageType parquetSchema, Schema avroSchema,
+      GenericData baseModel) {
+    this(null, parquetSchema, avroSchema, baseModel);
+  }
+
+  public AvroIndexedRecordConverter(ParentValueContainer parent, GroupType
+      parquetSchema, Schema avroSchema) {
+    this(parent, parquetSchema, avroSchema, SpecificData.get());
+  }
+
+  public AvroIndexedRecordConverter(ParentValueContainer parent, GroupType
+      parquetSchema, Schema avroSchema, GenericData baseModel) {
+    this.parent = parent;
+    this.avroSchema = avroSchema;
+    int schemaSize = parquetSchema.getFieldCount();
+    this.converters = new Converter[schemaSize];
+    this.specificClass = getDatumClass(baseModel, avroSchema);
+
+    this.model = this.specificClass == null ? GenericData.get() : baseModel;
+
+    Map<String, Integer> avroFieldIndexes = new HashMap<String, Integer>();
+    int avroFieldIndex = 0;
+    for (Schema.Field field: avroSchema.getFields()) {
+        avroFieldIndexes.put(field.name(), avroFieldIndex++);
+    }
+    int parquetFieldIndex = 0;
+    for (Type parquetField: parquetSchema.getFields()) {
+      Schema.Field avroField = getAvroField(parquetField.getName());
+      Schema nonNullSchema = AvroSchemaConverter.getNonNull(avroField.schema());
+      final int finalAvroIndex = avroFieldIndexes.remove(avroField.name());
+      converters[parquetFieldIndex++] = newConverter(nonNullSchema, parquetField, model, new ParentValueContainer() {
+        @Override
+        public void add(Object value) {
+          AvroIndexedRecordConverter.this.set(finalAvroIndex, value);
+        }
+      });
+    }
+    // store defaults for any new Avro fields from avroSchema that are not in the writer schema (parquetSchema)
+    for (String fieldName : avroFieldIndexes.keySet()) {
+      Schema.Field field = avroSchema.getField(fieldName);
+      if (field.schema().getType() == Schema.Type.NULL) {
+        continue; // skip null since Parquet does not write nulls
+      }
+      if (field.defaultValue() == null || model.getDefaultValue(field) == null) {
+        continue; // field has no default
+      }
+      recordDefaults.put(field, model.getDefaultValue(field));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Class<T> getDatumClass(GenericData model, Schema schema) {
+    if (model instanceof SpecificData) {
+      return (Class<T>) ((SpecificData) model).getClass(schema);
+    }
+    return null;
+  }
+
+  private Schema.Field getAvroField(String parquetFieldName) {
+    Schema.Field avroField = avroSchema.getField(parquetFieldName);
+    for (Schema.Field f : avroSchema.getFields()) {
+      if (f.aliases().contains(parquetFieldName)) {
+        return f;
+      }
+    }
+    if (avroField == null) {
+      throw new InvalidRecordException(String.format("Parquet/Avro schema mismatch. Avro field '%s' not found.",
+          parquetFieldName));
+    }
+    return avroField;
+  }
+
+  private static Converter newConverter(Schema schema, Type type,
+      GenericData model, ParentValueContainer parent) {
+    // this is the modified section
+    if (type.asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+      if (schema.getType().equals(Schema.Type.BYTES)) {
+        return new AvroConverters.FieldByteBufferConverter(parent);
+      } else if (schema.getType().equals(Schema.Type.LONG)) {
+        return new PrimitiveConverter() {
+          @Override
+          public void addBinary(Binary value) {
+            // this logic is taken from Spark's ParquetRowConverter
+            ByteBuffer buf = value.toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
+            long timeOfDayNanos = buf.getLong();
+            int julianDay = buf.getInt();
+            long seconds = (julianDay - JULIAN_DAY_OF_EPOCH) * SECONDS_PER_DAY;
+            long rawTime = TimeUnit.SECONDS.toMicros(seconds) + TimeUnit.NANOSECONDS.toMicros(timeOfDayNanos);
+            parent.addLong(rawTime);
+          }
+        };
+      } else {
+        throw new IllegalArgumentException(
+          String.format("INT96 field '%s' cannot be read as a '%s'. It must be read as bytes or a long.",
+                        type.getName(), schema.getType()));
+      }
+    }
+    // end of modified section
+    if (schema.getType().equals(Schema.Type.BOOLEAN)) {
+      return new AvroConverters.FieldBooleanConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.INT)) {
+      return new AvroConverters.FieldIntegerConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.LONG)) {
+      return new AvroConverters.FieldLongConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.FLOAT)) {
+      return new AvroConverters.FieldFloatConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.DOUBLE)) {
+      return new AvroConverters.FieldDoubleConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.BYTES)) {
+      return new AvroConverters.FieldByteBufferConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.STRING)) {
+      return new AvroConverters.FieldStringConverter(parent);
+    } else if (schema.getType().equals(Schema.Type.RECORD)) {
+      return new AvroIndexedRecordConverter(parent, type.asGroupType(), schema, model);
+    } else if (schema.getType().equals(Schema.Type.ENUM)) {
+      return new FieldEnumConverter(parent, schema, model);
+    } else if (schema.getType().equals(Schema.Type.ARRAY)) {
+      return new AvroArrayConverter(parent, type.asGroupType(), schema, model);
+    } else if (schema.getType().equals(Schema.Type.MAP)) {
+      return new MapConverter(parent, type.asGroupType(), schema, model);
+    } else if (schema.getType().equals(Schema.Type.UNION)) {
+      return new AvroUnionConverter(parent, type, schema, model);
+    } else if (schema.getType().equals(Schema.Type.FIXED)) {
+      return new FieldFixedConverter(parent, schema, model);
+    }
+    throw new UnsupportedOperationException(String.format("Cannot convert Avro type: %s" +
+        " (Parquet type: %s) ", schema, type));
+  }
+
+  private void set(int index, Object value) {
+    this.currentRecord.put(index, value);
+  }
+
+  @Override
+  public Converter getConverter(int fieldIndex) {
+    return converters[fieldIndex];
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void start() {
+    // Should do the right thing whether it is generic or specific
+    this.currentRecord = (T) ((this.specificClass == null) ?
+            new GenericData.Record(avroSchema) :
+            SpecificData.newInstance(specificClass, avroSchema));
+  }
+
+  @Override
+  public void end() {
+    fillInDefaults();
+    if (parent != null) {
+      parent.add(currentRecord);
+    }
+  }
+
+  private void fillInDefaults() {
+    for (Map.Entry<Schema.Field, Object> entry : recordDefaults.entrySet()) {
+      Schema.Field f = entry.getKey();
+      // replace following with model.deepCopy once AVRO-1455 is being used
+      Object defaultValue = deepCopy(f.schema(), entry.getValue());
+      this.currentRecord.put(f.pos(), defaultValue);
+    }
+  }
+
+  private Object deepCopy(Schema schema, Object value) {
+    switch (schema.getType()) {
+      case BOOLEAN:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        return value;
+      default:
+        return model.deepCopy(schema, value);
+    }
+  }
+
+  T getCurrentRecord() {
+    return currentRecord;
+  }
+
+  static final class FieldEnumConverter extends PrimitiveConverter {
+
+    private final ParentValueContainer parent;
+    private final Class<? extends Enum> enumClass;
+
+    public FieldEnumConverter(ParentValueContainer parent, Schema enumSchema,
+        GenericData model) {
+      this.parent = parent;
+      this.enumClass = model instanceof SpecificData ?
+          ((SpecificData) model).getClass(enumSchema) :
+          SpecificData.get().getClass(enumSchema);
+    }
+
+    @Override
+    final public void addBinary(Binary value) {
+      Object enumValue = value.toStringUsingUTF8();
+      if (enumClass != null) {
+        enumValue = (Enum.valueOf(enumClass,(String)enumValue));
+      }
+      parent.add(enumValue);
+    }
+  }
+
+  static final class FieldFixedConverter extends PrimitiveConverter {
+
+    private final ParentValueContainer parent;
+    private final Schema avroSchema;
+    private final Class<? extends GenericData.Fixed> fixedClass;
+    private final Constructor fixedClassCtor;
+
+    public FieldFixedConverter(ParentValueContainer parent, Schema avroSchema,
+        GenericData model) {
+      this.parent = parent;
+      this.avroSchema = avroSchema;
+      this.fixedClass = model instanceof SpecificData ?
+          ((SpecificData) model).getClass(avroSchema) :
+          SpecificData.get().getClass(avroSchema);
+      if (fixedClass != null) {
+        try {
+          this.fixedClassCtor = 
+              fixedClass.getConstructor(new Class[] { byte[].class });
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        this.fixedClassCtor = null;
+      }
+    }
+
+    @Override
+    final public void addBinary(Binary value) {
+      if (fixedClass == null) {
+        parent.add(new GenericData.Fixed(avroSchema, value.getBytes()));
+      } else {
+        if (fixedClassCtor == null) {
+          throw new IllegalArgumentException(
+              "fixedClass specified but fixedClassCtor is null.");
+        }
+        try {
+          Object fixed = fixedClassCtor.newInstance(value.getBytes());
+          parent.add(fixed);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Converter for a list.
+   *
+   * <pre>
+   *   optional group the_list (LIST) { <-- this layer
+   *     repeated group array {
+   *       optional (type) element;
+   *     }
+   *   }
+   * </pre>
+   *
+   * This class also implements LIST element backward-compatibility rules.
+   */
+  static final class AvroArrayConverter extends GroupConverter {
+
+    private final ParentValueContainer parent;
+    private final Schema avroSchema;
+    private final Converter converter;
+    private GenericArray<Object> array;
+
+    public AvroArrayConverter(ParentValueContainer parent, GroupType type,
+        Schema avroSchema, GenericData model) {
+      this.parent = parent;
+      this.avroSchema = avroSchema;
+      Schema elementSchema = AvroSchemaConverter
+          .getNonNull(avroSchema.getElementType());
+      Type repeatedType = type.getType(0);
+      // always determine whether the repeated type is the element type by
+      // matching it against the element schema.
+      if (isElementType(repeatedType, elementSchema)) {
+        // the element type is the repeated type (and required)
+        converter = newConverter(elementSchema, repeatedType, model, new ParentValueContainer() {
+          @Override
+          @SuppressWarnings("unchecked")
+          public void add(Object value) {
+            array.add(value);
+          }
+        });
+      } else {
+        // the element is wrapped in a synthetic group and may be optional
+        converter = new ElementConverter(repeatedType.asGroupType(), elementSchema, model);
+      }
+    }
+
+    @Override
+    public Converter getConverter(int fieldIndex) {
+      return converter;
+    }
+
+    @Override
+    public void start() {
+      array = new GenericData.Array<Object>(0, avroSchema);
+    }
+
+    @Override
+    public void end() {
+      parent.add(array);
+    }
+
+    /**
+     * Returns whether the given type is the element type of a list or is a
+     * synthetic group with one field that is the element type. This is
+     * determined by checking whether the type can be a synthetic group and by
+     * checking whether a potential synthetic group matches the expected schema.
+     * <p>
+     * Unlike {@link AvroSchemaConverter#isElementType(Type, String)}, this
+     * method never guesses because the expected schema is known.
+     *
+     * @param repeatedType a type that may be the element type
+     * @param elementSchema the expected Schema for list elements
+     * @return {@code true} if the repeatedType is the element schema
+     */
+    static boolean isElementType(Type repeatedType, Schema elementSchema) {
+      if (repeatedType.isPrimitive() ||
+          repeatedType.asGroupType().getFieldCount() > 1) {
+        // The repeated type must be the element type because it is an invalid
+        // synthetic wrapper (must be a group with one field).
+        return true;
+      } else if (elementSchema != null &&
+          elementSchema.getType() == Schema.Type.RECORD &&
+          elementSchema.getFields().size() == 1 &&
+          elementSchema.getFields().get(0).name().equals(
+              repeatedType.asGroupType().getFieldName(0))) {
+        // The repeated type must be the element type because it matches the
+        // structure of the Avro element's schema.
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     * Converter for list elements.
+     *
+     * <pre>
+     *   optional group the_list (LIST) {
+     *     repeated group array { <-- this layer
+     *       optional (type) element;
+     *     }
+     *   }
+     * </pre>
+     */
+    final class ElementConverter extends GroupConverter {
+      private Object element;
+      private final Converter elementConverter;
+
+      public ElementConverter(GroupType repeatedType, Schema elementSchema, GenericData model) {
+        Type elementType = repeatedType.getType(0);
+        Schema nonNullElementSchema = AvroSchemaConverter.getNonNull(elementSchema);
+        this.elementConverter = newConverter(nonNullElementSchema, elementType, model, new ParentValueContainer() {
+          @Override
+          public void add(Object value) {
+            ElementConverter.this.element = value;
+          }
+        });
+      }
+
+      @Override
+      public Converter getConverter(int fieldIndex) {
+        Preconditions.checkArgument(
+            fieldIndex == 0, "Illegal field index: " + fieldIndex);
+        return elementConverter;
+      }
+
+      @Override
+      public void start() {
+        element = null;
+      }
+
+      @Override
+      public void end() {
+        array.add(element);
+      }
+    }
+  }
+
+  static final class AvroUnionConverter extends GroupConverter {
+
+    private final ParentValueContainer parent;
+    private final Converter[] memberConverters;
+    private Object memberValue = null;
+
+    public AvroUnionConverter(ParentValueContainer parent, Type parquetSchema,
+                              Schema avroSchema, GenericData model) {
+      this.parent = parent;
+      GroupType parquetGroup = parquetSchema.asGroupType();
+      this.memberConverters = new Converter[ parquetGroup.getFieldCount()];
+
+      int parquetIndex = 0;
+      for (int index = 0; index < avroSchema.getTypes().size(); index++) {
+        Schema memberSchema = avroSchema.getTypes().get(index);
+        if (!memberSchema.getType().equals(Schema.Type.NULL)) {
+          Type memberType = parquetGroup.getType(parquetIndex);
+          memberConverters[parquetIndex] = newConverter(memberSchema, memberType, model, new ParentValueContainer() {
+            @Override
+            public void add(Object value) {
+              Preconditions.checkArgument(memberValue==null, "Union is resolving to more than one type");
+              memberValue = value;
+            }
+          });
+          parquetIndex++; // Note for nulls the parquetIndex id not increased
+        }
+      }
+    }
+
+    @Override
+    public Converter getConverter(int fieldIndex) {
+      return memberConverters[fieldIndex];
+    }
+
+    @Override
+    public void start() {
+      memberValue = null;
+    }
+
+    @Override
+    public void end() {
+      parent.add(memberValue);
+    }
+  }
+
+  static final class MapConverter<V> extends GroupConverter {
+
+    private final ParentValueContainer parent;
+    private final Converter keyValueConverter;
+    private Map<String, V> map;
+
+    public MapConverter(ParentValueContainer parent, GroupType mapType,
+        Schema mapSchema, GenericData model) {
+      this.parent = parent;
+      GroupType repeatedKeyValueType = mapType.getType(0).asGroupType();
+      this.keyValueConverter = new MapKeyValueConverter(
+          repeatedKeyValueType, mapSchema, model);
+    }
+
+    @Override
+    public Converter getConverter(int fieldIndex) {
+      return keyValueConverter;
+    }
+
+    @Override
+    public void start() {
+      this.map = new HashMap<String, V>();
+    }
+
+    @Override
+    public void end() {
+      parent.add(map);
+    }
+
+    final class MapKeyValueConverter extends GroupConverter {
+
+      private String key;
+      private V value;
+      private final Converter keyConverter;
+      private final Converter valueConverter;
+
+      public MapKeyValueConverter(GroupType keyValueType, Schema mapSchema,
+          GenericData model) {
+        keyConverter = new PrimitiveConverter() {
+          @Override
+          final public void addBinary(Binary value) {
+            key = value.toStringUsingUTF8();
+          }
+        };
+
+        Type valueType = keyValueType.getType(1);
+        Schema nonNullValueSchema = AvroSchemaConverter.getNonNull(mapSchema.getValueType());
+        valueConverter = newConverter(nonNullValueSchema, valueType, model, new ParentValueContainer() {
+          @Override
+          @SuppressWarnings("unchecked")
+          public void add(Object value) {
+            MapKeyValueConverter.this.value = (V) value;
+          }
+        });
+      }
+
+      @Override
+      public Converter getConverter(int fieldIndex) {
+        if (fieldIndex == 0) {
+          return keyConverter;
+        } else if (fieldIndex == 1) {
+          return valueConverter;
+        }
+        throw new IllegalArgumentException("only the key (0) and value (1) fields expected: " + fieldIndex);
+      }
+
+      @Override
+      public void start() {
+        key = null;
+        value = null;
+      }
+
+      @Override
+      public void end() {
+        map.put(key, value);
+      }
+    }
+  }
+
+}

--- a/format-parquet/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/format-parquet/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.avro;
+
+import java.util.*;
+
+import org.apache.avro.Schema;
+
+import org.apache.hadoop.conf.Configuration;
+import org.codehaus.jackson.node.NullNode;
+import org.apache.parquet.schema.ConversionPatterns;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+import static org.apache.parquet.avro.AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE;
+import static org.apache.parquet.avro.AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE_DEFAULT;
+import static org.apache.parquet.schema.OriginalType.*;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
+
+/**
+ * <p>
+ * Converts an Avro schema into a Parquet schema, or vice versa. See package
+ * documentation for details of the mapping.
+ * </p>
+ *
+ * A copy of the AvroSchemaConverter, except with handling for INT96.
+ */
+public class AvroSchemaConverter {
+
+  public static final String ADD_LIST_ELEMENT_RECORDS =
+    "parquet.avro.add-list-element-records";
+  private static final boolean ADD_LIST_ELEMENT_RECORDS_DEFAULT = true;
+
+  private final boolean assumeRepeatedIsListElement;
+  private final boolean writeOldListStructure;
+
+  public AvroSchemaConverter() {
+    this.assumeRepeatedIsListElement = ADD_LIST_ELEMENT_RECORDS_DEFAULT;
+    this.writeOldListStructure = WRITE_OLD_LIST_STRUCTURE_DEFAULT;
+  }
+
+  public AvroSchemaConverter(Configuration conf) {
+    this.assumeRepeatedIsListElement = conf.getBoolean(
+      ADD_LIST_ELEMENT_RECORDS, ADD_LIST_ELEMENT_RECORDS_DEFAULT);
+    this.writeOldListStructure = conf.getBoolean(
+      WRITE_OLD_LIST_STRUCTURE, WRITE_OLD_LIST_STRUCTURE_DEFAULT);
+  }
+
+  /**
+   * Given a schema, check to see if it is a union of a null type and a regular schema,
+   * and then return the non-null sub-schema. Otherwise, return the given schema.
+   *
+   * @param schema The schema to check
+   * @return The non-null portion of a union schema, or the given schema
+   */
+  public static Schema getNonNull(Schema schema) {
+    if (schema.getType().equals(Schema.Type.UNION)) {
+      List<Schema> schemas = schema.getTypes();
+      if (schemas.size() == 2) {
+        if (schemas.get(0).getType().equals(Schema.Type.NULL)) {
+          return schemas.get(1);
+        } else if (schemas.get(1).getType().equals(Schema.Type.NULL)) {
+          return schemas.get(0);
+        } else {
+          return schema;
+        }
+      } else {
+        return schema;
+      }
+    } else {
+      return schema;
+    }
+  }
+
+  public MessageType convert(Schema avroSchema) {
+    if (!avroSchema.getType().equals(Schema.Type.RECORD)) {
+      throw new IllegalArgumentException("Avro schema must be a record.");
+    }
+    return new MessageType(avroSchema.getFullName(), convertFields(avroSchema.getFields()));
+  }
+
+  private List<Type> convertFields(List<Schema.Field> fields) {
+    List<Type> types = new ArrayList<Type>();
+    for (Schema.Field field : fields) {
+      if (field.schema().getType().equals(Schema.Type.NULL)) {
+        continue; // Avro nulls are not encoded, unless they are null unions
+      }
+      types.add(convertField(field));
+    }
+    return types;
+  }
+
+  private Type convertField(String fieldName, Schema schema) {
+    return convertField(fieldName, schema, Type.Repetition.REQUIRED);
+  }
+
+  private Type convertField(String fieldName, Schema schema, Type.Repetition repetition) {
+    Schema.Type type = schema.getType();
+    if (type.equals(Schema.Type.BOOLEAN)) {
+      return primitive(fieldName, BOOLEAN, repetition);
+    } else if (type.equals(Schema.Type.INT)) {
+      return primitive(fieldName, INT32, repetition);
+    } else if (type.equals(Schema.Type.LONG)) {
+      return primitive(fieldName, INT64, repetition);
+    } else if (type.equals(Schema.Type.FLOAT)) {
+      return primitive(fieldName, FLOAT, repetition);
+    } else if (type.equals(Schema.Type.DOUBLE)) {
+      return primitive(fieldName, DOUBLE, repetition);
+    } else if (type.equals(Schema.Type.BYTES)) {
+      return primitive(fieldName, BINARY, repetition);
+    } else if (type.equals(Schema.Type.STRING)) {
+      return primitive(fieldName, BINARY, repetition, UTF8);
+    } else if (type.equals(Schema.Type.RECORD)) {
+      return new GroupType(repetition, fieldName, convertFields(schema.getFields()));
+    } else if (type.equals(Schema.Type.ENUM)) {
+      return primitive(fieldName, BINARY, repetition, ENUM);
+    } else if (type.equals(Schema.Type.ARRAY)) {
+      if (writeOldListStructure) {
+        return ConversionPatterns.listType(repetition, fieldName,
+                                           convertField("array", schema.getElementType(), Type.Repetition.REPEATED));
+      } else {
+        return ConversionPatterns.listOfElements(repetition, fieldName,
+                                                 convertField(AvroWriteSupport.LIST_ELEMENT_NAME, schema.getElementType()));
+      }
+    } else if (type.equals(Schema.Type.MAP)) {
+      Type valType = convertField("value", schema.getValueType());
+      // avro map key type is always string
+      return ConversionPatterns.stringKeyMapType(repetition, fieldName, valType);
+    } else if (type.equals(Schema.Type.FIXED)) {
+      return primitive(fieldName, FIXED_LEN_BYTE_ARRAY, repetition,
+                       schema.getFixedSize(), null);
+    } else if (type.equals(Schema.Type.UNION)) {
+      return convertUnion(fieldName, schema, repetition);
+    }
+    throw new UnsupportedOperationException("Cannot convert Avro type " + type);
+  }
+
+  private Type convertUnion(String fieldName, Schema schema, Type.Repetition repetition) {
+    List<Schema> nonNullSchemas = new ArrayList(schema.getTypes().size());
+    for (Schema childSchema : schema.getTypes()) {
+      if (childSchema.getType().equals(Schema.Type.NULL)) {
+        if (Type.Repetition.REQUIRED == repetition) {
+          repetition = Type.Repetition.OPTIONAL;
+        }
+      } else {
+        nonNullSchemas.add(childSchema);
+      }
+    }
+    // If we only get a null and one other type then its a simple optional field
+    // otherwise construct a union container
+    switch (nonNullSchemas.size()) {
+      case 0:
+        throw new UnsupportedOperationException("Cannot convert Avro union of only nulls");
+
+      case 1:
+        return convertField(fieldName, nonNullSchemas.get(0), repetition);
+
+      default: // complex union type
+        List<Type> unionTypes = new ArrayList(nonNullSchemas.size());
+        int index = 0;
+        for (Schema childSchema : nonNullSchemas) {
+          unionTypes.add( convertField("member" + index++, childSchema, Type.Repetition.OPTIONAL));
+        }
+        return new GroupType(repetition, fieldName, unionTypes);
+    }
+  }
+
+  private Type convertField(Schema.Field field) {
+    return convertField(field.name(), field.schema());
+  }
+
+  private PrimitiveType primitive(String name,
+                                  PrimitiveType.PrimitiveTypeName primitive, Type.Repetition repetition,
+                                  int typeLength, OriginalType originalType) {
+    return new PrimitiveType(repetition, primitive, typeLength, name,
+                             originalType);
+  }
+
+  private PrimitiveType primitive(String name,
+                                  PrimitiveType.PrimitiveTypeName primitive, Type.Repetition repetition,
+                                  OriginalType originalType) {
+    return new PrimitiveType(repetition, primitive, name, originalType);
+  }
+
+  private PrimitiveType primitive(String name,
+                                  PrimitiveType.PrimitiveTypeName primitive, Type.Repetition repetition) {
+    return new PrimitiveType(repetition, primitive, name, null);
+  }
+
+  public Schema convert(MessageType parquetSchema) {
+    return convertFields(parquetSchema.getName(), parquetSchema.getFields());
+  }
+
+  private Schema convertFields(String name, List<Type> parquetFields) {
+    List<Schema.Field> fields = new ArrayList<Schema.Field>();
+    for (Type parquetType : parquetFields) {
+      Schema fieldSchema = convertField(parquetType);
+      if (parquetType.isRepetition(Type.Repetition.REPEATED)) {
+        throw new UnsupportedOperationException("REPEATED not supported outside LIST or MAP. Type: " + parquetType);
+      } else if (parquetType.isRepetition(Type.Repetition.OPTIONAL)) {
+        fields.add(new Schema.Field(parquetType.getName(), optional(fieldSchema), null,
+                                    NullNode.getInstance()));
+      } else { // REQUIRED
+        fields.add(new Schema.Field(parquetType.getName(), fieldSchema, null, null));
+      }
+    }
+    Schema schema = Schema.createRecord(name, null, null, false);
+    schema.setFields(fields);
+    return schema;
+  }
+
+  private Schema convertField(final Type parquetType) {
+    if (parquetType.isPrimitive()) {
+      final PrimitiveTypeName parquetPrimitiveTypeName =
+        parquetType.asPrimitiveType().getPrimitiveTypeName();
+      final OriginalType originalType = parquetType.getOriginalType();
+      return parquetPrimitiveTypeName.convert(
+        new PrimitiveType.PrimitiveTypeNameConverter<Schema, RuntimeException>() {
+          @Override
+          public Schema convertBOOLEAN(PrimitiveTypeName primitiveTypeName) {
+            return Schema.create(Schema.Type.BOOLEAN);
+          }
+          @Override
+          public Schema convertINT32(PrimitiveTypeName primitiveTypeName) {
+            return Schema.create(Schema.Type.INT);
+          }
+          @Override
+          public Schema convertINT64(PrimitiveTypeName primitiveTypeName) {
+            return Schema.create(Schema.Type.LONG);
+          }
+          @Override
+          public Schema convertINT96(PrimitiveTypeName primitiveTypeName) {
+            // this is the modified part
+            return Schema.create(Schema.Type.BYTES);
+          }
+          @Override
+          public Schema convertFLOAT(PrimitiveTypeName primitiveTypeName) {
+            return Schema.create(Schema.Type.FLOAT);
+          }
+          @Override
+          public Schema convertDOUBLE(PrimitiveTypeName primitiveTypeName) {
+            return Schema.create(Schema.Type.DOUBLE);
+          }
+          @Override
+          public Schema convertFIXED_LEN_BYTE_ARRAY(PrimitiveTypeName primitiveTypeName) {
+            int size = parquetType.asPrimitiveType().getTypeLength();
+            return Schema.createFixed(parquetType.getName(), null, null, size);
+          }
+          @Override
+          public Schema convertBINARY(PrimitiveTypeName primitiveTypeName) {
+            if (originalType == OriginalType.UTF8 || originalType == OriginalType.ENUM) {
+              return Schema.create(Schema.Type.STRING);
+            } else {
+              return Schema.create(Schema.Type.BYTES);
+            }
+          }
+        });
+    } else {
+      GroupType parquetGroupType = parquetType.asGroupType();
+      OriginalType originalType = parquetGroupType.getOriginalType();
+      if (originalType != null) {
+        switch(originalType) {
+          case LIST:
+            if (parquetGroupType.getFieldCount()!= 1) {
+              throw new UnsupportedOperationException("Invalid list type " + parquetGroupType);
+            }
+            Type repeatedType = parquetGroupType.getType(0);
+            if (!repeatedType.isRepetition(Type.Repetition.REPEATED)) {
+              throw new UnsupportedOperationException("Invalid list type " + parquetGroupType);
+            }
+            if (isElementType(repeatedType, parquetGroupType.getName())) {
+              // repeated element types are always required
+              return Schema.createArray(convertField(repeatedType));
+            } else {
+              Type elementType = repeatedType.asGroupType().getType(0);
+              if (elementType.isRepetition(Type.Repetition.OPTIONAL)) {
+                return Schema.createArray(optional(convertField(elementType)));
+              } else {
+                return Schema.createArray(convertField(elementType));
+              }
+            }
+          case MAP_KEY_VALUE: // for backward-compatibility
+          case MAP:
+            if (parquetGroupType.getFieldCount() != 1 || parquetGroupType.getType(0).isPrimitive()) {
+              throw new UnsupportedOperationException("Invalid map type " + parquetGroupType);
+            }
+            GroupType mapKeyValType = parquetGroupType.getType(0).asGroupType();
+            if (!mapKeyValType.isRepetition(Type.Repetition.REPEATED) ||
+              !mapKeyValType.getOriginalType().equals(OriginalType.MAP_KEY_VALUE) ||
+              mapKeyValType.getFieldCount()!=2) {
+              throw new UnsupportedOperationException("Invalid map type " + parquetGroupType);
+            }
+            Type keyType = mapKeyValType.getType(0);
+            if (!keyType.isPrimitive() ||
+              !keyType.asPrimitiveType().getPrimitiveTypeName().equals(PrimitiveTypeName.BINARY) ||
+              !keyType.getOriginalType().equals(OriginalType.UTF8)) {
+              throw new IllegalArgumentException("Map key type must be binary (UTF8): "
+                                                   + keyType);
+            }
+            Type valueType = mapKeyValType.getType(1);
+            if (valueType.isRepetition(Type.Repetition.OPTIONAL)) {
+              return Schema.createMap(optional(convertField(valueType)));
+            } else {
+              return Schema.createMap(convertField(valueType));
+            }
+          case ENUM:
+            return Schema.create(Schema.Type.STRING);
+          case UTF8:
+          default:
+            throw new UnsupportedOperationException("Cannot convert Parquet type " +
+                                                      parquetType);
+
+        }
+      } else {
+        // if no original type then it's a record
+        return convertFields(parquetGroupType.getName(), parquetGroupType.getFields());
+      }
+    }
+  }
+
+  /**
+   * Implements the rules for interpreting existing data from the logical type
+   * spec for the LIST annotation. This is used to produce the expected schema.
+   * <p>
+   * The AvroArrayConverter will decide whether the repeated type is the array
+   * element type by testing whether the element schema and repeated type are
+   * the same. This ensures that the LIST rules are followed when there is no
+   * schema and that a schema can be provided to override the default behavior.
+   */
+  private boolean isElementType(Type repeatedType, String parentName) {
+    return (
+      // can't be a synthetic layer because it would be invalid
+      repeatedType.isPrimitive() ||
+        repeatedType.asGroupType().getFieldCount() > 1 ||
+        // known patterns without the synthetic layer
+        repeatedType.getName().equals("array") ||
+        repeatedType.getName().equals(parentName + "_tuple") ||
+        // default assumption
+        assumeRepeatedIsListElement
+    );
+  }
+
+  private static Schema optional(Schema original) {
+    // null is first in the union because Parquet's default is always null
+    return Schema.createUnion(Arrays.asList(
+      Schema.create(Schema.Type.NULL),
+      original));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -800,7 +800,7 @@
               <consoleOutput>true</consoleOutput>
               <failsOnError>true</failsOnError>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
-              <excludes>**/org/apache/cassandra/**,**/org/apache/hadoop/**</excludes>
+              <excludes>**/org/apache/cassandra/**,**/org/apache/**</excludes>
             </configuration>
             <goals>
               <goal>check</goal>


### PR DESCRIPTION
Added support for reading int96 fields by copying relevant classes
from the parquet library and slightly modifying them to handle
int96 fields. INT96 fields can be read as bytes or as a long.
When read as a long, the value is converted into a unix timestamp
in microseconds, which means the nanosecond component of the
original data is lost.

Fixed a bug with the existing parquet format so that it correctly
uses the user provided schema as the read schema, which does not
have to be the same as the write schema.