### PR TITLE
[PLUGIN-421] Add JavaScript Engine version to JavaScript Transform Documentation

### DIFF
--- a/core-plugins/docs/JavaScript-transform.md
+++ b/core-plugins/docs/JavaScript-transform.md
@@ -7,6 +7,8 @@ Executes user-provided JavaScript that transforms one record into zero or more r
 Input records are converted into JSON objects which can be directly accessed in
 JavaScript. The transform expects to receive a JSON object as input, which it can
 process and emit zero or more records or emit error using the provided emitter object.
+Currently, JDK 8's Nashorn JavaScript engine is used to run the user's code which
+supports ES5 syntax.
 
 
 Use Case


### PR DESCRIPTION
See [PLUGIN-421](https://issues.cask.co/browse/PLUGIN-421). Added documentation to the JavaScript transform plugin to include the supported JDK version and ECMAScript versions. Although we will need to change this in the future should we update to a newer version of JDK, it is probably a better user experience to document it now and change it later.