### PR TITLE
[CDAP-15787] Updated NullFieldSplitter for new Validation API

### DIFF
--- a/transform-plugins/src/test/java/io/cdap/plugin/NullFieldSplitterTest.java
+++ b/transform-plugins/src/test/java/io/cdap/plugin/NullFieldSplitterTest.java
@@ -51,7 +51,7 @@ public class NullFieldSplitterTest {
                                                         Schema.of(Schema.Type.BYTES),
                                                         Schema.of(Schema.Type.INT),
                                                         Schema.of(Schema.Type.LONG))));
-    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "a"));
+    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "a", null));
 
     expected = Schema.recordOf("abc.nonull",
                                Schema.Field.of("a", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
@@ -62,7 +62,7 @@ public class NullFieldSplitterTest {
                                                  Schema.of(Schema.Type.BYTES),
                                                  Schema.of(Schema.Type.INT),
                                                  Schema.of(Schema.Type.LONG))));
-    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "b"));
+    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "b", null));
 
     expected = Schema.recordOf("abc.nonull",
                                Schema.Field.of("a", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
@@ -72,7 +72,7 @@ public class NullFieldSplitterTest {
                                                  Schema.of(Schema.Type.BYTES),
                                                  Schema.of(Schema.Type.INT),
                                                  Schema.of(Schema.Type.LONG))));
-    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "c"));
+    Assert.assertEquals(expected, NullFieldSplitter.getNonNullSchema(schema, "c", null));
   }
 
   @Test


### PR DESCRIPTION
Made an overload method for getNonNullSchema since it seems that SplitterTransform does not have a way to retrieve context.