### PR TITLE
Fix SFTP plugin to return regex pattern matcher

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
@@ -141,7 +141,7 @@ public class FTPBatchSource extends AbstractFileSource {
     @Nullable
     @Override
     public Pattern getFilePattern() {
-      return null;
+      return Pattern.compile(fileRegex);
     }
 
     @Override


### PR DESCRIPTION
Currently fileRegex returns a null and SFTP plugin does not successfully parse files based on regex. Fixing the getFilePattern method to return the Pattern