### PR TITLE
PLUGIN-99 fix parquet format to handle group type correctly

### DIFF
--- a/format-parquet/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
+++ b/format-parquet/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
@@ -153,7 +153,7 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
   private static Converter newConverter(Schema schema, Type type,
       GenericData model, ParentValueContainer parent) {
     // this is the modified section
-    if (type.asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+    if (type.isPrimitive() && type.asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
       if (schema.getType().equals(Schema.Type.BYTES)) {
         return new AvroConverters.FieldByteBufferConverter(parent);
       } else if (schema.getType().equals(Schema.Type.LONG)) {


### PR DESCRIPTION
When we support INT96 for parquet file, we call asPrimitiveType(), this method will through ClassCastException if it is not, preventing the code to deal with group type.

JIRA: https://issues.cask.co/browse/PLUGIN-99