### PR TITLE
CDAP-16525 add config to filter pattern in field name

### DIFF
--- a/database-plugins/docs/Database-batchsource.md
+++ b/database-plugins/docs/Database-batchsource.md
@@ -67,6 +67,12 @@ Defaults to TRANSACTION_SERIALIZABLE. See java.sql.Connection#setTransactionIsol
 The Phoenix jdbc driver will throw an exception if the Phoenix database does not have transactions enabled
 and this setting is set to true. For drivers like that, this should be set to TRANSACTION_NONE.
 
+**Pattern To Replace:** The pattern to replace in the field name in the table, it is typically used with the
+Replace With config. If Replace With is not set, the pattern will be removed in the field name.
+
+**Replace With:** The string that will be replaced in the field name in the table, it must be used with the
+Pattern To Replace config.
+
 **Schema:** The schema of records output by the source. This will be used in place of whatever schema comes
 back from the query. However, it must match the schema that comes back from the query,
 except it can mark fields as nullable and can contain a subset of the fields.

--- a/database-plugins/widgets/Database-batchsource.json
+++ b/database-plugins/widgets/Database-batchsource.json
@@ -161,6 +161,21 @@
           }
         }
       ]
+    },
+    {
+      "label": "Column Names Normalization",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Pattern To Replace",
+          "name": "patternToReplace"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Replace With",
+          "name": "replaceWith"
+        }
+      ]
     }
   ],
   "outputs": [


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16525
https://builds.cask.co/browse/HYP-BAD688-1

Sometimes a db can contain some characters, for exmaple "\", which is not valid in the avro schema, we need to add a way to replace these patterns with something valid