### PR TITLE
Remove outdated Twill dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
     <mockftp.version>2.6</mockftp.version>
     <snappy.version>1.1.2</snappy.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <twill.version>0.9.0</twill.version>
     <twitter4j.version>4.0.3</twitter4j.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <jython.version>2.5.2</jython.version>
@@ -581,17 +580,6 @@
           <exclusion>
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.twill</groupId>
-        <artifactId>twill-core</artifactId>
-        <version>${twill.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Cherry-pick of #1141 for [CDAP-17192](https://issues.cask.co/browse/CDAP-17192).