### PR TITLE
CDAP-15428 fixed MD5 hasher plugin to check for field type

### DIFF
--- a/transform-plugins/src/main/java/io/cdap/plugin/Hasher.java
+++ b/transform-plugins/src/main/java/io/cdap/plugin/Hasher.java
@@ -64,7 +64,9 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
 
   @Override
   public void prepareRun(StageSubmitterContext context) throws Exception {
-    config.validate(context.getInputSchema(), context.getFailureCollector());
+    FailureCollector failureCollector = context.getFailureCollector();
+    config.validate(context.getInputSchema(), failureCollector);
+    failureCollector.getOrThrowException();
   }
 
   @Override

--- a/transform-plugins/src/main/java/io/cdap/plugin/Hasher.java
+++ b/transform-plugins/src/main/java/io/cdap/plugin/Hasher.java
@@ -23,14 +23,19 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.StageConfigurer;
+import io.cdap.cdap.etl.api.StageSubmitterContext;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.TransformContext;
 import org.apache.commons.codec.digest.DigestUtils;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -44,28 +49,27 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
   private final Config config;
   private Set<String> fieldSet = new HashSet<>();
 
-
   // For testing purpose only.
   public Hasher(Config config) {
     this.config = config;
   }
 
   @Override
-  public void initialize(TransformContext context) throws Exception {
-    super.initialize(context);
-    config.validate();
-    // Split the fields to be hashed.
-    String[] fields = config.fields.split(",");
-    for (String field : fields) {
-      fieldSet.add(field);
-    }
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    config.validate(stageConfigurer.getInputSchema(), stageConfigurer.getFailureCollector());
+    stageConfigurer.getFailureCollector().getOrThrowException();
+    stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    super.configurePipeline(pipelineConfigurer);
-    config.validate();
-    pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
+  public void prepareRun(StageSubmitterContext context) throws Exception {
+    config.validate(context.getInputSchema(), context.getFailureCollector());
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    fieldSet = config.getFields();
   }
 
   @Override
@@ -110,12 +114,15 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
    * Hasher Plugin Config.
    */
   public static class Config extends PluginConfig {
-    @Name("hash")
+    private static final String HASH = "hash";
+    private static final String FIELDS = "fields";
+
+    @Name(HASH)
     @Description("Specifies the Hash method for hashing fields.")
     @Nullable
     private final String hash;
     
-    @Name("fields")
+    @Name(FIELDS)
     @Description("List of fields to hash. Only string fields are allowed")
     private final String fields;
     
@@ -124,14 +131,37 @@ public final class Hasher extends Transform<StructuredRecord, StructuredRecord> 
       this.fields = fields;
     }
 
-    private void validate() {
+    private void validate(@Nullable Schema inputSchema, FailureCollector failureCollector) {
       // Checks if hash specified is one of the supported types.
-      if (!hash.equalsIgnoreCase("md2") && !hash.equalsIgnoreCase("md5") &&
+      if (hash != null && !hash.equalsIgnoreCase("md2") && !hash.equalsIgnoreCase("md5") &&
         !hash.equalsIgnoreCase("sha1") && !hash.equalsIgnoreCase("sha256") &&
         !hash.equalsIgnoreCase("sha384") && !hash.equalsIgnoreCase("sha512")) {
-        throw new IllegalArgumentException("Invalid hasher '" + hash + "' specified. Allowed hashers are md2, " +
-                                             "md5, sha1, sha256, sha384 and sha512");
+        failureCollector.addFailure(String.format("Invalid hasher '%s' specified.", hash),
+                                    "Allowed hashers are md2, md5, sha1, sha256, sha384 and sha512");
       }
+
+      if (inputSchema == null) {
+        return;
+      }
+
+      for (String field : getFields()) {
+        Schema.Field inputField = inputSchema.getField(field);
+        if (inputField == null) {
+          continue;
+        }
+        Schema inputFieldSchema = inputField.getSchema();
+        inputFieldSchema = inputFieldSchema.isNullable() ? inputFieldSchema.getNonNullable() : inputFieldSchema;
+        if (inputFieldSchema.getType() != Schema.Type.STRING) {
+          failureCollector.addFailure(
+            String.format("Field '%s' is of unsupported type '%s'.", field, inputFieldSchema.getDisplayName()),
+            "Ensure all fields to hash are strings.")
+            .withConfigElement(FIELDS, field);
+        }
+      }
+    }
+
+    private Set<String> getFields() {
+      return Arrays.stream(fields.split(",")).map(String::trim).collect(Collectors.toSet());
     }
   }
 }


### PR DESCRIPTION
Fixed the md5 hasher plugin to validate that the fields specified
are strings and to fail if they are not.