### PR TITLE
Consistent plug-in name: Transpose -> Normalize

### DIFF
--- a/transform-plugins/widgets/Normalize-transform.json
+++ b/transform-plugins/widgets/Normalize-transform.json
@@ -2,7 +2,7 @@
   "metadata": {
     "spec-version": "1.5"
   },
-  "display-name": "Transpose",
+  "display-name": "Transpose-Normalize",
   "configuration-groups": [
     {
       "properties": [


### PR DESCRIPTION
Most places refer to this plugin as: "Normalize" [1], [2], except for the plug-in display name and the new Doc Wiki [3].
It looks like the "Transpose" display name was set in this commit [4], how can we make it consistent? Change the name or all references to it?

[1] https://cloud.google.com/data-fusion/plugins#/Plugin%20Type=Transform
[2] https://github.com/cdapio/hydrator-plugins/blob/release/2.3/transform-plugins/docs/Normalize-transform.md
[3] https://cdap.atlassian.net/wiki/spaces/DOCS/pages/512295317/Transpose+Transformation
[4] https://github.com/cdapio/hydrator-plugins/commit/f2525f8299330eec3bd58305a304ca286852216c#diff-809eee6a236eca74ae9555e1f312345e23388f518d3f4ec766910cfb99496365R5