### PR TITLE
(CDAP-16655) Fix file input to use correct class loader to create split.

### DIFF
--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/input/CombineAvroInputFormat.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/input/CombineAvroInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.plugin.format.avro.input;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -38,13 +39,8 @@ public class CombineAvroInputFormat extends CombineFileInputFormat<NullWritable,
 
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    ClassLoader cl = job.getConfiguration().getClassLoader();
-    job.getConfiguration().setClassLoader(getClass().getClassLoader());
-    try {
-      return super.getSplits(job);
-    } finally {
-      job.getConfiguration().setClassLoader(cl);
-    }
+    return JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
+                                              CombineAvroInputFormat.super::getSplits);
   }
 
   /**

--- a/format-blob/src/main/java/io/cdap/plugin/format/blob/input/PathTrackingBlobInputFormat.java
+++ b/format-blob/src/main/java/io/cdap/plugin/format/blob/input/PathTrackingBlobInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ package io.cdap.plugin.format.blob.input;
 import com.google.common.io.ByteStreams;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -41,13 +42,8 @@ public class PathTrackingBlobInputFormat extends PathTrackingInputFormat {
 
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    ClassLoader cl = job.getConfiguration().getClassLoader();
-    job.getConfiguration().setClassLoader(getClass().getClassLoader());
-    try {
-      return super.getSplits(job);
-    } finally {
-      job.getConfiguration().setClassLoader(cl);
-    }
+    return JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
+                                              PathTrackingBlobInputFormat.super::getSplits);
   }
 
   @Override

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/CombineDelimitedInputFormat.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/CombineDelimitedInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.plugin.format.delimited.input;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -38,13 +39,8 @@ public class CombineDelimitedInputFormat extends CombineFileInputFormat<NullWrit
 
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    ClassLoader cl = job.getConfiguration().getClassLoader();
-    job.getConfiguration().setClassLoader(getClass().getClassLoader());
-    try {
-      return super.getSplits(job);
-    } finally {
-      job.getConfiguration().setClassLoader(cl);
-    }
+    return JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
+                                              CombineDelimitedInputFormat.super::getSplits);
   }
 
   /**

--- a/format-json/src/main/java/io/cdap/plugin/format/json/input/CombineJsonInputFormat.java
+++ b/format-json/src/main/java/io/cdap/plugin/format/json/input/CombineJsonInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.plugin.format.json.input;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -38,13 +39,8 @@ public class CombineJsonInputFormat extends CombineFileInputFormat<NullWritable,
 
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    ClassLoader cl = job.getConfiguration().getClassLoader();
-    job.getConfiguration().setClassLoader(getClass().getClassLoader());
-    try {
-      return super.getSplits(job);
-    } finally {
-      job.getConfiguration().setClassLoader(cl);
-    }
+    return JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
+                                              CombineJsonInputFormat.super::getSplits);
   }
 
   /**

--- a/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/CombineParquetInputFormat.java
+++ b/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/CombineParquetInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.plugin.format.parquet.input;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -38,13 +39,8 @@ public class CombineParquetInputFormat extends CombineFileInputFormat<NullWritab
 
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    ClassLoader cl = job.getConfiguration().getClassLoader();
-    job.getConfiguration().setClassLoader(getClass().getClassLoader());
-    try {
-      return super.getSplits(job);
-    } finally {
-      job.getConfiguration().setClassLoader(cl);
-    }
+    return JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
+                                              CombineParquetInputFormat.super::getSplits);
   }
 
   /**

--- a/format-text/src/main/java/io/cdap/plugin/format/text/input/CombineTextInputFormat.java
+++ b/format-text/src/main/java/io/cdap/plugin/format/text/input/CombineTextInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.plugin.format.text.input;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -57,14 +58,8 @@ public class CombineTextInputFormat extends CombineFileInputFormat<NullWritable,
    */
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    ClassLoader cl = job.getConfiguration().getClassLoader();
-    job.getConfiguration().setClassLoader(getClass().getClassLoader());
-    List<InputSplit> fileSplits;
-    try {
-      fileSplits = super.getSplits(job);
-    } finally {
-      job.getConfiguration().setClassLoader(cl);
-    }
+    List<InputSplit> fileSplits = JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
+                                                                     CombineTextInputFormat.super::getSplits);
     Configuration hConf = job.getConfiguration();
 
     boolean shouldCopyHeader = hConf.getBoolean(PathTrackingInputFormat.COPY_HEADER, false);

