### PR TITLE
CDAP-16367 fix fll for source and sink

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/SnapshotFileBatchSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/SnapshotFileBatchSource.java
@@ -26,19 +26,16 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.lib.FileSetProperties;
 import io.cdap.cdap.api.dataset.lib.PartitionedFileSet;
-import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
-import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
-import io.cdap.cdap.etl.api.lineage.field.FieldReadOperation;
 import io.cdap.cdap.etl.api.validation.ValidatingInputFormat;
 import io.cdap.plugin.batch.sink.SnapshotFileBatchSink;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.dataset.SnapshotFileSet;
 import org.apache.hadoop.io.NullWritable;
 
 import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -105,11 +102,9 @@ public abstract class SnapshotFileBatchSource<T extends SnapshotFileSetSourceCon
     Schema schema = config.getSchema();
     if (schema.getFields() != null) {
       String formatName = getInputFormatName();
-      FieldOperation operation =
-        new FieldReadOperation("Read", String.format("Read from SnapshotFile source in %s format.", formatName),
-                               EndPoint.of(context.getNamespace(), config.getName()),
-                               schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
-      context.record(Collections.singletonList(operation));
+      LineageRecorder recorder = new LineageRecorder(context, config.getName());
+      recorder.recordRead("Read", String.format("Read from SnapshotFile source in %s format.", formatName),
+                          schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
 
     context.setInput(Input.ofDataset(config.getName(), snapshotFileSet.getInputArguments(arguments)));

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/TableSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/TableSource.java
@@ -27,18 +27,15 @@ import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.api.dataset.table.Row;
 import io.cdap.cdap.api.dataset.table.Table;
-import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
-import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
-import io.cdap.cdap.etl.api.lineage.field.FieldReadOperation;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.common.Properties;
 import io.cdap.plugin.common.RowRecordTransformer;
 import io.cdap.plugin.common.TableSourceConfig;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -87,12 +84,9 @@ public class TableSource extends BatchReadableSource<byte[], Row, StructuredReco
     super.prepareRun(context);
     Schema schema = tableConfig.getSchema();
     if (schema != null && schema.getFields() != null) {
-      FieldOperation operation =
-        new FieldReadOperation("Read", "Read from Table dataset",
-                               EndPoint.of(context.getNamespace(), tableConfig.getName()),
-                               schema.getFields().stream().map(Schema.Field::getName)
-                                 .collect(Collectors.toList()));
-      context.record(Collections.singletonList(operation));
+      LineageRecorder recorder = new LineageRecorder(context, tableConfig.getName());
+      recorder.recordRead("Read", "Read from Table dataset",
+                          schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
   }
 

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/TimePartitionedFileSetSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/TimePartitionedFileSetSource.java
@@ -27,17 +27,14 @@ import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.lib.FileSetProperties;
 import io.cdap.cdap.api.dataset.lib.TimePartitionedFileSet;
 import io.cdap.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
-import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
-import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
-import io.cdap.cdap.etl.api.lineage.field.FieldReadOperation;
 import io.cdap.cdap.etl.api.validation.ValidatingInputFormat;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.common.TimeParser;
 import org.apache.hadoop.io.NullWritable;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -99,11 +96,9 @@ public abstract class TimePartitionedFileSetSource<T extends TPFSConfig>
     Schema schema = config.getSchema();
     if (schema.getFields() != null) {
       String formatName = getInputFormatName();
-      FieldOperation operation =
-        new FieldReadOperation("Read", String.format("Read from TimePartitionedFileSet in %s format.", formatName),
-                               EndPoint.of(context.getNamespace(), config.getName()),
-                               schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
-      context.record(Collections.singletonList(operation));
+      LineageRecorder recorder = new LineageRecorder(context, config.getName());
+      recorder.recordRead("Read", String.format("Read from TimePartitionedFileSet in %s format.", formatName),
+                          schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
 
     long duration = TimeParser.parseDuration(config.getDuration());

--- a/hydrator-common/src/main/java/io/cdap/plugin/common/LineageRecorder.java
+++ b/hydrator-common/src/main/java/io/cdap/plugin/common/LineageRecorder.java
@@ -85,10 +85,11 @@ public class LineageRecorder {
    * @param fields output fields of this read operation
    */
   public void recordRead(String operationName, String operationDescription, List<String> fields) {
-    context.record(Collections.singletonList(new FieldReadOperation(operationName,
-                                                                    operationDescription,
-                                                                    EndPoint.of(context.getNamespace(), dataset),
-                                                                    fields)));
+    fields.forEach(field -> context.record(
+      Collections.singletonList(new FieldReadOperation(operationName + field,
+                                                       operationDescription,
+                                                       EndPoint.of(context.getNamespace(), dataset),
+                                                       field))));
   }
 
   /**
@@ -96,12 +97,13 @@ public class LineageRecorder {
    *
    * @param operationName the name of the operation
    * @param operationDescription description for the operation
-   * @param fields input fields of this read operation
+   * @param fields input fields of this write operation
    */
   public void recordWrite(String operationName, String operationDescription, List<String> fields) {
-    context.record(Collections.singletonList(new FieldWriteOperation(operationName,
-                                                                     operationDescription,
-                                                                     EndPoint.of(context.getNamespace(), dataset),
-                                                                     fields)));
+    fields.forEach(field -> context.record(
+      Collections.singletonList(new FieldWriteOperation(operationName + field,
+                                                        operationDescription,
+                                                        EndPoint.of(context.getNamespace(), dataset),
+                                                        field))));
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16367
build: https://builds.cask.co/browse/HYP-BAD659-1

Currently we emit field lineage for source and sink using one operation containing all the fields, this basically means these fields are corelated, and if there are no transforms between source and sink, a lineage graph from all input to all output fields are generated. For pipelines with transform, this just happens to work since the transform is emitting the correct lineage for the output fields.