### PR TITLE
Fix schema auto detection

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FileBatchSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FileBatchSource.java
@@ -50,4 +50,11 @@ public class FileBatchSource extends AbstractFileSource<FileSourceConfig> {
     }
     return properties;
   }
+
+  @Override
+  protected boolean shouldGetSchema() {
+    return !config.containsMacro(FileSourceConfig.NAME_PATH) && !config.containsMacro(FileSourceConfig.NAME_FORMAT) &&
+      !config.containsMacro(FileSourceConfig.NAME_DELIMITER) &&
+      !config.containsMacro(FileSourceConfig.NAME_FILE_SYSTEM_PROPERTIES);
+  }
 }

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FileSourceConfig.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FileSourceConfig.java
@@ -32,10 +32,10 @@ import javax.annotation.Nullable;
  * File source config
  */
 public class FileSourceConfig extends AbstractFileSourceConfig {
-
+  public static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
+  public static final String NAME_PATH = "path";
   private static final Gson GSON = new Gson();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
-  private static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
 
   @Macro
   @Description("Path to file(s) to be read. If a directory is specified, " +

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
@@ -93,7 +93,7 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     if (config.containsMacro(NAME_FORMAT)) {
       // Deploy all format plugins. This ensures that the required plugin is available when
       // the format macro is evaluated in prepareRun.
-      for (FileFormat f: FileFormat.values()) {
+      for (FileFormat f : FileFormat.values()) {
         try {
           pipelineConfigurer.usePlugin(ValidatingInputFormat.PLUGIN_TYPE, f.name().toLowerCase(),
                                        f.name().toLowerCase(), config.getRawProperties());
@@ -109,18 +109,20 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     String fileFormat = config.getFormatName();
     Schema schema = null;
 
-    // Include source file system properties for schema auto detection
-    final PluginProperties.Builder builder = PluginProperties.builder();
+    PluginProperties.Builder builder = PluginProperties.builder();
     builder.addAll(config.getRawProperties().getProperties());
-    builder.add(FILE_SYSTEM_PROPERTIES, GSON.toJson(getFileSystemProperties(null)));
-    final PluginProperties pluginProperties = builder.build();
+
+    if (shouldGetSchema()) {
+      // Include source file system properties for schema auto detection
+      builder.add(FILE_SYSTEM_PROPERTIES, GSON.toJson(getFileSystemProperties(null)));
+    }
 
     ValidatingInputFormat validatingInputFormat =
-      pipelineConfigurer.usePlugin(ValidatingInputFormat.PLUGIN_TYPE, fileFormat, fileFormat, pluginProperties);
+      pipelineConfigurer.usePlugin(ValidatingInputFormat.PLUGIN_TYPE, fileFormat, fileFormat, builder.build());
     FormatContext context = new FormatContext(collector, null);
     validateInputFormatProvider(context, fileFormat, validatingInputFormat);
 
-    if (validatingInputFormat != null) {
+    if (validatingInputFormat != null && shouldGetSchema()) {
       schema = validatingInputFormat.getSchema(context);
     }
 
@@ -262,5 +264,14 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
           .withOutputSchemaField(schemaPathField.getName());
       }
     }
+  }
+
+  /**
+   * Determines if the schema should be auto detected. This method must return false if any of the plugin properties
+   * needed to determine the schema is a macro or not present. Otherwise this method should return true.
+   * See PLUGIN-508 and CDAP-17473
+   */
+  protected boolean shouldGetSchema() {
+    return true;
   }
 }

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
@@ -37,7 +37,8 @@ import javax.annotation.Nullable;
 public abstract class AbstractFileSourceConfig extends PluginConfig implements FileSourceProperties {
   public static final String NAME_FORMAT = "format";
   public static final String NAME_SCHEMA = "schema";
-  
+  public static final String NAME_DELIMITER = "delimiter";
+
   @Description("Name be used to uniquely identify this source for lineage, annotating metadata, etc.")
   private String referenceName;
 
@@ -93,6 +94,7 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
     + "read the data.")
   private String schema;
 
+  @Name(NAME_DELIMITER)
   @Macro
   @Nullable
   @Description("The delimiter to use if the format is 'delimited'. The delimiter will be ignored if the format "


### PR DESCRIPTION
Dont apply schema auto detection on file source if any of the below fields are macro:
```
- path 
- format
- delimiter
- file system properties