### PR TITLE
[PLUGIN-367] Blobs should not be splitable

### DIFF
--- a/format-blob/src/main/java/io/cdap/plugin/format/blob/input/PathTrackingBlobInputFormat.java
+++ b/format-blob/src/main/java/io/cdap/plugin/format/blob/input/PathTrackingBlobInputFormat.java
@@ -47,6 +47,12 @@ public class PathTrackingBlobInputFormat extends PathTrackingInputFormat {
   }
 
   @Override
+  protected boolean isSplitable(JobContext context, Path filename) {
+    // Blobs should not be splitable.
+    return false;
+  }
+
+  @Override
   protected RecordReader<NullWritable, StructuredRecord.Builder> createRecordReader(FileSplit split,
                                                                                     TaskAttemptContext context,
                                                                                     @Nullable String pathField,


### PR DESCRIPTION
See https://issues.cask.co/browse/PLUGIN-367.

Should we also consider adding a logging info message to AbstractFileSource which tells the user that the file will not be split?