### PR TITLE
CDAP-16002 fix bug where header is emitted multiple times

### DIFF
--- a/format-text/src/main/java/io/cdap/plugin/format/text/input/CombineTextInputFormat.java
+++ b/format-text/src/main/java/io/cdap/plugin/format/text/input/CombineTextInputFormat.java
@@ -120,7 +120,7 @@ public class CombineTextInputFormat extends CombineFileInputFormat<NullWritable,
 
     public WrapperReader(CombineFileSplit split, TaskAttemptContext context,
                          Integer idx) throws IOException, InterruptedException {
-      super(new PathTrackingTextInputFormat(), split, context, idx);
+      super(new PathTrackingTextInputFormat(idx != 0), split, context, idx);
     }
   }
 }


### PR DESCRIPTION
When multiple files with headers are being read, the header will
be emitted once per file within the same RecordReader. This causes
Wrangler's parse-as-csv with header to fail when it reaches the
header for the 2nd file.

To fix this, ignore the header for everything except for the first
file in the split. This is only done when the hidden copyHeader
variable is set, as we do not actually want to filter out the first
row for files that do not have a special header.