### PR TITLE
[CDAP-16030] Fix excel source validation

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/ExcelInputReader.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/ExcelInputReader.java
@@ -392,7 +392,6 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
 
   /**
    * Get the output schema from the Excel Input Reader specified by the user.
-   * @return outputSchema
    */
   private void getOutputSchema() {
     if (outputSchema == null) {
@@ -519,6 +518,7 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
 
     private String ifErrorRecord;
 
+    @Nullable
     private String errorDatasetName;
 
     public ExcelInputReaderConfig() {

--- a/core-plugins/widgets/Excel-batchsource.json
+++ b/core-plugins/widgets/Excel-batchsource.json
@@ -133,7 +133,6 @@
       ]
     },
     {
-      "label": "Error Handling",
       "properties": [
         {
           "widget-type": "hidden",


### PR DESCRIPTION
Excel source validation fails because error dataset property was made hidden in this PR: https://github.com/cdapio/hydrator-plugins/pull/952#discussion_r326847441
However, plugin was incorrectly expecting it to be a required property which failed validation. Fixing the issue by making the property nullable and also removing `Error handling` group from UI

<img width="1679" alt="Screen Shot 2019-10-10 at 4 56 19 PM" src="https://user-images.githubusercontent.com/14131070/66614708-e9a7b680-eb7e-11e9-92d1-4ad11a0ff4f6.png">
