### PR TITLE
Remove credential information from error message.

### DIFF
--- a/cassandra-plugins/src/main/java/io/cdap/plugin/batch/source/BatchCassandraSource.java
+++ b/cassandra-plugins/src/main/java/io/cdap/plugin/batch/source/BatchCassandraSource.java
@@ -108,9 +108,7 @@ public class BatchCassandraSource extends ReferenceBatchSource<Long, Row, Struct
     ConfigHelper.setInputPartitioner(conf, config.partitioner);
     ConfigHelper.setInputRpcPort(conf, (config.port == null) ? "9160" : Integer.toString(config.port));
     Preconditions.checkArgument(!(Strings.isNullOrEmpty(config.username) ^ Strings.isNullOrEmpty(config.password)),
-                                "You must either set both username and password or neither username nor password. " +
-                                  "Currently, they are username: " + config.username +
-                                  " and password: " + config.password);
+                                "You must either set both username and password or neither username nor password.");
     if (!Strings.isNullOrEmpty(config.username)) {
       ConfigHelper.setInputKeyspaceUserNameAndPassword(conf, config.username, config.password);
     }


### PR DESCRIPTION
Remove credential information (e.g username and password) from error message.