### PR TITLE
CDAP-16875 changed joiner plugin to use new auto-join API

### DIFF
--- a/core-plugins/docs/Joiner-batchjoiner.md
+++ b/core-plugins/docs/Joiner-batchjoiner.md
@@ -1,49 +1,90 @@
 # Joiner
 
-
 Description
 -----------
-Joins records from one or more input based on join keys. Supports `inner` and `outer` joins, selection and renaming of output fields.  
-
-Use Case
---------
-The transform is used when you want to combine fields from one or more input, similar to the joins in SQL.
+Joins records from one or more input based on join key equality.
+Supports `inner` and `outer` joins, selection and renaming of output fields.
+The plugin is used when you want to combine fields from one or more inputs, similar to joins in SQL.
 
 Properties
 ----------
-**joinKeys:** List of keys to perform the join operation. The list is separated by `&`. 
+**Fields:** List of fields from each input that should be included in the output. 
+Output field names must be unique. If the same field name exists in more than one input,
+each field must be aliased (renamed) to a unique output name.
+
+**Join Type:** Type of join to perform.
+A join between two required input is an inner join. A join between a required input and an optional
+input is a left outer join. A join between two optional inputs is an outer join.
+
+A join of more than two inputs is logically equivalent to performing inner joins over all the
+required inputs, followed by left outer joins on the optional inputs.
+
+**Join Condition:** List of keys to perform the join operation. The list is separated by `&`. 
 Join key from each input stage will be prefixed with `<stageName>.` and the relation among join keys from different inputs is represented by `=`. 
 For example: customers.customer_id=items.c_id&customers.customer_name=items.c_name means the join key is a composite key
 of customer id and customer name from customers and items input stages and join will be performed on equality 
 of the join keys. This transform only supports equality for joins.
 
-**selectedFields:** Comma-separated list of fields to be selected and renamed in join output from each input stage. 
-Each selected field that should be present in the output must be prefixed with '<input_stage_name>'. 
-The syntax for specifying alias for each selected field is similar to sql. 
-For example: customers.id as customer_id, customer.name as customer_name, item.id as item_id, <stageName>.inputFieldName as alias. 
-The output will have same order of fields as selected in selectedFields. There must not be any duplicate fields in output.
+**Inputs to Load in Memory:** Hint to the underlying execution engine that the specified input data should be
+loaded into memory to perform an in-memory join. This is ignored by the MapReduce engine and passed onto the Spark engine.
+An in-memory join performs well when one side of the join is small (for example, under 1gb). Be sure to set
+Spark executor memory to a number large enough to load all of these datasets into memory. This is most commonly
+used when a large input is being joined to a small input and will lead to much better performance in such scenarios.
 
-**requiredInputs:** Comma-separated list of stages. Required input stages decide the type of the join. 
-If all the input stages are present in required inputs, inner join will be performed. 
-Otherwise, outer join will be performed considering non-required inputs as optional.
+**Join on Null Keys:** Whether to join rows together if both of their key values are null.
+For example, suppose the join is on a 'purchases' input that contains:
 
-**numPartitions:** Number of partitions to use when grouping fields. If not specified, the execution
+| purchase_id | customer_name | item   |
+| ----------- | ------------- | ------ |
+| 1           | alice         | donut  |
+| 2           |               | coffee | 
+| 3           | bob           | water  |
+
+and a 'customers' input that contains:
+
+| customer_id | name   |
+| ----------- | ------ |
+| 1           | alice  |
+| 2           |        |
+| 3           | bob    |
+
+The join is a left outer join on purchases.customer_name = customers.name.
+If this property is set to true, the joined output would be:
+
+| purchase_id | customer_name | item   | customer_id | name  |
+| ----------- | ------------- | ------ | ----------- | ----- |
+| 1           | alice         | donut  | 1           | alice |
+| 2           |               | coffee | 2           |       |
+| 3           | bob           | water  | 3           | bob   |
+
+Note that the rows with a null customer name were joined together, with customer_id set to 2 for purchase 2.
+If this property is set to false, the joined output would be:
+
+| purchase_id | customer_name | item   | customer_id | name  |
+| ----------- | ------------- | ------ | ----------- | ----- |
+| 1           | alice         | donut  | 1           | alice |
+| 2           |               | coffee |             |       |
+| 3           | bob           | water  | 3           | bob   |
+
+In this scenario, the null customer name on the left did not get joined to the null customer name on the right.
+Traditional relational database systems do not join on null key values.
+In most situations, you will want to do the same and set this to false. 
+Setting it to true can cause a large drop in performance if there are a lot of null keys in your input data.
+
+**Number of Partitions:** Number of partitions to use when grouping fields. If not specified, the execution
 framework will decide on the number to use.
 
 Example
 -------
-This example inner joins records from ``customers`` and ``purchases`` inputs on customer id and selects customer_id, name, item and price fields.
+This example performs an inner join on records from ``customers`` and ``purchases`` inputs
+ on customer id. It selects customer_id, name, item and price fields as the output fields.
+This is equivalent to a SQL query like:
 
