### PR TITLE
CDAP-17486 fix gcs sink deploy

### DIFF
--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSinkProperties.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSinkProperties.java
@@ -65,7 +65,11 @@ public interface FileSinkProperties {
    * Get the name of the format plugin to use to write the data.
    */
   default String getFormatName() {
-    return null;
+    FileFormat format = getFormat();
+    if (format == null) {
+      return null;
+    }
+    return format.name().toLowerCase();
   }
 
   /**


### PR DESCRIPTION
The newly added method should not just return null since the gcs sink config does not implement this method so the format will always be null, so usePlugin will pass a null, which results in deploy failure.