### PR TITLE
CDAP-16875 changed joiner plugin to use new auto-join API

### DIFF
--- a/core-plugins/docs/Joiner-batchjoiner.md
+++ b/core-plugins/docs/Joiner-batchjoiner.md
@@ -1,49 +1,90 @@
 # Joiner
 
-
 Description
 -----------
-Joins records from one or more input based on join keys. Supports `inner` and `outer` joins, selection and renaming of output fields.  
-
-Use Case
---------
-The transform is used when you want to combine fields from one or more input, similar to the joins in SQL.
+Joins records from one or more input based on join key equality.
+Supports `inner` and `outer` joins, selection and renaming of output fields.
+The plugin is used when you want to combine fields from one or more inputs, similar to joins in SQL.
 
 Properties
 ----------
-**joinKeys:** List of keys to perform the join operation. The list is separated by `&`. 
+**Fields:** List of fields from each input that should be included in the output. 
+Output field names must be unique. If the same field name exists in more than one input,
+each field must be aliased (renamed) to a unique output name.
+
+**Join Type:** Type of join to perform.
+A join between two required input is an inner join. A join between a required input and an optional
+input is a left outer join. A join between two optional inputs is an outer join.
+
+A join of more than two inputs is logically equivalent to performing inner joins over all the
+required inputs, followed by left outer joins on the optional inputs.
+
+**Join Condition:** List of keys to perform the join operation. The list is separated by `&`. 
 Join key from each input stage will be prefixed with `<stageName>.` and the relation among join keys from different inputs is represented by `=`. 
 For example: customers.customer_id=items.c_id&customers.customer_name=items.c_name means the join key is a composite key
 of customer id and customer name from customers and items input stages and join will be performed on equality 
 of the join keys. This transform only supports equality for joins.
 
-**selectedFields:** Comma-separated list of fields to be selected and renamed in join output from each input stage. 
-Each selected field that should be present in the output must be prefixed with '<input_stage_name>'. 
-The syntax for specifying alias for each selected field is similar to sql. 
-For example: customers.id as customer_id, customer.name as customer_name, item.id as item_id, <stageName>.inputFieldName as alias. 
-The output will have same order of fields as selected in selectedFields. There must not be any duplicate fields in output.
+**Inputs to Load in Memory:** Hint to the underlying execution engine that the specified input data should be
+loaded into memory to perform an in-memory join. This is ignored by the MapReduce engine and passed onto the Spark engine.
+An in-memory join performs well when one side of the join is small (for example, under 1gb). Be sure to set
+Spark executor memory to a number large enough to load all of these datasets into memory. This is most commonly
+used when a large input is being joined to a small input and will lead to much better performance in such scenarios.
 
-**requiredInputs:** Comma-separated list of stages. Required input stages decide the type of the join. 
-If all the input stages are present in required inputs, inner join will be performed. 
-Otherwise, outer join will be performed considering non-required inputs as optional.
+**Join on Null Keys:** Whether to join rows together if both of their key values are null.
+For example, suppose the join is on a 'purchases' input that contains:
 
-**numPartitions:** Number of partitions to use when grouping fields. If not specified, the execution
+| purchase_id | customer_name | item   |
+| ----------- | ------------- | ------ |
+| 1           | alice         | donut  |
+| 2           |               | coffee | 
+| 3           | bob           | water  |
+
+and a 'customers' input that contains:
+
+| customer_id | name   |
+| ----------- | ------ |
+| 1           | alice  |
+| 2           |        |
+| 3           | bob    |
+
+The join is a left outer join on purchases.customer_name = customers.name.
+If this property is set to true, the joined output would be:
+
+| purchase_id | customer_name | item   | customer_id | name  |
+| ----------- | ------------- | ------ | ----------- | ----- |
+| 1           | alice         | donut  | 1           | alice |
+| 2           |               | coffee | 2           |       |
+| 3           | bob           | water  | 3           | bob   |
+
+Note that the rows with a null customer name were joined together, with customer_id set to 2 for purchase 2.
+If this property is set to false, the joined output would be:
+
+| purchase_id | customer_name | item   | customer_id | name  |
+| ----------- | ------------- | ------ | ----------- | ----- |
+| 1           | alice         | donut  | 1           | alice |
+| 2           |               | coffee |             |       |
+| 3           | bob           | water  | 3           | bob   |
+
+In this scenario, the null customer name on the left did not get joined to the null customer name on the right.
+Traditional relational database systems do not join on null key values.
+In most situations, you will want to do the same and set this to false. 
+Setting it to true can cause a large drop in performance if there are a lot of null keys in your input data.
+
+**Number of Partitions:** Number of partitions to use when grouping fields. If not specified, the execution
 framework will decide on the number to use.
 
 Example
 -------
