### PR TITLE
[CDAP-17248] Added support for decoding files encoded in fixed-length charsets when reading from a file source.

### DIFF
--- a/format-common/pom.xml
+++ b/format-common/pom.xml
@@ -29,6 +29,10 @@
   <name>Common Formats</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <powermock.version>2.0.9</powermock.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -54,6 +58,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/format-common/src/main/java/io/cdap/plugin/format/charset/CharsetTransformingLineRecordReader.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/charset/CharsetTransformingLineRecordReader.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharset;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharsetTransformingCodec;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharsetTransformingDecompressorStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.SplitCompressionInputStream;
+import org.apache.hadoop.io.compress.SplittableCompressionCodec;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.CompressedSplitLineReader;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.SplitLineReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Copy of Hadoop's LineRecordReader (Hadoop Version 2.3.0). The reason we copy this class is to create a
+ * FixedLengthCharsetTransformingCodec which works for every input file with no regards to the file extension.
+ * <p>
+ * This class has been simplified since we can assume that the input needs to be decompressed.
+ * <p>
+ * This class uses a fixed Codec and Decompressor to parse records.
+ */
+public class CharsetTransformingLineRecordReader extends RecordReader<LongWritable, Text> {
+  private static final Logger LOG = LoggerFactory.getLogger(CharsetTransformingLineRecordReader.class);
+  public static final String MAX_LINE_LENGTH =
+    "mapreduce.input.linerecordreader.line.maxlength";
+
+  private final FixedLengthCharset fixedLengthCharset;
+  private final byte[] recordDelimiterBytes;
+  private long start;
+  private long pos;
+  private long end;
+  private SplitLineReader in;
+  private Seekable filePosition;
+  private int maxLineLength;
+  private LongWritable key;
+  private Text value;
+  private Decompressor decompressor;
+
+  public CharsetTransformingLineRecordReader(FixedLengthCharset fixedLengthCharset, byte[] recordDelimiter) {
+    this.fixedLengthCharset = fixedLengthCharset;
+    this.recordDelimiterBytes = recordDelimiter;
+  }
+
+  @VisibleForTesting
+  protected CharsetTransformingLineRecordReader(FixedLengthCharset fixedLengthCharset,
+                                                byte[] recordDelimiter,
+                                                SplitLineReader in,
+                                                long start,
+                                                long pos,
+                                                long end,
+                                                int maxLineLength) {
+    this(fixedLengthCharset, recordDelimiter);
+    this.in = in;
+    this.start = start;
+    this.pos = pos;
+    this.end = end;
+    this.maxLineLength = maxLineLength;
+  }
+
+  /**
+   * Initialize method from parent class, simplified for this our use case from the base class.
+   *
+   * @param genericSplit File Split
+   * @param context      Execution context
+   * @throws IOException if the underlying file or decompression operations fail.
+   */
+  public void initialize(InputSplit genericSplit,
+                         TaskAttemptContext context) throws IOException {
+    FileSplit split = (FileSplit) genericSplit;
+    Configuration job = context.getConfiguration();
+    this.maxLineLength = job.getInt(MAX_LINE_LENGTH, Integer.MAX_VALUE);
+    start = split.getStart();
+    end = start + split.getLength();
+    final Path file = split.getPath();
+
+    // open the file and seek to the start of the split
+    final FileSystem fs = file.getFileSystem(job);
+    FSDataInputStream fileIn = fs.open(file);
+
+    SplittableCompressionCodec codec = new FixedLengthCharsetTransformingCodec(fixedLengthCharset);
+    decompressor = codec.createDecompressor();
+
+    final SplitCompressionInputStream cIn =
+      codec.createInputStream(
+        fileIn, decompressor, start, end,
+        SplittableCompressionCodec.READ_MODE.CONTINUOUS);
+    in = new CompressedSplitLineReader(cIn, job,
+                                       this.recordDelimiterBytes);
+    start = cIn.getAdjustedStart();
+    end = cIn.getAdjustedEnd();
+    filePosition = cIn;
+
+    // If this is not the first split, we always throw away first record
+    // because we always (except the last split) read one extra line in
+    // next() method.
+    if (start != 0) {
+      Text t = new Text();
+      start += in.readLine(t, 4096, Integer.MAX_VALUE);
+      LOG.info("Discarded line: " + t.toString());
+    }
+    this.pos = start;
+  }
+
+  /**
+   * Returns the File position in the underlying stream.
+   * <p>
+   * Note that, as the file is read in chunks to decompress, this number will only update in batches and usually be
+   * ahead of the actual decompressed position in the underlying file.
+   *
+   * See {@link FixedLengthCharsetTransformingDecompressorStream#getCompressedData}
+   *
+   * @return File position
+   * @throws IOException if an exception is thrown from the underlying strem operation.
+   */
+  @VisibleForTesting
+  protected long getFilePosition() throws IOException {
+    return filePosition.getPos();
+  }
+
+  /**
+   * Read the next Key Value from the decompressor.
+   * <p>
+   * Note that, as we read from the original file in chunks in order to decode, as we approach the partition boundary
+   * defined by `end`, the read operation
+   *
+   * @return
+   * @throws IOException
+   */
+  public boolean nextKeyValue() throws IOException {
+    if (key == null) {
+      key = new LongWritable();
+    }
+    key.set(pos);
+    if (value == null) {
+      value = new Text();
+    }
+    int newSize = 0;
+    // We always read one extra line, which lies outside the upper
+    // split limit i.e. (end - 1)
+    while (getFilePosition() <= end || in.needAdditionalRecordAfterSplit()) {
+      newSize = in.readLine(value, maxLineLength, Integer.MAX_VALUE);
+      pos += newSize;
+      if (newSize < maxLineLength) {
+        break;
+      }
+
+      // line too long. try again
+      LOG.info("Skipped line of size " + newSize + " at pos " +
+                 (pos - newSize));
+    }
+    if (newSize == 0) {
+      key = null;
+      value = null;
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  @Override
+  public LongWritable getCurrentKey() {
+    return key;
+  }
+
+  @Override
+  public Text getCurrentValue() {
+    return value;
+  }
+
+  /**
+   * Get the progress within the split
+   */
+  public float getProgress() throws IOException {
+    if (start == end) {
+      return 0.0f;
+    } else {
+      return Math.min(1.0f, (getFilePosition() - start) / (float) (end - start));
+    }
+  }
+
+  /**
+   * Close this input stream and clean up the decompressor.
+   *
+   * @throws IOException
+   */
+  public synchronized void close() throws IOException {
+    try {
+      if (in != null) {
+        in.close();
+      }
+    } finally {
+      if (decompressor != null) {
+        decompressor.end();
+      }
+    }
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharset.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharset.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Map;
+
+/**
+ * Enumeration containing all currently supported Fixed Length charsets.
+ * <p>
+ * This currently includes:
+ * - UTF-32
+ * - Any single-byte charset encoding supported by Java, including the ISO-8859, Windows-125x and EBCDIC
+ */
+public class FixedLengthCharset {
+  public static final FixedLengthCharset UTF_32 = new FixedLengthCharset("UTF-32", Charset.forName("UTF-32"), 4);
+  private static final Map<String, FixedLengthCharset> ALLOWED_MULTIBYTE_CHARSETS = ImmutableMap.of(
+    UTF_32.getName(), UTF_32
+  );
+
+  private final String name;
+  private final Charset charset;
+  private final int numBytesPerCharacter;
+
+  FixedLengthCharset(String name, Charset charset, int numBytesPerCharacter) {
+    this.name = name;
+    this.charset = charset;
+    this.numBytesPerCharacter = numBytesPerCharacter;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Charset getCharset() {
+    return charset;
+  }
+
+  public int getNumBytesPerCharacter() {
+    return numBytesPerCharacter;
+  }
+
+  /**
+   * Find a FixedLengthCharset for a given encoding name. Throws a runtime exception if not found.
+   *
+   * @param name Charset name
+   * @return FixedLengthCharset for the desired charset.
+   */
+  public static FixedLengthCharset forName(String name) {
+    if (!isValidEncoding(name)) {
+      throw new IllegalArgumentException("Charset not supported: " + name);
+    }
+
+    FixedLengthCharset fixedLengthCharset = ALLOWED_MULTIBYTE_CHARSETS.get(name.toUpperCase());
+    if (fixedLengthCharset != null) {
+      return fixedLengthCharset;
+    }
+    Charset charset = Charset.forName(name.toUpperCase());
+    return new FixedLengthCharset(name, charset, 1);
+  }
+
+  /**
+   * Check if this file encoding is valid.
+   *
+   * @return boolean value specifying if this is a valid encoding or not.
+   */
+  public static boolean isValidEncoding(String name) {
+    if (ALLOWED_MULTIBYTE_CHARSETS.containsKey(name.toUpperCase())) {
+      return true;
+    }
+    try {
+      Charset charset = Charset.forName(name.toUpperCase());
+      CharsetEncoder encoder = charset.newEncoder();
+      return encoder.maxBytesPerChar() == 1 && encoder.averageBytesPerChar() == 1;
+    } catch (UnsupportedOperationException | UnsupportedCharsetException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Takes the first word of the file encoding string, as any further words are just charset descriptions.
+   *
+   * @param fileEncoding The file encoding parameter supplied by the user
+   * @return the cleaned up file encoding name
+   */
+  public static String cleanFileEncodingName(String fileEncoding) {
+    fileEncoding = fileEncoding.trim();
+
+    return fileEncoding.split(" ")[0].toUpperCase();
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingCodec.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingCodec.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.DefaultCodec;
+import org.apache.hadoop.io.compress.DirectDecompressor;
+import org.apache.hadoop.io.compress.SplitCompressionInputStream;
+import org.apache.hadoop.io.compress.SplittableCompressionCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Codec implementation that returns a decompressor for Fixed Length character encodings.
+ */
+public class FixedLengthCharsetTransformingCodec extends DefaultCodec
+  implements Configurable, SplittableCompressionCodec {
+  private static final Logger LOG = LoggerFactory.getLogger(FixedLengthCharsetTransformingCodec.class);
+
+  private final FixedLengthCharset sourceEncoding;
+
+  public FixedLengthCharsetTransformingCodec(FixedLengthCharset sourceEncoding) {
+    this.sourceEncoding = sourceEncoding;
+  }
+
+  @Override
+  public CompressionOutputStream createOutputStream(OutputStream out) throws IOException {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Class<? extends Compressor> getCompressorType() {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Compressor createCompressor() {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Class<? extends Decompressor> getDecompressorType() {
+    return FixedLengthCharsetTransformingDecompressor.class;
+  }
+
+  @Override
+  public DirectDecompressor createDirectDecompressor() {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public String getDefaultExtension() {
+    return ".*";
+  }
+
+  @Override
+  public Decompressor createDecompressor() {
+    return new FixedLengthCharsetTransformingDecompressor(sourceEncoding);
+  }
+
+  public SplitCompressionInputStream createInputStream(InputStream seekableIn,
+                                                       Decompressor decompressor,
+                                                       long start,
+                                                       long end,
+                                                       READ_MODE readMode) throws IOException {
+    if (!(seekableIn instanceof Seekable)) {
+      throw new IOException("seekableIn must be an instance of " +
+                              Seekable.class.getName());
+    }
+
+    //Adjust start to align to the next character boundary.
+    if (start % sourceEncoding.getNumBytesPerCharacter() != 0) {
+      long adjustment = sourceEncoding.getNumBytesPerCharacter() - (start % sourceEncoding.getNumBytesPerCharacter());
+      LOG.trace("Adjusted partition start positioon from {} to {} by {} bytes",
+                start, start + adjustment, adjustment);
+      start += adjustment;
+    }
+
+    //Adjust end to align to the next character boundary.
+    if (end % sourceEncoding.getNumBytesPerCharacter() != 0) {
+      long adjustment = sourceEncoding.getNumBytesPerCharacter() - (end % sourceEncoding.getNumBytesPerCharacter());
+      LOG.trace("Adjusted partition end position from {} to {} by {} bytes",
+                end, end + adjustment, adjustment);
+      end += adjustment;
+    }
+
+    FixedLengthCharsetTransformingDecompressorStream decompressorStream =
+      new FixedLengthCharsetTransformingDecompressorStream(seekableIn, sourceEncoding, start, end);
+
+    return new TransformingCompressionInputStream(decompressorStream, start, end);
+  }
+
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressor.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressor.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import org.apache.hadoop.io.compress.Decompressor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Decompressor that can be used to convert byte streams in fixed-length character encodings to a stream of UTF-8 bytes.
+ */
+public class FixedLengthCharsetTransformingDecompressor implements Decompressor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FixedLengthCharsetTransformingDecompressor.class);
+
+  private final FixedLengthCharset sourceEncoding;
+  private final CharsetDecoder decoder;
+  private final CharsetEncoder encoder;
+  private final Charset targetCharset = StandardCharsets.UTF_8;
+
+  //Initializing all buffers.
+  private ByteBuffer inputByteBuffer = ByteBuffer.allocate(0);
+  private CharBuffer decodedCharBuffer = CharBuffer.allocate(0);
+  private ByteBuffer partialOutputByteBuffer = ByteBuffer.allocate(0);
+
+  public FixedLengthCharsetTransformingDecompressor(FixedLengthCharset sourceEncoding) {
+    this.sourceEncoding = sourceEncoding;
+    this.decoder = sourceEncoding.getCharset().newDecoder();
+    this.encoder = targetCharset.newEncoder();
+  }
+
+  @Override
+  public void setInput(byte[] b, int off, int len) {
+    //Set up incoming buffer for writes.
+    inputByteBuffer.compact();
+
+    //Expand incoming buffer if needed.
+    if (inputByteBuffer.remaining() < len) {
+      //Allocate new buffer that can fill the existing input + newly received bytes
+      ByteBuffer newIncomingBuffer = ByteBuffer.allocate(len + inputByteBuffer.capacity());
+
+      //Set up incoming buffer for reads and copy contents into new buffer.
+      inputByteBuffer.flip();
+      newIncomingBuffer.put(inputByteBuffer);
+
+      inputByteBuffer = newIncomingBuffer;
+    }
+
+    //Copy incoming payload into Input Byte Buffer
+    inputByteBuffer.put(b, off, len);
+    inputByteBuffer.flip();
+
+    //Set up char buffer for writes
+    decodedCharBuffer.compact();
+
+    //Expand the char buffer if needed.
+    if (decodedCharBuffer.capacity() < inputByteBuffer.limit() / sourceEncoding.getNumBytesPerCharacter()) {
+      decodedCharBuffer = CharBuffer.allocate(inputByteBuffer.limit() / sourceEncoding.getNumBytesPerCharacter());
+    }
+
+    //Decode bytes from the input buffer into the Decoded Char Buffer
+    decodeByteBufferIntoCharBuffer(inputByteBuffer);
+
+    //Set up decoded char buffer for reads.
+    decodedCharBuffer.flip();
+
+  }
+
+  /**
+   * Note that we only ask for additional input once we have completely depleted out outgoing buffer.
+   */
+  @Override
+  public boolean needsInput() {
+    return decodedCharBuffer.remaining() == 0;
+  }
+
+  @Override
+  public void setDictionary(byte[] b, int off, int len) {
+    //no-op
+  }
+
+  @Override
+  public boolean needsDictionary() {
+    return false;
+  }
+
+  @Override
+  public boolean finished() {
+    return decodedCharBuffer.remaining() == 0 && partialOutputByteBuffer.remaining() == 0;
+  }
+
+  @Override
+  public int decompress(byte[] b, int off, int len) throws IOException {
+
+    //Allocate new outgoing buffer
+    ByteBuffer encodedBuffer = ByteBuffer.wrap(b, off, len);
+
+    //Consume any remaining bytes from a previous decompress invocation.
+    while (partialOutputByteBuffer != null && partialOutputByteBuffer.hasRemaining() && encodedBuffer.hasRemaining()) {
+      encodedBuffer.put(partialOutputByteBuffer.get());
+    }
+
+    //Encode as many characters as possible into the Encoded Buffer.
+    encodeCharBufferIntoByteBuffer(encodedBuffer);
+
+    // Handle the case where we need to add a partial decompressed character to the output buffer.
+    // This means we need to encode one extra character and add as many bytes as possible into the output buffer.
+    // This is an expensive operation that is executed as a last resort, meaning we only do this when we were
+    // not able to add any bytes to the output payload before.
+    if (decodedCharBuffer.remaining() > 0 && encodedBuffer.remaining() > 0 && encodedBuffer.position() - off == 0) {
+      encodePartialCharIntoByteBuffer(encodedBuffer);
+    }
+
+    //Return the number of bytes copied,
+    // This is matches the actual position in the decoded buffer minus the initial offset
+    return encodedBuffer.position() - off;
+  }
+
+  /**
+   * Decode butes from the specified byteBuffer into the DecodedCharBuffer.
+   *
+   * @param buffer The target ByteBuffer
+   */
+  protected void decodeByteBufferIntoCharBuffer(ByteBuffer buffer) {
+    int initialCharBufferPos = decodedCharBuffer.position();
+
+    //Decode input buffer as characters.
+    CoderResult decodeResult = decoder.decode(buffer, decodedCharBuffer, false);
+
+    if (decodeResult.isError()) {
+      LOG.error("Unable to decode payload from file as {}", sourceEncoding.getCharset().name());
+      throw new CharacterDecodingException(decoder);
+    }
+
+    int finalCharBufferPos = decodedCharBuffer.position();
+  }
+
+  /**
+   * Encode bytes from the decodedCharBuffer into the specified ByteBuffer.
+   *
+   * @param buffer The target ByteBuffer
+   */
+  protected void encodeCharBufferIntoByteBuffer(ByteBuffer buffer) {
+    int initialCharBufferPos = decodedCharBuffer.position();
+
+    //Decode as many chars as possible into the outgoing buffer.
+    CoderResult encodeResult = encoder.encode(decodedCharBuffer, buffer, true);
+
+    if (encodeResult.isError()) {
+      LOG.error("Unable to encode decoded payload as UTF-8");
+      throw new CharacterEncodingException(encoder);
+    }
+
+    int finalCharBufferPos = decodedCharBuffer.position();
+  }
+
+  /**
+   * Encode a minimum of 1 additional character from the decoded char buffer into the output buffer.
+   * <p>
+   * Since the output is UTF-8, there can be up to 4 additional characters encoded in this temporary buffer.
+   * <p>
+   * Any remaining bytes that could not be added into the output stream are stored in the `partialOutputByteBuffer`
+   * and consumed in the next invocation of the `decompress` method.
+   *
+   * @param outputBuffer the output buffer we'll use to store the partial bytes from a character.
+   */
+  protected void encodePartialCharIntoByteBuffer(ByteBuffer outputBuffer) {
+    // UTF-8 characters can be up to 4 bytes long.
+    // We start from 2 bytes as a 1-byte-long character would already fit in the encoded buffer.
+    ByteBuffer additionalByteBuffer = ByteBuffer.allocate(4);
+
+    encodeCharBufferIntoByteBuffer(additionalByteBuffer);
+
+    //Set up additional char buffer for read in the next invocation of this method.
+    additionalByteBuffer.flip();
+
+    //Read as many bytes as possible from this additional char buffer.
+    while (additionalByteBuffer.hasRemaining() && outputBuffer.hasRemaining()) {
+      outputBuffer.put(additionalByteBuffer.get());
+    }
+
+    //Store remaining bytes in the Partial Byte Buffer
+    partialOutputByteBuffer = additionalByteBuffer;
+  }
+
+  @Override
+  public int getRemaining() {
+    return inputByteBuffer.remaining();
+  }
+
+  @Override
+  public void reset() {
+    inputByteBuffer = ByteBuffer.allocate(0);
+    decodedCharBuffer = CharBuffer.allocate(0);
+    partialOutputByteBuffer = ByteBuffer.allocate(0);
+  }
+
+  @Override
+  public void end() {
+    this.reset();
+  }
+
+  /**
+   * Runtime Character Decoding Exception in case we are unable to decode the supplied payload from the
+   * specified charset.
+   */
+  public static class CharacterDecodingException extends RuntimeException {
+    public CharacterDecodingException(CharsetDecoder decoder) {
+      super(String.format("Unable to read from source as text encoded in '%s'", decoder.charset().name()));
+    }
+  }
+
+  /**
+   * Runtime Character Decoding Exception in case we are unable to encode the decoded payload into the
+   * desired charset.
+   */
+  public static class CharacterEncodingException extends RuntimeException {
+    public CharacterEncodingException(CharsetEncoder encoder) {
+      super(String.format("Unable to encode byte payload as '%s'", encoder.charset().name()));
+    }
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressorStream.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressorStream.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.io.compress.DecompressorStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * DecompressorStream implementation for the FixedLengthCharsetTransformingDecompressor.
+ * <p>
+ * This can be used to convert input streams containing bytes for fixed length charsets into UTF-8 bytes.
+ */
+public class FixedLengthCharsetTransformingDecompressorStream extends DecompressorStream {
+
+  private final long start;
+  private final long end;
+  private long totalReadBytes = 0;
+
+  public FixedLengthCharsetTransformingDecompressorStream(InputStream in,
+                                                          FixedLengthCharset fixedLengthCharset,
+                                                          long start,
+                                                          long end)
+    throws IOException {
+    super(in, new FixedLengthCharsetTransformingDecompressor(fixedLengthCharset), 4096);
+    ((Seekable) in).seek(start);
+    this.start = start;
+    this.end = end;
+  }
+
+  @VisibleForTesting
+  protected FixedLengthCharsetTransformingDecompressorStream(InputStream in,
+                                                             FixedLengthCharset fixedLengthCharset,
+                                                             int bufferSize,
+                                                             long start,
+                                                             long end)
+    throws IOException {
+    super(in, new FixedLengthCharsetTransformingDecompressor(fixedLengthCharset), bufferSize);
+    ((Seekable) in).seek(start);
+    this.start = start;
+    this.end = end;
+  }
+
+  /**
+   * Fill the input buffer with data from the source input.
+   * <p>
+   * Partition boundaries present a challenge: We need to make sure to read just enough characters to make it into
+   * the next complete line.
+   * <p>
+   * The way we accomplish this is to keep track of how many bytes we have read from the source stream. It the next
+   * invocation of this method reaches or goes over the partition boundary, we align the read operation to the
+   * partition boundary.
+   * <p>
+   * This ensures the caller method will either read a full line, or call this method once again to ensure the final
+   * line of the given partition is read and not a single extra line.
+   *
+   * @return Number of bytes read from the source.
+   * @throws IOException when there is a problema reading from the underlying stream.
+   */
+  @Override
+  protected int getCompressedData() throws IOException {
+    checkStream();
+
+    int len = buffer.length;
+
+    // Make sure we decompress up to the partition boundary when the next read operation reaches this position.
+    // This ensures our decompression is aligned to the partition boundary and the next line that is read is the
+    // final line for this partition.
+    if (start + totalReadBytes < end && start + totalReadBytes + len > end) {
+      //Ensure we only decompress up to the partition boundary if we are approaching this limit.
+      long bytesUntilPartitionBoundary = end - (start + totalReadBytes);
+
+      if (bytesUntilPartitionBoundary < buffer.length) {
+        len = (int) bytesUntilPartitionBoundary;
+      }
+    }
+
+    int numReadBytes = in.read(buffer, 0, len);
+
+    totalReadBytes += numReadBytes;
+
+    return numReadBytes;
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/TransformingCompressionInputStream.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/charset/fixedlength/TransformingCompressionInputStream.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import org.apache.hadoop.io.compress.SplitCompressionInputStream;
+
+import java.io.IOException;
+
+/**
+ * Wrapper for the decompressor stream.
+ */
+public class TransformingCompressionInputStream extends SplitCompressionInputStream {
+
+  private final FixedLengthCharsetTransformingDecompressorStream decompressorStream;
+
+  public TransformingCompressionInputStream(FixedLengthCharsetTransformingDecompressorStream in, long start, long end)
+    throws IOException {
+    super(in, start, end);
+    decompressorStream = in;
+  }
+
+  @Override
+  public int read() throws IOException {
+    return decompressorStream.read();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return decompressorStream.read(b, off, len);
+  }
+
+  @Override
+  public void resetState() throws IOException {
+    decompressorStream.reset();
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return decompressorStream.getPos();
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/input/CharsetTransformingPathTrackingInputFormat.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/input/CharsetTransformingPathTrackingInputFormat.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.input;
+
+import io.cdap.plugin.format.charset.CharsetTransformingLineRecordReader;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharset;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * An input format that tracks which the file path each record was read from. This InputFormat is a wrapper around
+ * underlying input formats. The responsibility of this class is to keep track of which file each record is reading
+ * from, and to add the file URI to each record. In addition, for text files, it can be configured to keep track
+ * of the header for the file, which underlying record readers can use.
+ */
+public class CharsetTransformingPathTrackingInputFormat extends TextInputFormat {
+
+  protected final FixedLengthCharset fixedLengthCharset;
+
+  public CharsetTransformingPathTrackingInputFormat(String charsetName) {
+    this.fixedLengthCharset = FixedLengthCharset.forName(charsetName);
+  }
+
+  @Override
+  public RecordReader<LongWritable, Text> createRecordReader(InputSplit split, TaskAttemptContext context) {
+    String delimiter = context.getConfiguration().get("textinputformat.record.delimiter");
+    byte[] recordDelimiterBytes = null;
+    if (null != delimiter) {
+      recordDelimiterBytes = delimiter.getBytes(StandardCharsets.UTF_8);
+    }
+    return new CharsetTransformingLineRecordReader(fixedLengthCharset, recordDelimiterBytes);
+  }
+
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.common.IdUtils;
 import io.cdap.plugin.format.FileFormat;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharset;
 
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -38,7 +39,8 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   public static final String NAME_FORMAT = "format";
   public static final String NAME_SCHEMA = "schema";
   public static final String NAME_DELIMITER = "delimiter";
-  
+  public static final String DEFAULT_FILE_ENCODING = "UTF-8";
+
   @Description("Name be used to uniquely identify this source for lineage, annotating metadata, etc.")
   private String referenceName;
 
@@ -104,8 +106,13 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   @Macro
   @Nullable
   @Description("Whether to skip the first line of each file. Supported formats are 'text', 'csv', 'tsv', " +
-                 "'delimited'. Default value is false.")
+    "'delimited'. Default value is false.")
   private Boolean skipHeader;
+
+  @Macro
+  @Nullable
+  @Description("File encoding for the source files. The default encoding is 'UTF-8'")
+  private String fileEncoding;
 
   // this is a hidden property that only exists for wrangler's parse-as-csv that uses the header as the schema
   // when this is true and the format is text, the header will be the first record returned by every record reader
@@ -133,6 +140,13 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
       getSchema();
     } catch (IllegalArgumentException e) {
       collector.addFailure(e.getMessage(), null).withConfigProperty(NAME_SCHEMA).withStacktrace(e.getStackTrace());
+    }
+
+    if (getFileEncoding() != null && !getFileEncoding().equals(getDefaultFileEncoding())) {
+      if (!FixedLengthCharset.isValidEncoding(getFileEncoding())) {
+        collector.addFailure("Specified file encoding is not valid.",
+                             "Use one of the supported file encodings.");
+      }
     }
 
     // if failure collector has not collected any errors, that would mean either validation has succeeded or config
@@ -198,6 +212,18 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   @Override
   public boolean skipHeader() {
     return skipHeader == null ? false : skipHeader;
+  }
+
+  @Nullable
+  public String getFileEncoding() {
+    String encoding = fileEncoding == null || fileEncoding.isEmpty() ?
+      DEFAULT_FILE_ENCODING : fileEncoding;
+
+    return FixedLengthCharset.cleanFileEncodingName(encoding);
+  }
+
+  public String getDefaultFileEncoding() {
+    return DEFAULT_FILE_ENCODING;
   }
 
   @Nullable

--- a/format-common/src/test/java/io/cdap/plugin/format/charset/CharsetTransformingLineRecordReaderTest.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/charset/CharsetTransformingLineRecordReaderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset;
+
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharset;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharsetTransformingCodec;
+import io.cdap.plugin.format.charset.fixedlength.FixedLengthCharsetTransformingDecompressorStream;
+import io.cdap.plugin.format.charset.fixedlength.TransformingCompressionInputStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionInputStream;
+import org.apache.hadoop.io.compress.SplitCompressionInputStream;
+import org.apache.hadoop.mapreduce.lib.input.CompressedSplitLineReader;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CharsetTransformingLineRecordReaderTest {
+
+  Configuration conf;
+  FixedLengthCharset fixedLengthCharset;
+  CharsetTransformingLineRecordReader recordReader;
+  FixedLengthCharsetTransformingCodec codec;
+  SeekableByteArrayInputStream inputStream;
+  int availableBytes;
+  FixedLengthCharsetTransformingDecompressorStream decompressorStream;
+  SplitCompressionInputStream compressionInputStream;
+
+  //We set up the input so each line is 5 characters long, which is 20 bytes in UTF-32.
+  final String input = "abcd\nedfg\nijkl\n";
+
+  @Before
+  public void before() throws IOException {
+    //Set up the Compressed Split Line Reader with a buffer size of 4096 bytes.
+    //This ensures the buffer will consume all characters in the input stream if we allow it to.
+    conf = new Configuration();
+    conf.setInt("io.file.buffer.size", 4096);
+
+    fixedLengthCharset = FixedLengthCharset.UTF_32;
+
+    codec = new FixedLengthCharsetTransformingCodec(fixedLengthCharset);
+    codec.setConf(conf);
+
+    inputStream = new SeekableByteArrayInputStream(input.getBytes(fixedLengthCharset.getCharset()));
+    availableBytes = inputStream.available();
+  }
+
+  public void setUpRecordReaderForTest(SplitCompressionInputStream splitCompressionInputStream) throws IOException {
+
+    // Set up record reader to assume we'll read the file from the beggining, and the partition size is 32 bytes
+    // which is 8 characters in UTF-32, meaning we expect to read the first 2 lines for this partition.
+    recordReader = spy(new CharsetTransformingLineRecordReader(
+      fixedLengthCharset,
+      null,
+      new CompressedSplitLineReader(splitCompressionInputStream, conf, null),
+      0,
+      0,
+      32,
+      4096
+    ));
+
+    //We will calculate position based on the number of bytes consumed from the input stream.
+    doAnswer(a -> (long) availableBytes - inputStream.available()).when(recordReader).getFilePosition();
+  }
+
+  @Test
+  public void testGetNextLine() throws IOException {
+    decompressorStream =
+      new FixedLengthCharsetTransformingDecompressorStream(inputStream, FixedLengthCharset.UTF_32, 0, 32);
+    compressionInputStream = new TransformingCompressionInputStream(decompressorStream, 0, 32);
+
+    //Set up test
+    setUpRecordReaderForTest(compressionInputStream);
+
+    //Ensure the first line is read
+    Assert.assertTrue(recordReader.nextKeyValue());
+    Assert.assertEquals(0, recordReader.getCurrentKey().get());
+    Assert.assertEquals("abcd", recordReader.getCurrentValue().toString());
+    //Ensure the second line is read
+    Assert.assertTrue(recordReader.nextKeyValue());
+    Assert.assertEquals(5, recordReader.getCurrentKey().get());
+    Assert.assertEquals("edfg", recordReader.getCurrentValue().toString());
+    //Ensure no more lines can be read.
+    Assert.assertFalse(recordReader.nextKeyValue());
+    Assert.assertNull(recordReader.getCurrentKey());
+    Assert.assertNull(recordReader.getCurrentValue());
+    Assert.assertFalse(recordReader.nextKeyValue());
+    Assert.assertNull(recordReader.getCurrentKey());
+    Assert.assertNull(recordReader.getCurrentValue());
+  }
+
+  @Test
+  public void testGetNextLineCallingOriginalGetCompressedDataMethod() throws IOException {
+    //We'll override the getCompressedData method by invoking the superclass getCompressedData method.
+    //This will highlight the partition boundary issues we had to solve.
+    CompressionInputStream defaultCompressorInputStream =
+      codec.createInputStream(inputStream, codec.createDecompressor());
+    SplitCompressionInputStream defaultSplitCompressionInputStream =
+      new SplitCompressionInputStream(defaultCompressorInputStream, 0, 32) {
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+          return in.read(b, off, len);
+        }
+
+        @Override
+        public void resetState() throws IOException {
+          in.reset();
+        }
+
+        @Override
+        public int read() throws IOException {
+          return in.read();
+        }
+      };
+
+    //Set up test
+    setUpRecordReaderForTest(defaultSplitCompressionInputStream);
+
+    //Ensure first line is read
+    Assert.assertTrue(recordReader.nextKeyValue());
+    Assert.assertEquals(0, recordReader.getCurrentKey().get());
+    Assert.assertEquals("abcd", recordReader.getCurrentValue().toString());
+    //Notice that the next line does not get read, as the file position goes beyond the partition boundary, even when
+    //not all expected lines have been read yet.
+    Assert.assertFalse(recordReader.nextKeyValue());
+    Assert.assertNull(recordReader.getCurrentKey());
+    Assert.assertNull(recordReader.getCurrentValue());
+    Assert.assertFalse(recordReader.nextKeyValue());
+    Assert.assertNull(recordReader.getCurrentKey());
+    Assert.assertNull(recordReader.getCurrentValue());
+  }
+}

--- a/format-common/src/test/java/io/cdap/plugin/format/charset/SeekableByteArrayInputStream.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/charset/SeekableByteArrayInputStream.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset;
+
+import org.apache.hadoop.fs.Seekable;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class SeekableByteArrayInputStream extends ByteArrayInputStream implements Seekable {
+  public SeekableByteArrayInputStream(byte[] buf) {
+    super(buf);
+  }
+
+  @Override
+  public void seek(long pos) throws IOException {
+    super.reset();
+    super.skip(pos);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public boolean seekToNewSource(long targetPos) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/format-common/src/test/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTest.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import io.cdap.plugin.format.plugin.AbstractFileSourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FixedLengthCharsetTest {
+
+  @Test
+  public void testEncodingsAreValid() {
+    List<String> encodings = Arrays.asList(
+      "UTF-32",
+      "ISO-8859-1 (Latin-1 Western European)",
+      "ISO-8859-2 (Latin-2 Central European)",
+      "ISO-8859-3 (Latin-3 South European)",
+      "ISO-8859-4 (Latin-4 North European)",
+      "ISO-8859-5 (Latin/Cyrillic)",
+      "ISO-8859-6 (Latin/Arabic)",
+      "ISO-8859-7 (Latin/Greek)",
+      "ISO-8859-8 (Latin/Hebrew)",
+      "ISO-8859-9 (Latin-5 Turkish)",
+      "ISO-8859-11 (Latin/Thai)",
+      "ISO-8859-13 (Latin-7 Baltic Rim)",
+      "ISO-8859-15 (Latin-9)",
+      "Windows-1250",
+      "Windows-1251",
+      "Windows-1252",
+      "Windows-1253",
+      "Windows-1254",
+      "Windows-1255",
+      "Windows-1256",
+      "Windows-1257",
+      "Windows-1258",
+      "IBM00858",
+      "IBM01140",
+      "IBM01141",
+      "IBM01142",
+      "IBM01143",
+      "IBM01144",
+      "IBM01145",
+      "IBM01146",
+      "IBM01147",
+      "IBM01148",
+      "IBM01149",
+      "IBM037",
+      "IBM1026",
+      "IBM1047",
+      "IBM273",
+      "IBM277",
+      "IBM278",
+      "IBM280",
+      "IBM284",
+      "IBM285",
+      "IBM290",
+      "IBM297",
+      "IBM420",
+      "IBM424",
+      "IBM437",
+      "IBM500",
+      "IBM775",
+      "IBM850",
+      "IBM852",
+      "IBM855",
+      "IBM857",
+      "IBM860",
+      "IBM861",
+      "IBM862",
+      "IBM863",
+      "IBM864",
+      "IBM865",
+      "IBM866",
+      "IBM868",
+      "IBM869",
+      "IBM870",
+      "IBM871",
+      "IBM918"
+    );
+
+    for (String encoding : encodings) {
+      Assert.assertTrue(FixedLengthCharset.isValidEncoding(FixedLengthCharset.cleanFileEncodingName(encoding)));
+    }
+
+    Assert.assertFalse(FixedLengthCharset.isValidEncoding("utf-8"));
+  }
+}

--- a/format-common/src/test/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressorStreamTest.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressorStreamTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import io.cdap.plugin.format.charset.SeekableByteArrayInputStream;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.DecompressorStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class FixedLengthCharsetTransformingDecompressorStreamTest {
+
+  FixedLengthCharsetTransformingDecompressorStream decompressorStream;
+  SeekableByteArrayInputStream inputStream;
+
+  String text = "abc\ndef\nghi\njkl\nmno\npqr\nwxy\nz12\n";
+
+  @Before
+  public void test() {
+    inputStream = new SeekableByteArrayInputStream(text.getBytes(FixedLengthCharset.UTF_32.getCharset()));
+  }
+
+  @Test
+  public void testGetCompressedDataPartitionBoundaries_FirstPartition() throws IOException {
+    int bufferSize = 20;
+    long partitionStart = 0;
+    long partitionEnd = 32;
+
+    decompressorStream = new FixedLengthCharsetTransformingDecompressorStream(inputStream,
+                                                                              FixedLengthCharset.UTF_32,
+                                                                              bufferSize,
+                                                                              partitionStart,
+                                                                              partitionEnd);
+
+    int numReadBytes;
+
+    //First read, limit not reached
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(20, numReadBytes);
+    assertEquals(20, decompressorStream.getPos());
+
+    //Second read, limit is reached in this batch.
+    // Only 12 out of 20 possible bytes are read to reach the partition limit
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(12, numReadBytes);
+    assertEquals(32, decompressorStream.getPos());
+
+    //Additional read operation, buffer is now filled to completion.
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(20, numReadBytes);
+    assertEquals(52, decompressorStream.getPos());
+  }
+
+  @Test
+  public void testGetCompressedDataPartitionBoundaries_MiddlePartition() throws IOException {
+    int bufferSize = 20;
+    long partitionStart = 32;
+    long partitionEnd = 64;
+
+    decompressorStream = new FixedLengthCharsetTransformingDecompressorStream(inputStream,
+                                                                              FixedLengthCharset.UTF_32,
+                                                                              bufferSize,
+                                                                              partitionStart,
+                                                                              partitionEnd);
+
+    int numReadBytes;
+
+    //First read, limit not reached
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(20, numReadBytes);
+    assertEquals(52, decompressorStream.getPos());
+
+    //Second read, limit is reached in this batch.
+    // Only 12 out of 20 possible bytes are read to reach the partition limit
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(12, numReadBytes);
+    assertEquals(64, decompressorStream.getPos());
+
+    //Additional read operation, buffer is now filled to completion.
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(20, numReadBytes);
+    assertEquals(84, decompressorStream.getPos());
+  }
+
+  @Test
+  public void testGetCompressedDataPartitionBoundaries_FinalPartition() throws IOException {
+    int bufferSize = 20;
+    long partitionStart = 96;
+    long partitionEnd = 128;
+
+    decompressorStream = new FixedLengthCharsetTransformingDecompressorStream(inputStream,
+                                                                              FixedLengthCharset.UTF_32,
+                                                                              bufferSize,
+                                                                              partitionStart,
+                                                                              partitionEnd);
+
+    int numReadBytes;
+
+    //First read, limit not reached
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(20, numReadBytes);
+    assertEquals(116, decompressorStream.getPos());
+
+    //Second read, limit is reached in this batch.
+    // Only 12 out of 20 possible bytes are read to reach the partition limit
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(12, numReadBytes);
+    assertEquals(128, decompressorStream.getPos());
+
+    //Additional read operation, no more bytes can be read.
+    numReadBytes = decompressorStream.getCompressedData();
+    assertEquals(-1, numReadBytes);
+    assertEquals(128, decompressorStream.getPos());
+  }
+
+  @Test
+  public void testUsingDefaultDecompressor() throws IOException {
+
+    //Create new decompressor and decompressor stream.
+    //Notice we read from this compressor using the default read method.
+    Decompressor decompressor = new FixedLengthCharsetTransformingDecompressor(FixedLengthCharset.UTF_32);
+    DecompressorStream defaultDecompressorStream = new DecompressorStream(inputStream, decompressor, 20);
+
+    int numReadBytes;
+
+    //First read, Limit has exceeded boundary
+    numReadBytes = defaultDecompressorStream.read(new byte[20], 0, 20);
+    assertEquals(5, numReadBytes);
+    assertEquals(defaultDecompressorStream.getPos(), 20);
+
+    // Second read, as you can see, this read is already beyond our partition boundary. This will cause issues
+    // at the LineRecordReader layer.
+    numReadBytes = defaultDecompressorStream.read(new byte[20], 0, 20);
+    assertEquals(5, numReadBytes);
+    assertEquals(defaultDecompressorStream.getPos(), 40);
+  }
+}

--- a/format-common/src/test/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressorTest.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/charset/fixedlength/FixedLengthCharsetTransformingDecompressorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.charset.fixedlength;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class FixedLengthCharsetTransformingDecompressorTest {
+
+  FixedLengthCharsetTransformingDecompressor decompressor;
+
+  @Test
+  public void testUtf32Input() throws IOException {
+    testDecode("áéíóú This is a string that will need to be converted into UTF-8",
+               FixedLengthCharset.UTF_32);
+  }
+
+  @Test
+  public void testISO88591Input() throws IOException {
+    testDecode("This is áéíóú@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("ISO-8859-1"));
+  }
+
+  @Test
+  public void testISO88592Input() throws IOException {
+    testDecode("This is ŕęďţ@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("ISO-8859-2"));
+  }
+
+  @Test
+  public void testISO88593Input() throws IOException {
+    testDecode("This is ĜŝħĦ@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("ISO-8859-3"));
+  }
+
+  @Test
+  public void testISO88594Input() throws IOException {
+    testDecode("This is ŖąÆŦĸ@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("ISO-8859-4"));
+  }
+
+  @Test
+  public void testISO88595Input() throws IOException {
+    testDecode("This is ДЩЊЮѓ@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("ISO-8859-5"));
+  }
+
+  @Test
+  public void testISO88596Input() throws IOException {
+    testDecode("This is سشغقئ@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("ISO-8859-6"));
+  }
+
+  @Test
+  public void testWindows1252Bytes() throws IOException {
+    testDecode("This is áéíóú@ string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("Windows-1252"));
+  }
+
+  @Test
+  public void testIBM1047Bytes() throws IOException {
+    testDecode("This is a string that will need to be converted into UTF-8",
+               FixedLengthCharset.forName("IBM1047"));
+  }
+
+  public void testDecode(String testString, FixedLengthCharset fixedLengthCharset) throws IOException {
+    decompressor = new FixedLengthCharsetTransformingDecompressor(fixedLengthCharset);
+    ByteArrayOutputStream decompressed = new ByteArrayOutputStream();
+
+    byte[] sourceBytes = testString.getBytes(fixedLengthCharset.getCharset());
+    byte[] utf8Bytes = testString.getBytes(StandardCharsets.UTF_8);
+
+    //Consume input and output at different speeds to ensure the decompressor works as expected.
+    for (int inputBlockSize = 1; inputBlockSize <= 16; inputBlockSize++) {
+      for (int outputBlockSize = 1; outputBlockSize <= 16; outputBlockSize++) {
+
+        //Set input and decompress.
+        for (int i = 0; i < sourceBytes.length; i += inputBlockSize) {
+          decompressor.setInput(sourceBytes, i, Math.min(inputBlockSize, sourceBytes.length - i));
+
+          //Read from the decompressed stream one byte at a time.
+          while (!decompressor.finished()) {
+            byte[] buf = new byte[outputBlockSize];
+            int numReadBytes = decompressor.decompress(buf, 0, outputBlockSize);
+            decompressed.write(buf, 0, numReadBytes);
+          }
+        }
+
+        //Ensure decompressed output matches expected payload.
+        byte[] decompressedBytes = decompressed.toByteArray();
+        Assert.assertArrayEquals(utf8Bytes, decompressedBytes);
+
+        decompressed.reset();
+        decompressor.reset();
+
+      }
+    }
+  }
+}

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -46,7 +45,7 @@ public class PathTrackingDelimitedInputFormat extends PathTrackingInputFormat {
                                                                                     @Nullable String pathField,
                                                                                     @Nullable Schema schema) {
 
-    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    RecordReader<LongWritable, Text> delegate = getDefaultRecordReaderDelegate(split, context);
     String delimiter = context.getConfiguration().get(DELIMITER);
     boolean skipHeader = context.getConfiguration().getBoolean(SKIP_HEADER, false);
 

--- a/format-json/src/main/java/io/cdap/plugin/format/json/input/PathTrackingJsonInputFormat.java
+++ b/format-json/src/main/java/io/cdap/plugin/format/json/input/PathTrackingJsonInputFormat.java
@@ -65,7 +65,7 @@ public class PathTrackingJsonInputFormat extends PathTrackingInputFormat {
                                                                                     TaskAttemptContext context,
                                                                                     @Nullable String pathField,
                                                                                     @Nullable Schema schema) {
-    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    RecordReader<LongWritable, Text> delegate = getDefaultRecordReaderDelegate(split, context);
     Schema modifiedSchema = getModifiedSchema(schema, pathField);
 
     return new RecordReader<NullWritable, StructuredRecord.Builder>() {

--- a/format-text/src/main/java/io/cdap/plugin/format/text/input/PathTrackingTextInputFormat.java
+++ b/format-text/src/main/java/io/cdap/plugin/format/text/input/PathTrackingTextInputFormat.java
@@ -51,7 +51,7 @@ public class PathTrackingTextInputFormat extends PathTrackingInputFormat {
                                                                                     TaskAttemptContext context,
                                                                                     @Nullable String pathField,
                                                                                     Schema schema) {
-    RecordReader<LongWritable, Text> delegate = (new TextInputFormat()).createRecordReader(split, context);
+    RecordReader<LongWritable, Text> delegate = getDefaultRecordReaderDelegate(split, context);
     String header = context.getConfiguration().get(CombineTextInputFormat.HEADER);
     boolean skipHeader = context.getConfiguration().getBoolean(CombineTextInputFormat.SKIP_HEADER, false);
     return new TextRecordReader(delegate, schema, emittedHeader, header, skipHeader);


### PR DESCRIPTION
As it stands, UTF-32, ISO-8859-1 and Windows-1252 formats are supported.

I've identified an edge case when some lines get skipped in the partition edges. I'm close to isolating the cause of the issue.