### PR TITLE
PLUGIN-102 remove format hardcoding

### DIFF
--- a/core-plugins/docs/File-batchsink.md
+++ b/core-plugins/docs/File-batchsink.md
@@ -23,7 +23,9 @@ For example, the format 'yyyy-MM-dd-HH-mm' will result in a directory of the for
 If not specified, nothing will be appended to the path."
 
 **Format:** Format to write the records in.
-The format must be one of 'json', 'avro', 'parquet', 'csv', 'tsv', or 'delimited'.
+The format must be one of 'json', 'avro', 'parquet', 'csv', 'tsv', 'delimited', or the name of any
+format plugins deployed to your environment. If the format is a macro, only the pre-packaged
+formats can be used.
 
 **Delimiter:** Delimiter to use if the format is 'delimited'.
 

--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -15,7 +15,9 @@ Properties
 **Path:** Path to read from. For example, s3a://<bucket>/path/to/input
 
 **Format:** Format of the data to read.
-The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', or 'tsv'.
+The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv', or the
+name of any format plugin that you have deployed to your environment.
+If the format is a macro, only the pre-packaged formats can be used.
 If the format is 'blob', every input file will be read into a separate record.
 The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
 If the format is 'text', the schema must contain a field named 'body' of type 'string'.

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
@@ -165,8 +165,8 @@ public class FTPBatchSource extends AbstractFileSource {
     }
 
     @Override
-    public FileFormat getFormat() {
-      return FileFormat.TEXT;
+    public String getFormatName() {
+      return FileFormat.TEXT.name().toLowerCase();
     }
 
     @Nullable

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
@@ -530,7 +530,7 @@ public class FileBatchSourceTest extends ETLBatchTestBase {
     ImmutableMap.Builder<String, String> sourceProperties = ImmutableMap.<String, String>builder()
       .put(Constants.Reference.REFERENCE_NAME, appName + "TestFile")
       .put(Properties.File.PATH, testFolder.getAbsolutePath())
-      .put(Properties.File.FORMAT, FileFormat.BLOB.name())
+      .put(Properties.File.FORMAT, FileFormat.BLOB.name().toLowerCase())
       .put(Properties.File.IGNORE_NON_EXISTING_FOLDERS, "false")
       .put("skipHeader", "false")
       .put("pathField", "file")

--- a/core-plugins/widgets/File-batchsink.json
+++ b/core-plugins/widgets/File-batchsink.json
@@ -31,19 +31,11 @@
           }
         },
         {
-          "widget-type": "select",
+          "widget-type": "plugin-list",
           "label": "Format",
           "name": "format",
           "widget-attributes": {
-            "values": [
-              "avro",
-              "csv",
-              "delimited",
-              "json",
-              "parquet",
-              "tsv"
-            ],
-            "default": "json"
+            "plugin-type": "validatingOutputFormat"
           }
         },
         {

--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -23,21 +23,11 @@
           }
         },
         {
-          "widget-type": "select",
+          "widget-type": "plugin-list",
           "label": "Format",
           "name": "format",
           "widget-attributes": {
-            "values": [
-              "avro",
-              "blob",
-              "csv",
-              "delimited",
-              "json",
-              "parquet",
-              "text",
-              "tsv"
-            ],
-            "default": "text"
+            "plugin-type": "validatingInputFormat"
           },
           "plugin-function": {
             "method": "POST",

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
@@ -122,21 +122,11 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
 
   public void validate() {
     IdUtils.validateId(referenceName);
-    if (!containsMacro(NAME_FORMAT)) {
-      getFormat();
-    }
     getSchema();
   }
 
   public void validate(FailureCollector collector) {
     IdUtils.validateReferenceName(referenceName, collector);
-    if (!containsMacro(NAME_FORMAT)) {
-      try {
-        getFormat();
-      } catch (IllegalArgumentException e) {
-        collector.addFailure(e.getMessage(), null).withConfigProperty(NAME_FORMAT).withStacktrace(e.getStackTrace());
-      }
-    }
     try {
       getSchema();
     } catch (IllegalArgumentException e) {
@@ -160,8 +150,15 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   }
 
   @Override
-  public FileFormat getFormat() {
-    return FileFormat.from(format, x -> true);
+  public String getFormatName() {
+    // need to do this for backwards compatibility, where the pre-packaged format names were case insensitive.
+    try {
+      FileFormat fileFormat = FileFormat.from(format, x -> true);
+      return fileFormat.name().toLowerCase();
+    } catch (IllegalArgumentException e) {
+      // ignore
+    }
+    return format;
   }
 
   @Nullable

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSinkProperties.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSinkProperties.java
@@ -62,9 +62,20 @@ public interface FileSinkProperties {
   String getPath();
 
   /**
-   * Get the format of the data to write.
+   * Get the name of the format plugin to use to write the data.
    */
-  FileFormat getFormat();
+  default String getFormatName() {
+    return null;
+  }
+
+  /**
+   * @deprecated use {@link #getFormatName()} instead
+   */
+  @Nullable
+  @Deprecated
+  default FileFormat getFormat() {
+    return null;
+  }
 
   /**
    * Get the output schema if it is known and constant, or null if it is not known or not constant.

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSourceProperties.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSourceProperties.java
@@ -64,9 +64,24 @@ public interface FileSourceProperties {
   String getPath();
 
   /**
-   * Get the format of the data to read.
+   * Get the name of the format plugin used to read data.
    */
-  FileFormat getFormat();
+  default String getFormatName() {
+    FileFormat format = getFormat();
+    if (format == null) {
+      return null;
+    }
+    return format.name().toLowerCase();
+  }
+
+  /**
+   * @deprecated use {@link #getFormatName()} instead
+   */
+  @Nullable
+  @Deprecated
+  default FileFormat getFormat() {
+    return null;
+  }
 
   /**
    * Get the pattern that file names must match if filename filter should be done.

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/TSVOutputFormatProvider.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/TSVOutputFormatProvider.java
@@ -19,8 +19,10 @@ package io.cdap.plugin.format.delimited.output;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.validation.FormatContext;
 import io.cdap.cdap.etl.api.validation.ValidatingOutputFormat;
 import io.cdap.plugin.format.output.AbstractOutputFormatProvider;
 
@@ -41,6 +43,20 @@ public class TSVOutputFormatProvider extends AbstractOutputFormatProvider {
   @Override
   public String getOutputFormatClassName() {
     return StructuredDelimitedOutputFormat.class.getName();
+  }
+
+  @Override
+  public void validate(FormatContext context) {
+    Schema inputSchema = context.getInputSchema();
+    boolean allSimpleFields = inputSchema.getFields().stream()
+      .map(Schema.Field::getSchema)
+      .allMatch(Schema::isSimpleOrNullableSimple);
+    if (allSimpleFields == false) {
+      context.getFailureCollector().addFailure(
+        "Input has multi-level structure that cannot be represented appropriately as tsv.",
+        "Consider using json, avro or parquet to write data."
+      ).withConfigProperty("format");
+    }
   }
 
   @Override


### PR DESCRIPTION
Removed hardcoded format checks and instead rely on the plugin
framework to raise an error if the plugin doesn't exist.

Also changed the widget to pull the formats from the plugin API
instead of using a hardcoded list. This allows proper support
for users who deploy their own custom formats.