### PR TITLE
2.4 cherry pick for azure adls plugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,10 @@
 	path = amazon-s3-plugins
 	url = ../../data-integrations/amazon-s3-plugins
 	branch = release/1.12
+[submodule "azure"]
+	path = azure
+	url = ../../data-integrations/azure
+	branch = release/1.8
 [submodule "condition-plugins"]
 	path = condition-plugins
 	url = ../../data-integrations/condition-plugins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
 [submodule "azure"]
 	path = azure
 	url = ../../data-integrations/azure
-	branch = release/1.7
+	branch = release/1.8
 [submodule "condition-plugins"]
 	path = condition-plugins
 	url = ../../data-integrations/condition-plugins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
 [submodule "azure"]
 	path = azure
 	url = ../../data-integrations/azure
-	branch = release/1.6
+	branch = release/1.7
 [submodule "condition-plugins"]
 	path = condition-plugins
 	url = ../../data-integrations/condition-plugins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,10 @@
 	path = amazon-s3-plugins
 	url = ../../data-integrations/amazon-s3-plugins
 	branch = release/1.12
+[submodule "azure"]
+	path = azure
+	url = ../../data-integrations/azure
+	branch = release/1.6
 [submodule "condition-plugins"]
 	path = condition-plugins
 	url = ../../data-integrations/condition-plugins.git

--- a/pom.xml
+++ b/pom.xml
@@ -837,6 +837,7 @@
         <module>google-cloud</module>
         <module>kafka-plugins</module>
         <module>amazon-s3-plugins</module>
+        <module>azure</module>
         <module>condition-plugins</module>
       </modules>
     </profile>


### PR DESCRIPTION
cherry pick azure adls changes into 2.4 branch. Changes mainly includes add azure as submodule and update the release branch from 1.6 to 1.7.  Update submodule is not included. 