-```json
-    {
-        "name": "Joiner",
-        "type": "batchjoiner",
-        "properties": {
-            "selectedFields": "customers.id as customer_id,customers.first_name as name,purchases.item,purchases.price",
-            "requiredInputs": "customers, purchases",
-            "joinKeys": "customers.id = purchases.customer_id"
-        }
-    }
+```
+SELECT customes.id as customer_id, customers.first_name as name, purchases.item, purchases.price
+FROM customers 
+INNER JOIN purchases
+ON customers.id = purchases.customer_id
 ```
 
 For example, suppose the joiner receives input records from customers and purchases as below:
@@ -78,4 +119,3 @@ Output records will contain inner join on customer id:
 | 2           | David   | plate  | 0.50  |
 | 3           | Hugh    | tea    | 1.99  |
 | 5           | Frank   | cookie | 0.50  |
-

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/Joiner.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/Joiner.java
@@ -17,37 +17,39 @@
 package io.cdap.plugin.batch.joiner;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Table;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
-import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
-import io.cdap.cdap.etl.api.JoinConfig;
-import io.cdap.cdap.etl.api.JoinElement;
-import io.cdap.cdap.etl.api.MultiInputPipelineConfigurer;
-import io.cdap.cdap.etl.api.MultiInputStageConfigurer;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoinerContext;
-import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.InvalidJoinException;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
+import io.cdap.cdap.etl.api.join.error.JoinError;
+import io.cdap.cdap.etl.api.join.error.OutputSchemaError;
+import io.cdap.cdap.etl.api.join.error.SelectedFieldError;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Batch joiner to join records from multiple inputs
@@ -58,40 +60,83 @@ import java.util.Set;
   "required inputs, inner join will be performed. Otherwise inner join will be performed on required inputs and " +
   "records from non-required inputs will only be present if they match join criteria. If there are no required " +
   "inputs, outer join will be performed")
-public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, StructuredRecord> {
+public class Joiner extends BatchAutoJoiner {
 
   static final String JOIN_OPERATION_DESCRIPTION = "Used as a key in a join";
   static final String IDENTITY_OPERATION_DESCRIPTION = "Unchanged as part of a join";
   static final String RENAME_OPERATION_DESCRIPTION = "Renamed as a part of a join";
 
   private final JoinerConfig conf;
-  private Schema outputSchema;
-  private Map<String, List<String>> perStageJoinKeys;
-  private Table<String, String, String> perStageSelectedFields;
-  private JoinConfig joinConfig;
-  private Map<String, Schema> keySchemas = new HashMap<>();
 
   public Joiner(JoinerConfig conf) {
     this.conf = conf;
   }
 
+  @Nullable
   @Override
-  public void configurePipeline(MultiInputPipelineConfigurer pipelineConfigurer) {
-    MultiInputStageConfigurer stageConfigurer = pipelineConfigurer.getMultiInputStageConfigurer();
-    Map<String, Schema> inputSchemas = stageConfigurer.getInputSchemas();
-    FailureCollector collector = pipelineConfigurer.getMultiInputStageConfigurer().getFailureCollector();
-    init(inputSchemas, collector);
-    collector.getOrThrowException();
-    if (!conf.inputSchemasAvailable(inputSchemas) && !conf.containsMacro(JoinerConfig.OUTPUT_SCHEMA) &&
+  public JoinDefinition define(AutoJoinerContext context) {
+    FailureCollector collector = context.getFailureCollector();
+
+    boolean hasUnknownInputSchema = context.getInputStages().values().stream().anyMatch(Objects::isNull);
+    if (hasUnknownInputSchema && !conf.containsMacro(JoinerConfig.OUTPUT_SCHEMA) &&
       conf.getOutputSchema(collector) == null) {
       // If input schemas are unknown, an output schema must be provided.
       collector.addFailure("Output schema must be specified", null).withConfigProperty(JoinerConfig.OUTPUT_SCHEMA);
     }
 
-    Schema outputSchema = getOutputSchema(inputSchemas, collector);
-    if (outputSchema != null) {
-      // Set output schema if it's not a macro.
-      stageConfigurer.setOutputSchema(outputSchema);
+    if (conf.requiredPropertiesContainMacros()) {
+      return null;
+    }
+
+    Set<String> requiredStages = conf.getRequiredInputs();
+    Set<String> broadcastStages = conf.getBroadcastInputs();
+    List<JoinStage> inputs = new ArrayList<>(context.getInputStages().size());
+    boolean useOutputSchema = false;
+    for (JoinStage joinStage : context.getInputStages().values()) {
+      inputs.add(JoinStage.builder(joinStage)
+        .setRequired(requiredStages.contains(joinStage.getStageName()))
+        .setBroadcast(broadcastStages.contains(joinStage.getStageName()))
+        .build());
+      useOutputSchema = useOutputSchema || joinStage.getSchema() == null;
+    }
+
+    try {
+      JoinDefinition.Builder joinBuilder = JoinDefinition.builder()
+        .select(conf.getSelectedFields(collector))
+        .from(inputs)
+        .on(JoinCondition.onKeys()
+              .setKeys(conf.getJoinKeys(collector))
+              .setNullSafe(conf.isNullSafe())
+              .build());
+      if (useOutputSchema) {
+        joinBuilder.setOutputSchema(conf.getOutputSchema(collector));
+      } else {
+        joinBuilder.setOutputSchemaName("join.output");
+      }
+      return joinBuilder.build();
+    } catch (InvalidJoinException e) {
+      if (e.getErrors().isEmpty()) {
+        collector.addFailure(e.getMessage(), null);
+      }
+      for (JoinError error : e.getErrors()) {
+        ValidationFailure failure = collector.addFailure(error.getMessage(), error.getCorrectiveAction());
+        switch (error.getType()) {
+          case JOIN_KEY:
+          case JOIN_KEY_FIELD:
+            failure.withConfigProperty(JoinerConfig.JOIN_KEYS);
+            break;
+          case SELECTED_FIELD:
+            JoinField badField = ((SelectedFieldError) error).getField();
+            failure.withConfigElement(
+              JoinerConfig.SELECTED_FIELDS,
+              String.format("%s.%s as %s", badField.getStageName(), badField.getFieldName(), badField.getAlias()));
+            break;
+          case OUTPUT_SCHEMA:
+            OutputSchemaError schemaError = (OutputSchemaError) error;
+            failure.withOutputSchemaField(schemaError.getField());
+        }
+      }
+      throw collector.getOrThrowException();
     }
   }
 
@@ -101,17 +146,8 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
       context.setNumPartitions(conf.getNumPartitions());
     }
     FailureCollector collector = context.getFailureCollector();
-    Map<String, Schema> inputSchemas = context.getInputSchemas();
-    if (!conf.inputSchemasAvailable(inputSchemas)) {
-      // inputSchemas will be empty if the output schema of a previous node is a macro
-      return;
-    }
-
-    init(inputSchemas, collector);
-    collector.getOrThrowException();
-    Collection<OutputFieldInfo> outputFieldInfos = createOutputFieldInfos(inputSchemas, collector);
-    collector.getOrThrowException();
-    context.record(createFieldOperations(outputFieldInfos, perStageJoinKeys));
+    context.record(createFieldOperations(conf.getSelectedFields(collector),
+                                         conf.getJoinKeys(collector)));
   }
 
   /**
@@ -128,14 +164,15 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
    * For other fields which are not renamed in join, Identity transform is added, while for fields which
    * are renamed Rename transform is added.
    *
-   * @param outputFieldInfos collection of output fields along with information such as stage name, alias
-   * @param perStageJoinKeys join keys
+   * @param outputFields collection of output fields along with information such as stage name, alias
+   * @param joinKeys join keys
    * @return List of field operations
    */
   @VisibleForTesting
-  static List<FieldOperation> createFieldOperations(Collection<OutputFieldInfo> outputFieldInfos,
-                                                    Map<String, List<String>> perStageJoinKeys) {
+  static List<FieldOperation> createFieldOperations(List<JoinField> outputFields, Set<JoinKey> joinKeys) {
     LinkedList<FieldOperation> operations = new LinkedList<>();
+    Map<String, List<String>> perStageJoinKeys = joinKeys.stream()
+      .collect(Collectors.toMap(JoinKey::getStageName, JoinKey::getFields));
 
     // Add JOIN operation
     List<String> joinInputs = new ArrayList<>();
@@ -152,14 +189,15 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
 
     Set<String> outputsSoFar = new HashSet<>(joinOutputs);
 
-    for (OutputFieldInfo outputFieldInfo : outputFieldInfos) {
+    for (JoinField outputField : outputFields) {
       // input field name for the operation will come in from schema if its not outputted so far
-      String stagedInputField = outputsSoFar.contains(outputFieldInfo.inputFieldName) ?
-        outputFieldInfo.inputFieldName : outputFieldInfo.stageName + "." + outputFieldInfo.inputFieldName;
+      String stagedInputField = outputsSoFar.contains(outputField.getFieldName()) ?
+        outputField.getFieldName() : outputField.getStageName() + "." + outputField.getFieldName();
 
-      if (outputFieldInfo.name.equals(outputFieldInfo.inputFieldName)) {
+      String outputFieldName = outputField.getAlias() == null ? outputField.getFieldName() : outputField.getAlias();
+      if (outputField.getFieldName().equals(outputFieldName)) {
         // Record identity transform
-        if (perStageJoinKeys.get(outputFieldInfo.stageName).contains(outputFieldInfo.inputFieldName)) {
+        if (perStageJoinKeys.get(outputField.getStageName()).contains(outputField.getFieldName())) {
           // if the field is part of join key no need to emit the identity transform as it is already taken care
           // by join
           continue;
@@ -167,7 +205,7 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
         String operationName = String.format("Identity %s", stagedInputField);
         FieldOperation identity = new FieldTransformOperation(operationName, IDENTITY_OPERATION_DESCRIPTION,
                                                               Collections.singletonList(stagedInputField),
-                                                              outputFieldInfo.name);
+                                                              outputFieldName);
         operations.add(identity);
         continue;
       }
@@ -176,312 +214,10 @@ public class Joiner extends BatchJoiner<StructuredRecord, StructuredRecord, Stru
 
       FieldOperation transform = new FieldTransformOperation(operationName, RENAME_OPERATION_DESCRIPTION,
                                                              Collections.singletonList(stagedInputField),
-                                                             outputFieldInfo.name);
+                                                             outputFieldName);
       operations.add(transform);
     }
 
     return operations;
-  }
-
-  @Override
-  public void initialize(BatchJoinerRuntimeContext context) {
-    FailureCollector collector = context.getFailureCollector();
-    Map<String, Schema> inputSchemas = context.getInputSchemas();
-    init(inputSchemas, collector);
-    collector.getOrThrowException();
-    outputSchema = getOutputSchema(inputSchemas, collector);
-    collector.getOrThrowException();
-  }
-
-  @Override
-  public StructuredRecord joinOn(String stageName, StructuredRecord record) {
-    Schema keySchema;
-    List<String> joinKeys = perStageJoinKeys.get(stageName);
-
-    if (keySchemas.containsKey(stageName)) {
-      keySchema = keySchemas.get(stageName);
-    } else {
-      List<Schema.Field> fields = new ArrayList<>();
-      Schema schema = record.getSchema();
-
-      int i = 1;
-      for (String joinKey : joinKeys) {
-        Schema.Field field = schema.getField(joinKey);
-        if (field == null) {
-          throw new IllegalArgumentException(String.format("Join key field '%s' does not exist in schema from '%s'.",
-                  joinKey, stageName));
-        }
-        Schema.Field joinField = Schema.Field.of(String.valueOf(i++), field.getSchema());
-        fields.add(joinField);
-      }
-      keySchema = Schema.recordOf("join.key", fields);
-      keySchemas.put(stageName, keySchema);
-    }
-    StructuredRecord.Builder keyRecordBuilder = StructuredRecord.builder(keySchema);
-    int i = 1;
-    for (String joinKey : joinKeys) {
-      keyRecordBuilder.set(String.valueOf(i++), record.get(joinKey));
-    }
-
-    return keyRecordBuilder.build();
-  }
-
-  @Override
-  public JoinConfig getJoinConfig() {
-    return joinConfig;
-  }
-
-  @Override
-  public StructuredRecord merge(StructuredRecord joinKey, Iterable<JoinElement<StructuredRecord>> joinRow) {
-    StructuredRecord.Builder outRecordBuilder = StructuredRecord.builder(outputSchema);
-
-    for (JoinElement<StructuredRecord> joinElement : joinRow) {
-      String stageName = joinElement.getStageName();
-      StructuredRecord record = joinElement.getInputRecord();
-
-      Map<String, String> selectedFields = perStageSelectedFields.row(stageName);
-
-      for (Schema.Field field : Objects.requireNonNull(record.getSchema().getFields())) {
-        String inputFieldName = field.getName();
-
-        // drop the field if not part of fieldsToRename
-        if (!selectedFields.containsKey(inputFieldName)) {
-          continue;
-        }
-
-        String outputFieldName = selectedFields.get(inputFieldName);
-        outRecordBuilder.set(outputFieldName, record.get(inputFieldName));
-      }
-    }
-    return outRecordBuilder.build();
-  }
-
-  @VisibleForTesting
-  FailureCollector init(Map<String, Schema> inputSchemas, FailureCollector failureCollector) {
-    validateJoinKeySchemas(inputSchemas, conf.getPerStageJoinKeys(), failureCollector);
-    joinConfig = new JoinConfig(conf.getInputs());
-    perStageSelectedFields = conf.getPerStageSelectedFields();
-    return failureCollector;
-  }
-
-  private void validateJoinKeySchemas(Map<String, Schema> inputSchemas, Map<String, List<String>> joinKeys,
-                                      FailureCollector collector) {
-    perStageJoinKeys = joinKeys;
-    conf.validateJoinKeySchemas(inputSchemas, joinKeys, collector);
-
-    List<Schema> prevSchemaList = null;
-    for (Map.Entry<String, List<String>> entry : perStageJoinKeys.entrySet()) {
-      ArrayList<Schema> schemaList = new ArrayList<>();
-      String stageName = entry.getKey();
-
-      Schema schema = inputSchemas.get(stageName);
-      if (schema == null) {
-        // Input schema will be null if the output schema of the previous node is a macro
-        return;
-      }
-
-      for (String joinKey : entry.getValue()) {
-        Schema.Field field = schema.getField(joinKey);
-        if (field == null) {
-          collector.addFailure(
-            String.format("Join key field '%s' is not present in input stage of '%s'.", joinKey, stageName), null)
-            .withConfigProperty(JoinerConfig.JOIN_KEYS);
-        }
-        schemaList.add(field.getSchema());
-      }
-      if (prevSchemaList != null && !prevSchemaList.equals(schemaList)) {
-        collector.addFailure(
-          String.format("For stage '%s', Schemas of join keys '%s' are expected to be: '%s', but found: '%s'.",
-                        stageName, entry.getValue(), prevSchemaList.toString(), schemaList.toString()), null)
-          .withConfigProperty(JoinerConfig.JOIN_KEYS);
-      }
-      prevSchemaList = schemaList;
-    }
-  }
-
-  @VisibleForTesting
-  Schema getOutputSchema(Map<String, Schema> inputSchemas, FailureCollector collector) {
-    perStageSelectedFields = conf.getPerStageSelectedFields();
-    List<Schema.Field> outputFields = getOutputFields(createOutputFieldInfos(inputSchemas, collector));
-    if (outputFields.isEmpty()) {
-      // Could not derive output schema from input schema. Try to get output schema from config.
-      return conf.getOutputSchema(collector);
-    } else {
-      return Schema.recordOf("join.output", outputFields);
-    }
-  }
-
-  private Collection<OutputFieldInfo> createOutputFieldInfos(Map<String, Schema> inputSchemas,
-                                                             FailureCollector collector) {
-    validateRequiredInputs(inputSchemas, collector);
-    collector.getOrThrowException();
-
-    // stage name to input schema
-    Map<String, Schema> inputs = new HashMap<>(inputSchemas);
-    // Selected Field name to output field info
-    Map<String, OutputFieldInfo> outputFieldInfo = new LinkedHashMap<>();
-    List<String> duplicateAliases = new ArrayList<>();
-
-    if (!conf.inputSchemasAvailable(inputSchemas)) {
-      // inputSchemas will be empty if the output schema of a previous node is a macro
-      return outputFieldInfo.values();
-    }
-
-    // order of fields in output schema will be same as order of selectedFields
-    Set<Table.Cell<String, String, String>> rows = perStageSelectedFields.cellSet();
-    Multimap<String, String> duplicateFields = ArrayListMultimap.create();
-
-    for (Table.Cell<String, String, String> row : rows) {
-      String stageName = row.getRowKey();
-      String inputFieldName = row.getColumnKey();
-      String alias = row.getValue();
-      Schema inputSchema = inputs.get(stageName);
-
-      if (inputSchema == null) {
-        collector.addFailure(String.format("Input schema for input stage '%s' cannot be null.", stageName), null);
-        throw collector.getOrThrowException();
-      }
-
-      if (outputFieldInfo.containsKey(alias)) {
-        OutputFieldInfo outInfo = outputFieldInfo.get(alias);
-        duplicateAliases.add(alias);
-        duplicateFields.put(outInfo.getStageName(), outInfo.getInputFieldName());
-        continue;
-      }
-
-      Schema.Field inputField = inputSchema.getField(inputFieldName);
-      if (inputField == null) {
-        collector.addFailure(
-          String.format("Field '%s' of stage '%s' must be present in input schema '%s'.",
-                        inputFieldName, stageName, inputSchema), null)
-          .withConfigElement("selectedFields",
-                             String.format("%s.%s as %s", stageName, inputFieldName, alias));
-      } else if (conf.getInputs().contains(stageName) || inputField.getSchema().isNullable()) {
-        outputFieldInfo.put(alias, new OutputFieldInfo(alias, stageName, inputFieldName,
-                                                       Schema.Field.of(alias, inputField.getSchema())));
-      } else {
-        outputFieldInfo.put(alias, new OutputFieldInfo(alias, stageName, inputFieldName,
-                                                       Schema.Field.of(alias,
-                                                                       Schema.nullableOf(inputField.getSchema()))));
-      }
-    }
-
-    if (!duplicateFields.isEmpty()) {
-      collector.addFailure(String.format("Output schema must not contain duplicate fields: '%s' for aliases: '%s'.",
-                                         duplicateFields, duplicateAliases), null)
-        .withConfigProperty(JoinerConfig.SELECTED_FIELDS);
-      collector.getOrThrowException();
-    }
-
-    return outputFieldInfo.values();
-  }
-
-  private List<Schema.Field> getOutputFields(Collection<OutputFieldInfo> fieldsInfo) {
-    List<Schema.Field> outputFields = new ArrayList<>();
-    for (OutputFieldInfo fieldInfo : fieldsInfo) {
-      outputFields.add(fieldInfo.getField());
-    }
-    return outputFields;
-  }
-
-  /**
-   * Class to hold information about output fields
-   */
-  @VisibleForTesting
-  static class OutputFieldInfo {
-    private String name;
-    private String stageName;
-    private String inputFieldName;
-    private Schema.Field field;
-
-    OutputFieldInfo(String name, String stageName, String inputFieldName, Schema.Field field) {
-      this.name = name;
-      this.stageName = stageName;
-      this.inputFieldName = inputFieldName;
-      this.field = field;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public void setName(String name) {
-      this.name = name;
-    }
-
-    public String getStageName() {
-      return stageName;
-    }
-
-    public void setStageName(String stageName) {
-      this.stageName = stageName;
-    }
-
-    public String getInputFieldName() {
-      return inputFieldName;
-    }
-
-    public void setInputFieldName(String inputFieldName) {
-      this.inputFieldName = inputFieldName;
-    }
-
-    public Schema.Field getField() {
-      return field;
-    }
-
-    public void setField(Schema.Field field) {
-      this.field = field;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      OutputFieldInfo that = (OutputFieldInfo) o;
-
-      if (!name.equals(that.name)) {
-        return false;
-      }
-      if (!stageName.equals(that.stageName)) {
-        return false;
-      }
-      if (!inputFieldName.equals(that.inputFieldName)) {
-        return false;
-      }
-      return field.equals(that.field);
-    }
-
-    @Override
-    public int hashCode() {
-      int result = name.hashCode();
-      result = 31 * result + stageName.hashCode();
-      result = 31 * result + inputFieldName.hashCode();
-      result = 31 * result + field.hashCode();
-      return result;
-    }
-
-    @Override
-    public String toString() {
-      return "OutputFieldInfo{" +
-        "name='" + name + '\'' +
-        ", stageName='" + stageName + '\'' +
-        ", inputFieldName='" + inputFieldName + '\'' +
-        ", field=" + field +
-        '}';
-    }
-  }
-
-  private void validateRequiredInputs(Map<String, Schema> inputSchemas, FailureCollector collector) {
-    for (String requiredInput : conf.getInputs()) {
-      if (conf.inputSchemasAvailable(inputSchemas) && !inputSchemas.containsKey(requiredInput)) {
-        collector.addFailure(String.format("Provided input '%s' must be an input stage name.", requiredInput), null)
-          .withConfigElement(JoinerConfig.REQUIRED_INPUTS, requiredInput);
-      }
-    }
   }
 }

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
@@ -19,25 +19,27 @@ package io.cdap.plugin.batch.joiner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Table;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
 import io.cdap.plugin.common.KeyValueListParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -90,6 +92,18 @@ public class JoinerConfig extends PluginConfig {
   @Description(OUTPUT_SCHEMA)
   private String schema;
 
+  @Nullable
+  @Macro
+  @Description("Set of input stages to try to load completely in memory to perform an in-memory join. " +
+    "This is just a hint to the underlying execution engine to try and perform an in-memory join. " +
+    "Whether it is actually loaded into memory is up to the engine. This property is ignored when MapReduce is used.")
+  private String inMemoryInputs;
+
+  @Nullable
+  @Macro
+  @Description("Whether null values in the join key should be joined on. For example, if the join is on A.id = B.id " +
+    "and this value is false, records with a null id from input stages A and B will not get joined together.")
+  private Boolean joinNullKeys;
 
   public JoinerConfig() {
     this.joinKeys = "";
@@ -109,19 +123,6 @@ public class JoinerConfig extends PluginConfig {
     return numPartitions;
   }
 
-  public String getSelectedFields() {
-    return selectedFields;
-  }
-
-  public String getJoinKeys() {
-    return joinKeys;
-  }
-
-  @Nullable
-  public String getRequiredInputs() {
-    return requiredInputs;
-  }
-
   @Nullable
   public Schema getOutputSchema(FailureCollector collector) {
     try {
@@ -138,23 +139,26 @@ public class JoinerConfig extends PluginConfig {
     return !inputSchemas.isEmpty() && inputSchemas.values().stream().noneMatch(Objects::isNull);
   }
 
+  boolean requiredPropertiesContainMacros() {
+    return containsMacro(SELECTED_FIELDS) || containsMacro(REQUIRED_INPUTS) || containsMacro(JOIN_KEYS) ||
+      containsMacro(OUTPUT_SCHEMA);
+  }
 
-  Map<String, List<String>> getPerStageJoinKeys() {
+  Set<JoinKey> getJoinKeys(FailureCollector failureCollector) {
     // Use a LinkedHashMap to maintain the ordering as the input config.
     // This helps making error report deterministic.
     Map<String, List<String>> stageToKey = new LinkedHashMap<>();
-    if (containsMacro(JoinerConfig.JOIN_KEYS)) {
-      return stageToKey;
-    }
 
     if (Strings.isNullOrEmpty(joinKeys)) {
-      throw new IllegalArgumentException("Join keys can not be empty");
+      failureCollector.addFailure("Join keys cannot be empty", null).withConfigProperty(JOIN_KEYS);
+      throw failureCollector.getOrThrowException();
     }
 
     Iterable<String> multipleJoinKeys = Splitter.on('&').trimResults().omitEmptyStrings().split(joinKeys);
 
     if (Iterables.isEmpty(multipleJoinKeys)) {
-      throw new IllegalArgumentException("Join keys can not be empty.");
+      failureCollector.addFailure("Join keys cannot be empty", null).withConfigProperty(JOIN_KEYS);
+      throw failureCollector.getOrThrowException();
     }
 
     int numJoinKeys = 0;
@@ -164,32 +168,33 @@ public class JoinerConfig extends PluginConfig {
       if (numJoinKeys == 0) {
         numJoinKeys = Iterables.size(keyValues);
       } else if (numJoinKeys != Iterables.size(keyValues)) {
-        throw new IllegalArgumentException("There should be one join key from each of the stages. Please add join " +
-                                             "keys for each stage.");
+        failureCollector.addFailure("There should be one join key from each of the stages",
+                                    "Please add join keys for each stage.")
+          .withConfigProperty(JOIN_KEYS);
+        throw failureCollector.getOrThrowException();
       }
       for (KeyValue<String, String> keyValue : keyValues) {
         String stageName = keyValue.getKey();
         String joinKey = keyValue.getValue();
         if (!stageToKey.containsKey(stageName)) {
-          stageToKey.put(stageName, new ArrayList<String>());
+          stageToKey.put(stageName, new ArrayList<>());
         }
         stageToKey.get(stageName).add(joinKey);
       }
     }
-    return stageToKey;
+
+    return stageToKey.entrySet().stream()
+      .map(entry -> new JoinKey(entry.getKey(), entry.getValue()))
+      .collect(Collectors.toSet());
   }
 
-  Table<String, String, String> getPerStageSelectedFields() {
-    // table to store <stageName, oldFieldName, alias>
-    ImmutableTable.Builder<String, String, String> tableBuilder = new ImmutableTable.Builder<>();
-    if (containsMacro(JoinerConfig.SELECTED_FIELDS)) {
-      return tableBuilder.build();
-    }
-
-
+  List<JoinField> getSelectedFields(FailureCollector failureCollector) {
     if (Strings.isNullOrEmpty(selectedFields)) {
-      throw new IllegalArgumentException("selectedFields can not be empty. Please provide at least 1 selectedFields");
+      failureCollector.addFailure("Must select at least one field", null).withConfigProperty(SELECTED_FIELDS);
+      throw failureCollector.getOrThrowException();
     }
+
+    List<JoinField> selectedJoinFields = new ArrayList<>();
 
     for (String selectedField : Splitter.on(',').trimResults().omitEmptyStrings().split(selectedFields)) {
       Iterable<String> stageOldNameAliasPair = Splitter.on(" as ").trimResults().omitEmptyStrings()
@@ -198,41 +203,45 @@ public class JoinerConfig extends PluginConfig {
         split(Iterables.get(stageOldNameAliasPair, 0));
 
       if (Iterables.size(stageOldNamePair) != 2) {
-        throw new IllegalArgumentException(String.format("Invalid syntax. Selected Fields must be of syntax " +
-                                                           "<stageName>.<oldFieldName> as <alias>, but found %s",
-                                                         selectedField));
+        failureCollector.addFailure(String.format("Invalid syntax. Selected Fields must be of syntax " +
+                                                    "<stageName>.<oldFieldName> as <alias>, but found %s",
+                                                  selectedField), null)
+          .withConfigProperty(SELECTED_FIELDS);
+        continue;
       }
 
       String stageName = Iterables.get(stageOldNamePair, 0);
       String oldFieldName = Iterables.get(stageOldNamePair, 1);
 
       // if alias is not present in selected fields, use original field name as alias
-      String alias = isAliasPresent(stageOldNameAliasPair) ? oldFieldName : Iterables.get(stageOldNameAliasPair, 1);
-      tableBuilder.put(stageName, oldFieldName, alias);
+      String alias = Iterables.size(stageOldNameAliasPair) == 1 ?
+        oldFieldName : Iterables.get(stageOldNameAliasPair, 1);
+      selectedJoinFields.add(new JoinField(stageName, oldFieldName, alias));
     }
-    return tableBuilder.build();
+    failureCollector.getOrThrowException();
+    return selectedJoinFields;
   }
 
-  private boolean isAliasPresent(Iterable<String> stageOldNameAliasPair) {
-    return Iterables.size(stageOldNameAliasPair) == 1;
+  Set<String> getRequiredInputs() {
+    return getSet(requiredInputs);
   }
 
-  Set<String> getInputs() {
-    if (!Strings.isNullOrEmpty(requiredInputs) && !containsMacro(JoinerConfig.REQUIRED_INPUTS)) {
-      return ImmutableSet.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().split(requiredInputs));
-    }
-    return ImmutableSet.of();
+  Set<String> getBroadcastInputs() {
+    return getSet(inMemoryInputs);
   }
 
-  void validateJoinKeySchemas(Map<String, Schema> inputSchemas, Map<String, List<String>> joinKeys,
-                              FailureCollector collector) {
-    // Skip validation if joinKeys is a macro, or if any input's output schema is a macro.
-    if (!containsMacro(JoinerConfig.JOIN_KEYS) &&
-      inputSchemasAvailable(inputSchemas) &&
-      joinKeys.size() != inputSchemas.size()) {
-      collector.addFailure("There should be join keys present from each stage.",
-                           "Ensure join keys are present from each stage.")
-        .withConfigProperty(JoinerConfig.JOIN_KEYS);
+  boolean isNullSafe() {
+    return joinNullKeys == null ? true : joinNullKeys;
+  }
+
+  private Set<String> getSet(String strVal) {
+    if (strVal == null || strVal.isEmpty()) {
+      return Collections.emptySet();
     }
+    Set<String> set = new HashSet<>();
+    for (String val : Splitter.on(",").trimResults().omitEmptyStrings().split(strVal)) {
+      set.add(val);
+    }
+    return set;
   }
 }

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinFieldLineageTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinFieldLineageTest.java
@@ -16,7 +16,8 @@
 
 package io.cdap.plugin.batch.joiner;
 
-import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import org.junit.Assert;
@@ -25,9 +26,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -42,15 +43,13 @@ public class JoinFieldLineageTest {
     //                              |
     //  purchase -> (customer_id)---
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id", "customer", "id"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     FieldOperation operation = new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
                                                            Arrays.asList("customer.id", "purchase.customer_id"),
                                                            Arrays.asList("id", "customer_id"));
@@ -67,19 +66,15 @@ public class JoinFieldLineageTest {
     //  purchase ->(customer_id, item)---
 
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("name", "customer", "name",
-                                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("item", "purchase", "item",
-                                                    Schema.Field.of("item", Schema.of(Schema.Type.STRING))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id", "customer", "id"));
+    outputFieldInfos.add(new JoinField("name", "customer", "name"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    outputFieldInfos.add(new JoinField("item", "purchase", "item"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     List<FieldOperation> expected = new ArrayList<>();
 
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
@@ -102,16 +97,14 @@ public class JoinFieldLineageTest {
     //                                  |
     //  purchase ->(customer_id, item)---
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_customer", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_purchase", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id_from_customer", "customer", "id"));
+    outputFieldInfos.add(new JoinField("id_from_purchase", "purchase", "customer_id"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
 
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
 
     List<FieldOperation> expected = new ArrayList<>();
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
@@ -133,19 +126,15 @@ public class JoinFieldLineageTest {
     //                                JOIN  --->(id_from_customer, customer_id, name_from_customer, item_from_purchase)
     //                                  |
     //  purchase ->(customer_id, item)---
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_customer", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("name_from_customer", "customer", "name",
-                                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("item_from_purchase", "purchase", "item",
-                                                    Schema.Field.of("item", Schema.of(Schema.Type.STRING))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id_from_customer", "customer", "id"));
+    outputFieldInfos.add(new JoinField("name_from_customer", "customer", "name"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    outputFieldInfos.add(new JoinField("item_from_purchase", "purchase", "item"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     List<FieldOperation> expected = new ArrayList<>();
 
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
@@ -172,22 +161,17 @@ public class JoinFieldLineageTest {
     //                                  |
     // address ->(address_id, address)--|
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_customer", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("name_from_customer", "customer", "name",
-                                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("address_id", "address", "address_id",
-                                                    Schema.Field.of("address_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("address", "address", "address",
-                                                    Schema.Field.of("address", Schema.of(Schema.Type.STRING))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    perStageJoinKeys.put("address", Collections.singletonList("address_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id_from_customer", "customer", "id"));
+    outputFieldInfos.add(new JoinField("name_from_customer", "customer", "name"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    outputFieldInfos.add(new JoinField("address_id", "address", "address_id"));
+    outputFieldInfos.add(new JoinField("address", "address", "address"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    joinKeys.add(new JoinKey("address", Collections.singletonList("address_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     List<FieldOperation> expected = new ArrayList<>();
 
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerConfigTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerConfigTest.java
@@ -16,21 +16,29 @@
 
 package io.cdap.plugin.batch.joiner;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableTable;
-import com.google.common.collect.Table;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.ValidationException;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.api.validation.ValidationFailure.Cause;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Test cases for {@link JoinerConfig}.
@@ -64,6 +72,11 @@ public class JoinerConfigTest {
   private static final String SELECTED_FIELDS = "film.film_id, film.film_name, " +
     "filmActor.actor_name as renamed_actor, filmCategory.category_name as renamed_category";
 
+  private static final Map<String, JoinStage> INPUT_STAGES = ImmutableMap.of(
+    "film", JoinStage.builder("film", FILM_SCHEMA).build(),
+    "filmActor", JoinStage.builder("filmActor", FILM_ACTOR_SCHEMA).build(),
+    "filmCategory", JoinStage.builder("filmCategory", FILM_CATEGORY_SCHEMA).build());
+
   private static final String STAGE = "stage";
   private static final String MOCK_STAGE = "mockstage";
 
@@ -74,12 +87,11 @@ public class JoinerConfigTest {
                                            SELECTED_FIELDS, "film,filmActor,filmCategory");
 
     Joiner joiner = new Joiner(config);
-    Map<String, Schema> inputSchemas = ImmutableMap.of("film", FILM_SCHEMA, "filmActor", FILM_ACTOR_SCHEMA,
-                                                       "filmCategory", FILM_CATEGORY_SCHEMA);
     FailureCollector collector = new MockFailureCollector();
-    joiner.init(inputSchemas, collector);
-    Schema actualOutputSchema = joiner.getOutputSchema(inputSchemas, collector);
-    Assert.assertEquals(OUTPUT_SCHEMA, actualOutputSchema);
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+
+    JoinDefinition joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertEquals(OUTPUT_SCHEMA, joinDefinition.getOutputSchema());
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
@@ -89,10 +101,11 @@ public class JoinerConfigTest {
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            SELECTED_FIELDS, "film,filmActor,filmCategory");
 
-    Assert.assertEquals(ImmutableMap.of("film", ImmutableList.of("film_id", "film_name"),
-                                        "filmActor", ImmutableList.of("film_id", "film_name"),
-                                        "filmCategory", ImmutableList.of("film_id", "film_name")),
-                        config.getPerStageJoinKeys());
+    Set<JoinKey> expected = new HashSet<>(Arrays.asList(
+      new JoinKey("film", Arrays.asList("film_id", "film_name")),
+      new JoinKey("filmActor", Arrays.asList("film_id", "film_name")),
+      new JoinKey("filmCategory", Arrays.asList("film_id", "film_name"))));
+    Assert.assertEquals(expected, config.getJoinKeys(new MockFailureCollector()));
   }
 
   @Test
@@ -100,7 +113,7 @@ public class JoinerConfigTest {
     JoinerConfig config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            SELECTED_FIELDS, "film,filmActor,filmCategory");
-    Assert.assertEquals(ImmutableSet.of("film", "filmActor", "filmCategory"), config.getInputs());
+    Assert.assertEquals(ImmutableSet.of("film", "filmActor", "filmCategory"), config.getRequiredInputs());
   }
 
   @Test
@@ -108,18 +121,25 @@ public class JoinerConfigTest {
     JoinerConfig config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            SELECTED_FIELDS, "film,filmActor,filmCategory");
-    ImmutableTable.Builder<String, String, String> expected =  new ImmutableTable.Builder<>();
-    expected.put("film", "film_id", "film_id");
-    expected.put("film", "film_name", "film_name");
-    expected.put("filmActor", "actor_name", "renamed_actor");
-    expected.put("filmCategory", "category_name", "renamed_category");
-    Assert.assertEquals(expected.build(), config.getPerStageSelectedFields());
+    List<JoinField> expected = Arrays.asList(
+      new JoinField("film", "film_id", "film_id"),
+      new JoinField("film", "film_name", "film_name"),
+      new JoinField("filmActor", "actor_name", "renamed_actor"),
+      new JoinField("filmCategory", "category_name", "renamed_category"));
+    Assert.assertEquals(expected, config.getSelectedFields(new MockFailureCollector()));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testJoinerConfigWithoutJoinKeys() {
     JoinerConfig config = new JoinerConfig("", SELECTED_FIELDS, "film,filmActor,filmCategory");
-    config.getPerStageJoinKeys();
+    MockFailureCollector failureCollector = new MockFailureCollector();
+    try {
+      config.getJoinKeys(failureCollector);
+    } catch (ValidationException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      ValidationFailure failure = e.getFailures().get(0);
+      Assert.assertEquals(1, failure.getCauses().size());
+    }
   }
 
   @Test
@@ -137,30 +157,46 @@ public class JoinerConfigTest {
                                            SELECTED_FIELDS, "film");
 
     Joiner joiner = new Joiner(config);
-    Map<String, Schema> inputSchemas = ImmutableMap.of("film", FILM_SCHEMA, "filmActor", FILM_ACTOR_SCHEMA,
-                                                       "filmCategory", FILM_CATEGORY_SCHEMA);
     FailureCollector collector = new MockFailureCollector();
-    joiner.init(inputSchemas, collector);
-    Schema actualOutputSchema = joiner.getOutputSchema(inputSchemas, collector);
-    Assert.assertEquals(outputSchema, actualOutputSchema);
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+    JoinDefinition joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertEquals(outputSchema, joinDefinition.getOutputSchema());
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testJoinerConfigWithoutSelectedFields() {
     JoinerConfig config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
                                              "film.film_name=filmActor.film_name=filmCategory.film_name", "",
                                            "film,filmActor,filmCategory");
-
-    config.getPerStageSelectedFields();
+    FailureCollector failureCollector = new MockFailureCollector();
+    try {
+      config.getSelectedFields(failureCollector);
+    } catch (ValidationException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      ValidationFailure failure = e.getFailures().get(0);
+      Assert.assertEquals(1, failure.getCauses().size());
+      Cause cause = failure.getCauses().get(0);
+      Assert.assertEquals(JoinerConfig.SELECTED_FIELDS, cause.getAttribute(CauseAttributes.STAGE_CONFIG));
+    }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testJoinerConfigWithWrongJoinKeys() {
     JoinerConfig config = new JoinerConfig("film.film_id=filmCategory.film_id&" +
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            SELECTED_FIELDS, "film,filmActor,filmCategory");
-    config.getPerStageJoinKeys();
+    FailureCollector failureCollector = new MockFailureCollector();
+    try {
+      config.getJoinKeys(failureCollector);
+      Assert.fail();
+    } catch (ValidationException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      ValidationFailure failure = e.getFailures().get(0);
+      Assert.assertEquals(1, failure.getCauses().size());
+      ValidationFailure.Cause cause = failure.getCauses().get(0);
+      Assert.assertEquals(JoinerConfig.JOIN_KEYS, cause.getAttribute(CauseAttributes.STAGE_CONFIG));
+    }
   }
 
   @Test
@@ -172,15 +208,14 @@ public class JoinerConfigTest {
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            selectedFields, "film,filmActor,filmCategory");
 
-    Table<String, String, String> actual = config.getPerStageSelectedFields();
-    ImmutableTable.Builder<String, String, String> tableBuilder = new ImmutableTable.Builder<>();
-    tableBuilder.put("film", "film_id", "film_id");
-    tableBuilder.put("film", "film_name", "film_name");
-    tableBuilder.put("filmActor", "actor_name", "renamed_actor");
-    tableBuilder.put("filmCategory", "category_name", "renamed_category");
-    Table<String, String, String> expected = tableBuilder.build();
+    FailureCollector failureCollector = new MockFailureCollector();
+    List<JoinField> actual = config.getSelectedFields(failureCollector);
+    List<JoinField> expected = Arrays.asList(
+      new JoinField("film", "film_id", "film_id"),
+      new JoinField("film", "film_name", "film_name"),
+      new JoinField("filmActor", "actor_name", "renamed_actor"),
+      new JoinField("filmCategory", "category_name", "renamed_category"));
     Assert.assertEquals(expected, actual);
-
   }
 
   @Test
@@ -192,12 +227,10 @@ public class JoinerConfigTest {
                                              "film.film_name=filmActor.film_name=filmCategory.film_name",
                                            selectedFields, "film,filmActor,filmCategory");
     Joiner joiner = new Joiner(config);
-    Map<String, Schema> inputSchemas = ImmutableMap.of("film", FILM_SCHEMA, "filmActor", FILM_ACTOR_SCHEMA,
-                                                       "filmCategory", FILM_CATEGORY_SCHEMA);
     FailureCollector collector = new MockFailureCollector();
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
     try {
-      joiner.init(inputSchemas, collector);
-      joiner.getOutputSchema(inputSchemas, collector);
+      joiner.define(autoJoinerContext);
       Assert.fail();
     } catch (ValidationException e) {
       Assert.assertEquals(1, e.getFailures().size());
@@ -205,6 +238,7 @@ public class JoinerConfigTest {
       Cause expectedCause = new Cause();
       expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, JoinerConfig.SELECTED_FIELDS);
       expectedCause.addAttribute(STAGE, MOCK_STAGE);
+      expectedCause.addAttribute(CauseAttributes.CONFIG_ELEMENT, "filmCategory.category_name as name");
       Assert.assertEquals(expectedCause, e.getFailures().get(0).getCauses().get(0));
     }
   }
@@ -226,13 +260,22 @@ public class JoinerConfigTest {
 
     Joiner joiner = new Joiner(config);
     FailureCollector collector = new MockFailureCollector();
-    joiner.init(ImmutableMap.of("film", FILM_SCHEMA, "filmActor", FILM_ACTOR_SCHEMA,
-                                "filmCategory", filmCategorySchema), collector);
-    Assert.assertEquals(1, collector.getValidationFailures().size());
-    Assert.assertEquals(1, collector.getValidationFailures().get(0).getCauses().size());
-    Cause expectedCause = new Cause();
-    expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, JoinerConfig.JOIN_KEYS);
-    Assert.assertEquals(expectedCause, collector.getValidationFailures().get(0).getCauses().get(0));
+    Map<String, JoinStage> inputStages = new HashMap<>();
+    inputStages.put("film", JoinStage.builder("film", FILM_SCHEMA).build());
+    inputStages.put("filmActor", JoinStage.builder("filmActor", FILM_ACTOR_SCHEMA).build());
+    inputStages.put("fileCategory", JoinStage.builder("filmCategory", filmCategorySchema).build());
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(inputStages, collector);
+    try {
+      joiner.define(autoJoinerContext);
+    } catch (ValidationException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      Assert.assertEquals(1, e.getFailures().get(0).getCauses().size());
+      Cause expectedCause = new Cause();
+      expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, JoinerConfig.JOIN_KEYS);
+      expectedCause.addAttribute("stage", "mockstage");
+      Assert.assertEquals(JoinerConfig.JOIN_KEYS,
+                          e.getFailures().get(0).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+    }
   }
 
   @Test
@@ -247,8 +290,9 @@ public class JoinerConfigTest {
 
     Joiner joiner = new Joiner(joinerConfig);
     FailureCollector collector = new MockFailureCollector();
-    joiner.init(inputSchemas, collector);
-    Assert.assertEquals(OUTPUT_SCHEMA, joiner.getOutputSchema(inputSchemas, collector));
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+    JoinDefinition joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertEquals(OUTPUT_SCHEMA, joinDefinition.getOutputSchema());
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
@@ -261,9 +305,6 @@ public class JoinerConfigTest {
       Schema.Field.of("film_name", Schema.of(Schema.Type.STRING)),
       Schema.Field.of("category_name", Schema.of(Schema.Type.STRING)));
 
-    Map<String, Schema> inputSchemas = ImmutableMap.of("film", FILM_SCHEMA, "filmActor", FILM_ACTOR_SCHEMA,
-                                                       "filmCategory", filmCategorySchema);
-
     String joinKeys = "film.film_id=filmActor.film_id=filmCategory.film_id";
     String selectedFields = "film.film_id, film.film_name, filmActor.actor_name as renamed_actor, " +
       "filmCategory.category_name as renamed_category";
@@ -272,9 +313,13 @@ public class JoinerConfigTest {
 
     Joiner joiner = new Joiner(config);
     FailureCollector collector = new MockFailureCollector();
+    Map<String, JoinStage> inputStages = new HashMap<>();
+    inputStages.put("film", JoinStage.builder("film", FILM_SCHEMA).build());
+    inputStages.put("filmActor", JoinStage.builder("filmActor", FILM_ACTOR_SCHEMA).build());
+    inputStages.put("filmCategory", JoinStage.builder("filmCategory", filmCategorySchema).build());
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(inputStages, collector);
     try {
-      joiner.init(inputSchemas, collector);
-      joiner.getOutputSchema(inputSchemas, collector);
+      joiner.define(autoJoinerContext);
       Assert.fail();
     } catch (ValidationException e) {
       Assert.assertEquals(1, e.getFailures().get(0).getCauses().size());
@@ -310,8 +355,9 @@ public class JoinerConfigTest {
 
     Joiner joiner = new Joiner(conf);
     FailureCollector collector = new MockFailureCollector();
-    joiner.init(inputSchemas, collector);
-    Assert.assertEquals(outputSchema, joiner.getOutputSchema(inputSchemas, collector));
+    AutoJoinerContext autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+    JoinDefinition joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertEquals(outputSchema, joinDefinition.getOutputSchema());
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerTestRun.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerTestRun.java
@@ -113,7 +113,6 @@ public class JoinerTestRun extends ETLBatchTestBase {
     verifyOutput.apply(outputSchema, fileSet);
   }
 
-
   @Test
   public void testInnerJoin() throws Exception {
     String filmDatasetName = "film-innerjoin";
@@ -154,7 +153,6 @@ public class JoinerTestRun extends ETLBatchTestBase {
     joinHelper(filmStage, filmActorStage, filmCategoryStage, joinStage, joinSinkStage,
                filmDatasetName, filmActorDatasetName, filmCategoryDatasetName, joinedDatasetName,
                outputSchema, this::verifyInnerJoinOutput, ImmutableMap.of());
-
   }
 
   @Test

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/MockAutoJoinerContext.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/MockAutoJoinerContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.batch.joiner;
+
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinStage;
+
+import java.util.Map;
+
+/**
+ * Mock AutoJoiner context.
+ */
+public class MockAutoJoinerContext implements AutoJoinerContext {
+  private final Map<String, JoinStage> inputStages;
+  private final FailureCollector failureCollector;
+
+  public MockAutoJoinerContext(Map<String, JoinStage> inputStages, FailureCollector failureCollector) {
+    this.inputStages = inputStages;
+    this.failureCollector = failureCollector;
+  }
+
+  @Override
+  public Map<String, JoinStage> getInputStages() {
+    return inputStages;
+  }
+
+  @Override
+  public FailureCollector getFailureCollector() {
+    return failureCollector;
+  }
+}

--- a/core-plugins/widgets/Joiner-batchjoiner.json
+++ b/core-plugins/widgets/Joiner-batchjoiner.json
@@ -7,7 +7,7 @@
   },
   "configuration-groups": [
     {
-      "label": "Join",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "sql-select-fields",
@@ -28,19 +28,39 @@
           "description": "List of join keys to perform join operation."
         },
         {
+          "widget-type": "get-schema",
+          "widget-category": "plugin"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Inputs to Load in Memory",
+          "name": "inMemoryInputs"
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Join on Null Keys",
+          "name": "joinNullKeys",
+          "widget-attributes": {
+            "default": "true",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Number of Partitions",
-          "name": "numPartitions",
-          "plugin-function": {
-            "method": "POST",
-            "label": "Generate Schema",
-            "widget": "outputSchema",
-            "output-property": "schema",
-            "plugin-method": "outputSchema",
-            "position": "bottom",
-            "multiple-inputs": true,
-            "button-class": "btn-hydrator"
-          }
+          "name": "numPartitions"
         }
       ]
     }
@@ -50,6 +70,5 @@
       "name": "schema",
       "widget-type": "schema"
     }
-
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
     <commons-lang-version>2.6</commons-lang-version>
-    <cdap.version>6.1.2</cdap.version>
+    <cdap.version>6.1.3-SNAPSHOT</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
     <es.version>1.6.0</es.version>
@@ -678,8 +678,8 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[6.1.2,7.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[6.1.2,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.1.3-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-streams[6.1.3-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>


### PR DESCRIPTION
Changed the joiner to use the new AutoJoiner API to take
advantage of the performance improvements it allows in Spark
pipelines.

Introduced two new optional properties. The first determines
whether the join will use null safe equality, and the second
provides hint to the execution engine about which input datasets
should be broadcast to perform an in-memory join.

Removed much of the existing join logic because it has been moved
into the application code. Updated the documentation to use
the property names that show up in the UI, to display the properties
in the same order that they appear in the UI, and to include
descriptions of the two new properties.