### PR TITLE
CDAP-15879 fix RegexPathFilter class loading

### DIFF
--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/input/CombineAvroInputFormat.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/input/CombineAvroInputFormat.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
@@ -28,11 +29,23 @@ import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Combined input format that tracks which file each avro record was read from.
  */
 public class CombineAvroInputFormat extends CombineFileInputFormat<NullWritable, StructuredRecord> {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    ClassLoader cl = job.getConfiguration().getClassLoader();
+    job.getConfiguration().setClassLoader(getClass().getClassLoader());
+    try {
+      return super.getSplits(job);
+    } finally {
+      job.getConfiguration().setClassLoader(cl);
+    }
+  }
 
   /**
    * Creates a RecordReader that delegates to some other RecordReader for each path in the input split.

--- a/format-blob/src/main/java/io/cdap/plugin/format/blob/input/PathTrackingBlobInputFormat.java
+++ b/format-blob/src/main/java/io/cdap/plugin/format/blob/input/PathTrackingBlobInputFormat.java
@@ -25,17 +25,30 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import java.io.IOException;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
  * Blob input format
  */
 public class PathTrackingBlobInputFormat extends PathTrackingInputFormat {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    ClassLoader cl = job.getConfiguration().getClassLoader();
+    job.getConfiguration().setClassLoader(getClass().getClassLoader());
+    try {
+      return super.getSplits(job);
+    } finally {
+      job.getConfiguration().setClassLoader(cl);
+    }
+  }
 
   @Override
   protected RecordReader<NullWritable, StructuredRecord.Builder> createRecordReader(FileSplit split,

--- a/format-common/src/main/java/io/cdap/plugin/format/RegexPathFilter.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/RegexPathFilter.java
@@ -39,7 +39,7 @@ public class RegexPathFilter extends Configured implements PathFilter {
   @Override
   public boolean accept(Path path) {
     try {
-      FileSystem fileSystem = path.getFileSystem(new Configuration());
+      FileSystem fileSystem = path.getFileSystem(getConf());
       if (fileSystem.isDirectory(path)) {
         return true;
       } else if (fileSystem.isFile(path)) {

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/CombineDelimitedInputFormat.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/CombineDelimitedInputFormat.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
@@ -28,11 +29,23 @@ import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Delimited text input format that tracks which file each record was read from.
  */
 public class CombineDelimitedInputFormat extends CombineFileInputFormat<NullWritable, StructuredRecord> {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    ClassLoader cl = job.getConfiguration().getClassLoader();
+    job.getConfiguration().setClassLoader(getClass().getClassLoader());
+    try {
+      return super.getSplits(job);
+    } finally {
+      job.getConfiguration().setClassLoader(cl);
+    }
+  }
 
   /**
    * Creates a RecordReader that delegates to some other RecordReader for each path in the input split.

--- a/format-json/src/main/java/io/cdap/plugin/format/json/input/CombineJsonInputFormat.java
+++ b/format-json/src/main/java/io/cdap/plugin/format/json/input/CombineJsonInputFormat.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
@@ -28,11 +29,23 @@ import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Combined input format that tracks which file each json record was read from.
  */
 public class CombineJsonInputFormat extends CombineFileInputFormat<NullWritable, StructuredRecord> {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    ClassLoader cl = job.getConfiguration().getClassLoader();
+    job.getConfiguration().setClassLoader(getClass().getClassLoader());
+    try {
+      return super.getSplits(job);
+    } finally {
+      job.getConfiguration().setClassLoader(cl);
+    }
+  }
 
   /**
    * Creates a RecordReader that delegates to some other RecordReader for each path in the input split.

--- a/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/CombineParquetInputFormat.java
+++ b/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/CombineParquetInputFormat.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
@@ -28,11 +29,23 @@ import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Combined input format that tracks which file each parquet record was read from.
  */
 public class CombineParquetInputFormat extends CombineFileInputFormat<NullWritable, StructuredRecord> {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    ClassLoader cl = job.getConfiguration().getClassLoader();
+    job.getConfiguration().setClassLoader(getClass().getClassLoader());
+    try {
+      return super.getSplits(job);
+    } finally {
+      job.getConfiguration().setClassLoader(cl);
+    }
+  }
 
   /**
    * Creates a RecordReader that delegates to some other RecordReader for each path in the input split.

--- a/format-text/src/main/java/io/cdap/plugin/format/text/input/CombineTextInputFormat.java
+++ b/format-text/src/main/java/io/cdap/plugin/format/text/input/CombineTextInputFormat.java
@@ -56,7 +56,14 @@ public class CombineTextInputFormat extends CombineFileInputFormat<NullWritable,
    */
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    List<InputSplit> fileSplits = super.getSplits(job);
+    ClassLoader cl = job.getConfiguration().getClassLoader();
+    job.getConfiguration().setClassLoader(getClass().getClassLoader());
+    List<InputSplit> fileSplits;
+    try {
+      fileSplits = super.getSplits(job);
+    } finally {
+      job.getConfiguration().setClassLoader(cl);
+    }
     Configuration hConf = job.getConfiguration();
 
     boolean shouldCopyHeader = hConf.getBoolean(PathTrackingInputFormat.COPY_HEADER, false);


### PR DESCRIPTION
Fixed a bug where RegexPathFilter needed to be exported by any
plugins using the AbstractFileSource. It is a shared class that
should not be exported by multiple plugins, otherwise classloading
conflicts could arise.

The class gets instantiated by FileInputFormat when generating
splits. Fixed the format input formats to set the Configuration
classloader to the plugin classloader, which will be able to
create RegexPathFilter without exports since the class is packaged
in the plugin jar.

This also fixes a related bug, where the FileSystem used by
RegexPathFilter would only contain the filesystems deployed
directly on the cluster, and not the connectors packaged in the
plugins. This was causing the GCS plugins to fail
when run on clusters without the GCS connector installed.