--- a/hydrator-common/src/main/java/io/cdap/plugin/common/CombineClassLoader.java
+++ b/hydrator-common/src/main/java/io/cdap/plugin/common/CombineClassLoader.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.common;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link ClassLoader} that load classes from list of other {@link ClassLoader}s. Note that
+ * this ClassLoader just delegates to other ClassLoaders, but never define class, hence no Class
+ * loaded by this class would have {@link Class#getClassLoader()}} returning this ClassLoader.
+ */
+public class CombineClassLoader extends URLClassLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CombineClassLoader.class);
+  private final List<ClassLoader> delegates;
+
+  /**
+   * Creates a CombineClassLoader with the given parent and a list of ClassLoaders for delegation.
+   *
+   * @param parent parent ClassLoader. If null, bootstrap ClassLoader will be the parent.
+   * @param delegates list of ClassLoaders for delegation
+   */
+  public CombineClassLoader(@Nullable ClassLoader parent, ClassLoader...delegates) {
+    this(parent, Arrays.asList(delegates));
+  }
+
+  /**
+   * Creates a CombineClassLoader with the given parent and a list of ClassLoaders for delegation.
+   *
+   * @param parent parent ClassLoader. If null, bootstrap ClassLoader will be the parent.
+   * @param delegates list of ClassLoaders for delegation
+   */
+  public CombineClassLoader(@Nullable ClassLoader parent, Iterable<? extends ClassLoader> delegates) {
+    super(new URL[0], parent);
+    this.delegates = ImmutableList.copyOf(delegates);
+  }
+
+  @Override
+  public URL[] getURLs() {
+    List<URL> urls = new ArrayList<>();
+    for (ClassLoader delegate : delegates) {
+      if (delegate instanceof URLClassLoader) {
+        Collections.addAll(urls, ((URLClassLoader) delegate).getURLs());
+      }
+    }
+    return urls.toArray(new URL[0]);
+  }
+
+  /**
+   * Returns the list of {@link ClassLoader}s that this class delegates to.
+   */
+  public List<ClassLoader> getDelegates() {
+    return delegates;
+  }
+
+  @Override
+  protected Class<?> findClass(String name) throws ClassNotFoundException {
+    for (ClassLoader classLoader : delegates) {
+      try {
+        return classLoader.loadClass(name);
+      } catch (ClassNotFoundException e) {
+        LOG.trace("Class {} not found in ClassLoader {}", name, classLoader);
+      }
+    }
+
+    throw new ClassNotFoundException("Class not found in all delegated ClassLoaders: " + name);
+  }
+
+  @Override
+  public URL findResource(String name) {
+    for (ClassLoader classLoader : delegates) {
+      URL url = classLoader.getResource(name);
+      if (url != null) {
+        return url;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Enumeration<URL> findResources(String name) throws IOException {
+    // Using LinkedHashSet to preserve the ordering
+    Set<URL> urls = Sets.newLinkedHashSet();
+    for (ClassLoader classLoader : delegates) {
+      Iterators.addAll(urls, Iterators.forEnumeration(classLoader.getResources(name)));
+    }
+    return Iterators.asEnumeration(urls.iterator());
+  }
+
+  @Override
+  public InputStream getResourceAsStream(String name) {
+    for (ClassLoader classLoader : delegates) {
+      InputStream is = classLoader.getResourceAsStream(name);
+      if (is != null) {
+        return is;
+      }
+    }
+    return null;
+  }
+}

--- a/hydrator-common/src/main/java/io/cdap/plugin/common/batch/ThrowableFunction.java
+++ b/hydrator-common/src/main/java/io/cdap/plugin/common/batch/ThrowableFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.common.batch;
+
+import java.util.function.Function;
+
+/**
+ * A function that is similar to {@link Function} but allows exception being thrown from the {@link #apply(Object)}
+ * method.
+ *
+ * @param <F> the type of the input to the function
+ * @param <T> the type of the result of the function
+ * @param <E> the type of the exception thrown by the function
+ */
+public interface ThrowableFunction<F, T, E extends Exception> {
+
+  /**
+   * Applies this function to the given argument.
+   *
+   * @param t the function argument
+   * @return the function result
+   * @throws E if application failed
+   */
+  T apply(F t) throws E;
+}


### PR DESCRIPTION
It fixes an error introduced in CDAP-15879, in which the plugin classloader don't provide access to FileSystem implementation that is available from the parent / execution framework classloader.