-This example inner joins records from ``customers`` and ``purchases`` inputs on customer id and selects customer_id, name, item and price fields.
+This example performs an inner join on records from ``customers`` and ``purchases`` inputs
+ on customer id. It selects customer_id, name, item and price fields as the output fields.
+This is equivalent to a SQL query like:
 
-```json
-    {
-        "name": "Joiner",
-        "type": "batchjoiner",
-        "properties": {
-            "selectedFields": "customers.id as customer_id,customers.first_name as name,purchases.item,purchases.price",
-            "requiredInputs": "customers, purchases",
-            "joinKeys": "customers.id = purchases.customer_id"
-        }
-    }
+```
+SELECT customes.id as customer_id, customers.first_name as name, purchases.item, purchases.price
+FROM customers 
+INNER JOIN purchases
+ON customers.id = purchases.customer_id
 ```
 
 For example, suppose the joiner receives input records from customers and purchases as below:
@@ -78,4 +119,3 @@ Output records will contain inner join on customer id:
 | 2           | David   | plate  | 0.50  |
 | 3           | Hugh    | tea    | 1.99  |
 | 5           | Frank   | cookie | 0.50  |
-

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinFieldLineageTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinFieldLineageTest.java
@@ -16,7 +16,8 @@
 
 package io.cdap.plugin.batch.joiner;
 
-import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import org.junit.Assert;
@@ -25,9 +26,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -42,15 +43,13 @@ public class JoinFieldLineageTest {
     //                              |
     //  purchase -> (customer_id)---
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id", "customer", "id"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     FieldOperation operation = new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
                                                            Arrays.asList("customer.id", "purchase.customer_id"),
                                                            Arrays.asList("id", "customer_id"));
@@ -67,19 +66,15 @@ public class JoinFieldLineageTest {
     //  purchase ->(customer_id, item)---
 
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("name", "customer", "name",
-                                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("item", "purchase", "item",
-                                                    Schema.Field.of("item", Schema.of(Schema.Type.STRING))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id", "customer", "id"));
+    outputFieldInfos.add(new JoinField("name", "customer", "name"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    outputFieldInfos.add(new JoinField("item", "purchase", "item"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     List<FieldOperation> expected = new ArrayList<>();
 
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
@@ -102,16 +97,14 @@ public class JoinFieldLineageTest {
     //                                  |
     //  purchase ->(customer_id, item)---
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_customer", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_purchase", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id_from_customer", "customer", "id"));
+    outputFieldInfos.add(new JoinField("id_from_purchase", "purchase", "customer_id"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
 
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
 
     List<FieldOperation> expected = new ArrayList<>();
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
@@ -133,19 +126,15 @@ public class JoinFieldLineageTest {
     //                                JOIN  --->(id_from_customer, customer_id, name_from_customer, item_from_purchase)
     //                                  |
     //  purchase ->(customer_id, item)---
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_customer", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("name_from_customer", "customer", "name",
-                                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("item_from_purchase", "purchase", "item",
-                                                    Schema.Field.of("item", Schema.of(Schema.Type.STRING))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id_from_customer", "customer", "id"));
+    outputFieldInfos.add(new JoinField("name_from_customer", "customer", "name"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    outputFieldInfos.add(new JoinField("item_from_purchase", "purchase", "item"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     List<FieldOperation> expected = new ArrayList<>();
 
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,
@@ -172,22 +161,17 @@ public class JoinFieldLineageTest {
     //                                  |
     // address ->(address_id, address)--|
 
-    List<Joiner.OutputFieldInfo> outputFieldInfos = new ArrayList<>();
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("id_from_customer", "customer", "id",
-                                                    Schema.Field.of("id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("name_from_customer", "customer", "name",
-                                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("customer_id", "purchase", "customer_id",
-                                                    Schema.Field.of("customer_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("address_id", "address", "address_id",
-                                                    Schema.Field.of("address_id", Schema.of(Schema.Type.INT))));
-    outputFieldInfos.add(new Joiner.OutputFieldInfo("address", "address", "address",
-                                                    Schema.Field.of("address", Schema.of(Schema.Type.STRING))));
-    Map<String, List<String>> perStageJoinKeys = new LinkedHashMap<>();
-    perStageJoinKeys.put("customer", Collections.singletonList("id"));
-    perStageJoinKeys.put("purchase", Collections.singletonList("customer_id"));
-    perStageJoinKeys.put("address", Collections.singletonList("address_id"));
-    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, perStageJoinKeys);
+    List<JoinField> outputFieldInfos = new ArrayList<>();
+    outputFieldInfos.add(new JoinField("id_from_customer", "customer", "id"));
+    outputFieldInfos.add(new JoinField("name_from_customer", "customer", "name"));
+    outputFieldInfos.add(new JoinField("customer_id", "purchase", "customer_id"));
+    outputFieldInfos.add(new JoinField("address_id", "address", "address_id"));
+    outputFieldInfos.add(new JoinField("address", "address", "address"));
+    Set<JoinKey> joinKeys = new HashSet<>();
+    joinKeys.add(new JoinKey("customer", Collections.singletonList("id")));
+    joinKeys.add(new JoinKey("purchase", Collections.singletonList("customer_id")));
+    joinKeys.add(new JoinKey("address", Collections.singletonList("address_id")));
+    List<FieldOperation> fieldOperations = Joiner.createFieldOperations(outputFieldInfos, joinKeys);
     List<FieldOperation> expected = new ArrayList<>();
 
     expected.add(new FieldTransformOperation("Join", Joiner.JOIN_OPERATION_DESCRIPTION,

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerTestRun.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerTestRun.java
@@ -113,7 +113,6 @@ public class JoinerTestRun extends ETLBatchTestBase {
     verifyOutput.apply(outputSchema, fileSet);
   }
 
-
   @Test
   public void testInnerJoin() throws Exception {
     String filmDatasetName = "film-innerjoin";
@@ -154,7 +153,6 @@ public class JoinerTestRun extends ETLBatchTestBase {
     joinHelper(filmStage, filmActorStage, filmCategoryStage, joinStage, joinSinkStage,
                filmDatasetName, filmActorDatasetName, filmCategoryDatasetName, joinedDatasetName,
                outputSchema, this::verifyInnerJoinOutput, ImmutableMap.of());
-
   }
 
   @Test

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/MockAutoJoinerContext.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/MockAutoJoinerContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.batch.joiner;
+
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinStage;
+
+import java.util.Map;
+
+/**
+ * Mock AutoJoiner context.
+ */
+public class MockAutoJoinerContext implements AutoJoinerContext {
+  private final Map<String, JoinStage> inputStages;
+  private final FailureCollector failureCollector;
+
+  public MockAutoJoinerContext(Map<String, JoinStage> inputStages, FailureCollector failureCollector) {
+    this.inputStages = inputStages;
+    this.failureCollector = failureCollector;
+  }
+
+  @Override
+  public Map<String, JoinStage> getInputStages() {
+    return inputStages;
+  }
+
+  @Override
+  public FailureCollector getFailureCollector() {
+    return failureCollector;
+  }
+}

--- a/core-plugins/widgets/Joiner-batchjoiner.json
+++ b/core-plugins/widgets/Joiner-batchjoiner.json
@@ -7,7 +7,7 @@
   },
   "configuration-groups": [
     {
-      "label": "Join",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "sql-select-fields",
@@ -28,19 +28,39 @@
           "description": "List of join keys to perform join operation."
         },
         {
+          "widget-type": "get-schema",
+          "widget-category": "plugin"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Inputs to Load in Memory",
+          "name": "inMemoryInputs"
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Join on Null Keys",
+          "name": "joinNullKeys",
+          "widget-attributes": {
+            "default": "true",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Number of Partitions",
-          "name": "numPartitions",
-          "plugin-function": {
-            "method": "POST",
-            "label": "Generate Schema",
-            "widget": "outputSchema",
-            "output-property": "schema",
-            "plugin-method": "outputSchema",
-            "position": "bottom",
-            "multiple-inputs": true,
-            "button-class": "btn-hydrator"
-          }
+          "name": "numPartitions"
         }
       ]
     }
@@ -50,6 +70,5 @@
       "name": "schema",
       "widget-type": "schema"
     }
-
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
     <commons-lang-version>2.6</commons-lang-version>
-    <cdap.version>6.2.0</cdap.version>
+    <cdap.version>6.2.1-SNAPSHOT</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
     <es.version>1.6.0</es.version>
@@ -678,8 +678,8 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[6.2.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[6.2.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.2.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-streams[6.2.1-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>


### PR DESCRIPTION
Changed the joiner to use the new AutoJoiner API to take
advantage of the performance improvements it allows in Spark
pipelines.

Introduced two new optional properties. The first determines
whether the join will use null safe equality, and the second
provides hint to the execution engine about which input datasets
should be broadcast to perform an in-memory join.

Removed much of the existing join logic because it has been moved
into the application code. Updated the documentation to use
the property names that show up in the UI, to display the properties
in the same order that they appear in the UI, and to include
descriptions of the two new properties.