### PR TITLE
[CDAP-16160] Add azure adls plugins as hydrator-plugins.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,10 @@
 	path = amazon-s3-plugins
 	url = ../../data-integrations/amazon-s3-plugins
 	branch = release/1.11
+[submodule "azure"]
+	path = azure
+	url = ../../data-integrations/azure
+	branch = release/1.6
 [submodule "condition-plugins"]
 	path = condition-plugins
 	url = ../../data-integrations/condition-plugins.git

--- a/pom.xml
+++ b/pom.xml
@@ -837,6 +837,7 @@
         <module>google-cloud</module>
         <module>kafka-plugins</module>
         <module>amazon-s3-plugins</module>
+        <module>azure</module>
         <module>condition-plugins</module>
       </modules>
     </profile>


### PR DESCRIPTION
This is a required step to release azure adls plugins as hydrator plugins for cdap. 

Jira link: https://issues.cask.co/browse/CDAP-16160
Build link: https://builds.cask.co/browse/HYP-BAD636