### PR TITLE
Upgraded Hive dependency to 2.4.0

### DIFF
--- a/hive-plugins/pom.xml
+++ b/hive-plugins/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015-2019 Cask Data, Inc.
+  Copyright © 2015-2020 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -23,16 +23,9 @@
     <version>2.5.0-SNAPSHOT</version>
   </parent>
 
-  <name>Hive Hydrator Plugins</name>
+  <name>Hive Plugins</name>
   <artifactId>hive-plugins</artifactId>
   <modelVersion>4.0.0</modelVersion>
-
-  <repositories>
-    <repository>
-      <id>cloudera</id>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-    </repository>
-  </repositories>
 
   <dependencies>
     <dependency>
@@ -51,7 +44,7 @@
     <dependency>
       <groupId>org.apache.hive.hcatalog</groupId>
       <artifactId>hive-hcatalog-core</artifactId>
-      <version>${cdh.hive.version}</version>
+      <version>${hive.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.avro</groupId>
@@ -82,7 +75,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-metastore</artifactId>
-      <version>${cdh.hive.version}</version>
+      <version>${hive.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -122,6 +115,17 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
+    <!-- Dependencies are required after upgrading hive to 2.4.0  -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>${commons-codec.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-serde</artifactId>
+      <version>${hive.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -134,7 +138,8 @@
         <configuration>
           <instructions>
             <_exportcontents>io.cdap.plugin.batch.*;org.apache.commons.lang;org.apache.hive.hcatalog.*;
-              org.apache.hadoop.hive.metastore.*;org.apache.hadoop.hive.ql.io.avro
+              org.apache.hadoop.hive.metastore.*;org.apache.hadoop.hive.ql.io.avro;org.apache.commons.codec.binary.*;
+              org.apache.hadoop.hive.ql.io.*;org.apache.hadoop.hive.serde2.lazy.*;
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>

--- a/hive-plugins/src/main/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
+++ b/hive-plugins/src/main/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
@@ -1,4 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hive.ql.io.avro;
+
+
+import java.io.IOException;
+import java.rmi.server.UID;
+import java.util.Map;
+import java.util.Properties;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -6,42 +29,37 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.FsInput;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.hive.serde2.avro.AvroGenericRecordWritable;
 import org.apache.hadoop.hive.serde2.avro.AvroSerdeException;
 import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
+import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.AvroTableProperties;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
-import org.apache.hive.hcatalog.common.HCatConstants;
-
-import java.io.IOException;
-import java.rmi.server.UID;
-import java.util.Map;
-import java.util.Properties;
 
 /**
  * RecordReader optimized against Avro GenericRecords that returns to record
  * as the value of the k-v pair, as Hive requires.
- *
- * Patched so that it won't read the wrong schema when reading from and writing to different avro tables.
  */
 public class AvroGenericRecordReader implements
   RecordReader<NullWritable, AvroGenericRecordWritable>, JobConfigurable {
-  private static final Log LOG = LogFactory.getLog(AvroGenericRecordReader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AvroGenericRecordReader.class);
 
   final private org.apache.avro.file.FileReader<GenericRecord> reader;
   final private long start;
   final private long stop;
   protected JobConf jobConf;
+  final private boolean isEmptyInput;
   /**
    * A unique ID for each record reader.
    */
@@ -50,11 +68,6 @@ public class AvroGenericRecordReader implements
   public AvroGenericRecordReader(JobConf job, FileSplit split, Reporter reporter) throws IOException {
     this.jobConf = job;
     Schema latest;
-
-    String jobString = job.get(HCatConstants.HCAT_KEY_JOB_INFO);
-    if (jobString == null) {
-      throw new IOException("hcatalog job info not found in JobContext. Was HCatInputFormat.setInput() called?");
-    }
 
     try {
       latest = getSchema(job, split);
@@ -68,9 +81,17 @@ public class AvroGenericRecordReader implements
       gdr.setExpected(latest);
     }
 
-    this.reader = new DataFileReader<GenericRecord>(new FsInput(split.getPath(), job), gdr);
-    this.reader.sync(split.getStart());
-    this.start = reader.tell();
+    if (split.getLength() == 0) {
+      this.isEmptyInput = true;
+      this.start = 0;
+      this.reader = null;
+    }
+    else {
+      this.isEmptyInput = false;
+      this.reader = new DataFileReader<GenericRecord>(new FsInput(split.getPath(), job), gdr);
+      this.reader.sync(split.getStart());
+      this.start = reader.tell();
+    }
     this.stop = split.getStart() + split.getLength();
     this.recordReaderID = new UID();
   }
@@ -89,8 +110,8 @@ public class AvroGenericRecordReader implements
 
       // Iterate over the Path -> Partition descriptions to find the partition
       // that matches our input split.
-      for (Map.Entry<String,PartitionDesc> pathsAndParts: mapWork.getPathToPartitionInfo().entrySet()){
-        String partitionPath = pathsAndParts.getKey();
+      for (Map.Entry<Path,PartitionDesc> pathsAndParts: mapWork.getPathToPartitionInfo().entrySet()){
+        Path partitionPath = pathsAndParts.getKey();
         if(pathIsInPartition(split.getPath(), partitionPath)) {
           if(LOG.isInfoEnabled()) {
             LOG.info("Matching partition " + partitionPath +
@@ -98,8 +119,7 @@ public class AvroGenericRecordReader implements
           }
 
           Properties props = pathsAndParts.getValue().getProperties();
-          if(props.containsKey(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL) ||
-            props.containsKey(AvroSerdeUtils.AvroTableProperties.SCHEMA_URL)) {
+          if(props.containsKey(AvroTableProperties.SCHEMA_LITERAL.getPropName()) || props.containsKey(AvroTableProperties.SCHEMA_URL.getPropName())) {
             return AvroSerdeUtils.determineSchemaOrThrowException(job, props);
           }
           else {
@@ -112,36 +132,32 @@ public class AvroGenericRecordReader implements
       }
     }
 
-    // commenting this out. This is the patch.
-    // AvroSerdeUtils.AVRO_SERDE_SCHEMA can have the schema of the other table if there are multiple tables involved
-    // in this mapreduce job. So just force the reader to re-encode.
-
     // In "select * from table" situations (non-MR), we can add things to the job
     // It's safe to add this to the job since it's not *actually* a mapred job.
     // Here the global state is confined to just this process.
-    /*String s = job.get(AvroSerdeUtils.AVRO_SERDE_SCHEMA);
+    String s = job.get(AvroTableProperties.AVRO_SERDE_SCHEMA.getPropName());
     if(s != null) {
       LOG.info("Found the avro schema in the job: " + s);
       return AvroSerdeUtils.getSchemaFor(s);
-    }*/
+    }
     // No more places to get the schema from. Give up.  May have to re-encode later.
     return null;
   }
 
-  private boolean pathIsInPartition(Path split, String partitionPath) {
+  private boolean pathIsInPartition(Path split, Path partitionPath) {
     boolean schemeless = split.toUri().getScheme() == null;
     if (schemeless) {
-      String schemelessPartitionPath = new Path(partitionPath).toUri().getPath();
-      return split.toString().startsWith(schemelessPartitionPath);
+      Path pathNoSchema = Path.getPathWithoutSchemeAndAuthority(partitionPath);
+      return FileUtils.isPathWithinSubtree(split,pathNoSchema);
     } else {
-      return split.toString().startsWith(partitionPath);
+      return FileUtils.isPathWithinSubtree(split,partitionPath);
     }
   }
 
 
   @Override
   public boolean next(NullWritable nullWritable, AvroGenericRecordWritable record) throws IOException {
-    if(!reader.hasNext() || reader.pastSync(stop)) {
+    if(isEmptyInput || !reader.hasNext() || reader.pastSync(stop)) {
       return false;
     }
 
@@ -165,12 +181,13 @@ public class AvroGenericRecordReader implements
 
   @Override
   public long getPos() throws IOException {
-    return reader.tell();
+    return isEmptyInput ? 0 : reader.tell();
   }
 
   @Override
   public void close() throws IOException {
-    reader.close();
+    if (isEmptyInput == false)
+      reader.close();
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015-2019 Cask Data, Inc.
+  Copyright © 2015-2020 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -111,7 +111,7 @@
     <guava.version>13.0.1</guava.version>
     <hadoop.version>2.3.0</hadoop.version>
     <hsql.version>2.2.4</hsql.version>
-    <cdh.hive.version>1.1.0-cdh5.5.1</cdh.hive.version>
+    <hive.version>2.3.7</hive.version>
     <javamail.version>1.4.1</javamail.version>
     <junit.version>4.11</junit.version>
     <kafka.version>0.8.2.2</kafka.version>
@@ -840,19 +840,19 @@
         <module>condition-plugins</module>
       </modules>
     </profile>
-    <profile> 
+    <profile>
       <id>skipTests</id>
       <build>
-       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.14.1</version>
-          <configuration>
-            <skipTests>true</skipTests>
-          </configuration>
-        </plugin>
-       </plugins>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.14.1</version>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
     <profile>


### PR DESCRIPTION
Note: AvroGenericRecordReader is copied from https://github.com/apache/hive/blob/rel/release-2.3.7/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java

At this point, not including the plugin with CDAP, but just making it work with Hive 2.x.

Tested with Hive Metastore:

![image](https://user-images.githubusercontent.com/3895099/84698528-c8187f00-af04-11ea-98c2-92f98b201e55.png)
