### PR TITLE
add regex file pattern

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
@@ -141,7 +141,7 @@ public class FTPBatchSource extends AbstractFileSource {
     @Nullable
     @Override
     public Pattern getFilePattern() {
-      return null;
+      return Pattern.compile("(ftp|sftp)://.+:.+@.+:\\d+/.+", Pattern.CASE_INSENSITIVE);
     }
 
     @Override


### PR DESCRIPTION
Before the getFilePattern() function is returning null, I added in a regex expression to do some filtering on the file path based on the path specified in the original code: 'prefix://username:password@hostname:port/path'