### PR TITLE
CDAP-17522 fix npe for file sink

### DIFF
--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
@@ -107,7 +107,10 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     }
 
     String fileFormat = config.getFormatName();
-    Schema schema = null;
+
+    // here set the schema from the config since the input format can only provide schema if all the required fields
+    // are not macro
+    Schema schema = config.getSchema();
 
     PluginProperties.Builder builder = PluginProperties.builder();
     builder.addAll(config.getRawProperties().getProperties());

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/CSVOutputFormatProvider.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/CSVOutputFormatProvider.java
@@ -48,6 +48,10 @@ public class CSVOutputFormatProvider extends AbstractOutputFormatProvider {
   @Override
   public void validate(FormatContext context) {
     Schema inputSchema = context.getInputSchema();
+    // this is possible if schema is macro enabled
+    if (inputSchema == null) {
+      return;
+    }
     boolean allSimpleFields = inputSchema.getFields().stream()
       .map(Schema.Field::getSchema)
       .allMatch(Schema::isSimpleOrNullableSimple);

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/DelimitedOutputFormatProvider.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/DelimitedOutputFormatProvider.java
@@ -52,6 +52,10 @@ public class DelimitedOutputFormatProvider extends AbstractOutputFormatProvider 
   @Override
   public void validate(FormatContext context) {
     Schema inputSchema = context.getInputSchema();
+    // this is possible if schema is macro enabled
+    if (inputSchema == null) {
+      return;
+    }
     boolean allSimpleFields = inputSchema.getFields().stream()
       .map(Schema.Field::getSchema)
       .allMatch(Schema::isSimpleOrNullableSimple);

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/TSVOutputFormatProvider.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/output/TSVOutputFormatProvider.java
@@ -48,6 +48,10 @@ public class TSVOutputFormatProvider extends AbstractOutputFormatProvider {
   @Override
   public void validate(FormatContext context) {
     Schema inputSchema = context.getInputSchema();
+    // this is possible if schema is macro enabled
+    if (inputSchema == null) {
+      return;
+    }
     boolean allSimpleFields = inputSchema.getFields().stream()
       .map(Schema.Field::getSchema)
       .allMatch(Schema::isSimpleOrNullableSimple);


### PR DESCRIPTION
The issue is we introduced a shouldGetSchema in CDAP-17473, the NPE for this pipeline is because there is a macro field in the source, so shouldGetSchema will return false, so the schema is set as null, but the output format is validating the schema, so causing the NPE.

https://cdap.atlassian.net/browse/CDAP-17522