### PR TITLE
Cherry pick fixes to support macros in joiner plugin

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerConfigTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerConfigTest.java
@@ -203,7 +203,7 @@ public class JoinerConfigTest {
       Assert.assertEquals(1, e.getFailures().size());
       Assert.assertEquals(1, e.getFailures().get(0).getCauses().size());
       Cause expectedCause = new Cause();
-      expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, JoinerConfig.SELECT_FIELDS);
+      expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, JoinerConfig.SELECTED_FIELDS);
       expectedCause.addAttribute(STAGE, MOCK_STAGE);
       Assert.assertEquals(expectedCause, e.getFailures().get(0).getCauses().get(0));
     }
@@ -277,7 +277,6 @@ public class JoinerConfigTest {
       joiner.getOutputSchema(inputSchemas, collector);
       Assert.fail();
     } catch (ValidationException e) {
-      Assert.assertEquals(1, e.getFailures().size());
       Assert.assertEquals(1, e.getFailures().get(0).getCauses().size());
       Cause expectedCause = new Cause();
       expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, JoinerConfig.JOIN_KEYS);

--- a/core-plugins/widgets/Joiner-batchjoiner.json
+++ b/core-plugins/widgets/Joiner-batchjoiner.json
@@ -45,5 +45,11 @@
       ]
     }
   ],
-  "outputs": []
+  "outputs": [
+    {
+      "name": "schema",
+      "widget-type": "schema"
+    }
+
+  ]
 }


### PR DESCRIPTION
This cherry pick includes the following commits:
- [Support macro for Joiner, dedupe and distinct transform fields](https://github.com/cdapio/hydrator-plugins/commit/e5a53606f061e500b59b7adb0c36e3e5432bb4e8)
- [CDAP-16324) Improve macro support in Joiner plugin](https://github.com/cdapio/hydrator-plugins/commit/73104a9073184a47d607ad5d890c9614b46a1480)
- Parts of [Refactoring of the Joiner implementation](https://github.com/cdapio/hydrator-plugins/commit/500235d3ea3e7a65517a01688f2263ab93fdac8b)
  - This commit in release/2.3 conflicts with the macro changes in develop. In particular, the performance optimization to cache join key schema is not compatible with the changes in develop, so it has been reverted.
- Re-implemented caching logic on develop #1047

