### PR TITLE
[PLUGIN-470] Cherry Pick into 2.3

### DIFF
--- a/database-plugins/src/main/java/io/cdap/plugin/DBRecord.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/DBRecord.java
@@ -274,7 +274,6 @@ public class DBRecord implements Writable, DBWritable, Configurable {
         case DECIMAL:
           BigDecimal value = record.getDecimal(fieldName);
           stmt.setBigDecimal(sqlIndex, value);
-          bytesWritten += value.unscaledValue().bitLength() / Byte.SIZE + Integer.BYTES;
           break;
       }
       return;

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/AvroOutputFormatProvider.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/AvroOutputFormatProvider.java
@@ -62,6 +62,10 @@ public class AvroOutputFormatProvider extends AbstractOutputFormatProvider {
   @Override
   public Map<String, String> getOutputFormatConfiguration() {
     Map<String, String> configuration = new HashMap<>();
+    if (conf.schema != null && !conf.containsMacro("schema")) {
+      configuration.put(SCHEMA_KEY, conf.schema);
+    }
+
     if (conf.compressionCodec != null && !conf.containsMacro("compressionCodec") &&
       !"none".equalsIgnoreCase(conf.compressionCodec)) {
 

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/AvroOutputFormatProvider.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/AvroOutputFormatProvider.java
@@ -52,7 +52,11 @@ public class AvroOutputFormatProvider extends AbstractOutputFormatProvider {
 
   @Override
   public String getOutputFormatClassName() {
-    return StructuredAvroOutputFormat.class.getName();
+    if (conf.schema != null) {
+      return StructuredAvroOutputFormat.class.getName();
+    } else {
+      return RuntimeSuppliedSchemaAvroOutputFormat.class.getName();
+    }
   }
 
   @Override
@@ -85,6 +89,7 @@ public class AvroOutputFormatProvider extends AbstractOutputFormatProvider {
       "Compression codec to use when writing data. Must be 'snappy', 'deflate', 'bzip2', 'xz', or 'none.'";
 
     @Macro
+    @Nullable
     @Description(SCHEMA_DESC)
     private String schema;
 
@@ -96,7 +101,7 @@ public class AvroOutputFormatProvider extends AbstractOutputFormatProvider {
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    properties.put("schema", new PluginPropertyField("schema", Conf.SCHEMA_DESC, "string", true, true));
+    properties.put("schema", new PluginPropertyField("schema", Conf.SCHEMA_DESC, "string", false, true));
     properties.put("compressionCodec",
                    new PluginPropertyField("compressionCodec", Conf.CODEC_DESC, "string", false, true));
     return new PluginClass(ValidatingOutputFormat.PLUGIN_TYPE, NAME, DESC, AvroOutputFormatProvider.class.getName(),

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/AvroOutputFormatProvider.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/AvroOutputFormatProvider.java
@@ -62,10 +62,6 @@ public class AvroOutputFormatProvider extends AbstractOutputFormatProvider {
   @Override
   public Map<String, String> getOutputFormatConfiguration() {
     Map<String, String> configuration = new HashMap<>();
-    if (!conf.containsMacro("schema")) {
-      configuration.put(SCHEMA_KEY, conf.schema);
-    }
-
     if (conf.compressionCodec != null && !conf.containsMacro("compressionCodec") &&
       !"none".equalsIgnoreCase(conf.compressionCodec)) {
 

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/DelegatingAvroKeyOutputFormat.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/DelegatingAvroKeyOutputFormat.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.avro.output;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+import org.apache.avro.mapreduce.AvroOutputFormatBase;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.function.Function;
+
+/**
+ * Output format for Avro files which uses the DelegatingAvroKeyRecordWriter to write records.
+ */
+public class DelegatingAvroKeyOutputFormat extends AvroKeyOutputFormat<GenericRecord> {
+
+  @Override
+  public RecordWriter<AvroKey<GenericRecord>, NullWritable> getRecordWriter(TaskAttemptContext context) {
+    Function<TaskAttemptContext, OutputStream> outputStreamSupplier = (ctx) -> {
+      try {
+        return getAvroFileOutputStream(ctx);
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to get Output Stream", e);
+      }
+    };
+
+    return new DelegatingAvroKeyRecordWriter(context,
+                                             getCompressionCodec(context),
+                                             outputStreamSupplier,
+                                             getSyncInterval(context));
+  }
+}

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/DelegatingAvroKeyRecordWriter.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/DelegatingAvroKeyRecordWriter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.avro.output;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.hadoop.io.AvroSerialization;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapreduce.AvroJob;
+import org.apache.avro.mapreduce.AvroKeyRecordWriter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Record Writer for Avro records that delegates to additional record writers based on the Schema hash.
+ */
+public class DelegatingAvroKeyRecordWriter extends RecordWriter<AvroKey<GenericRecord>, NullWritable> {
+  private final Map<Integer, RecordWriter<AvroKey<GenericRecord>, NullWritable>> delegateMap;
+  private final TaskAttemptContext context;
+  private final CodecFactory codecFactory;
+  private final Function<TaskAttemptContext, OutputStream> outputStreamSupplier;
+  private final int syncInterval;
+
+  public DelegatingAvroKeyRecordWriter(TaskAttemptContext context,
+                                       CodecFactory codecFactory,
+                                       Function<TaskAttemptContext, OutputStream> outputStreamSupplier,
+                                       int syncInterval) {
+    super();
+    this.delegateMap = new HashMap<>();
+    this.context = context;
+    this.codecFactory = codecFactory;
+    this.outputStreamSupplier = outputStreamSupplier;
+    this.syncInterval = syncInterval;
+  }
+
+  @Override
+  public void write(AvroKey<GenericRecord> key, NullWritable value) throws IOException, InterruptedException {
+    RecordWriter<AvroKey<GenericRecord>, NullWritable> delegate =
+      delegateMap.computeIfAbsent(key.datum().getSchema().hashCode(), (k) -> {
+        try {
+          Configuration conf = context.getConfiguration();
+          GenericData dataModel = AvroSerialization.createDataModel(conf);
+
+          return new AvroKeyRecordWriter<>(key.datum().getSchema(),
+                                           dataModel,
+                                           codecFactory,
+                                           outputStreamSupplier.apply(context),
+                                           syncInterval);
+        } catch (IOException ioe) {
+          throw new RuntimeException("Unable to initialize Avro Record Writer", ioe);
+        }
+      });
+
+    delegate.write(key, value);
+  }
+
+  @Override
+  public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    IOException ex = null;
+
+    for (RecordWriter<AvroKey<GenericRecord>, NullWritable> delegate : delegateMap.values()) {
+      try {
+        delegate.close(context);
+      } catch (IOException e) {
+        if (ex == null) {
+          ex = e;
+        } else {
+          ex.addSuppressed(e);
+        }
+      }
+    }
+
+    if (ex != null) {
+      throw ex;
+    }
+  }
+}

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/RuntimeSuppliedSchemaAvroOutputFormat.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/RuntimeSuppliedSchemaAvroOutputFormat.java
@@ -48,14 +48,7 @@ public class RuntimeSuppliedSchemaAvroOutputFormat extends
 
     Configuration hConf = context.getConfiguration();
 
-    String schemaJson = hConf.get(AvroOutputFormatProvider.SCHEMA_KEY);
-    Schema schema = null;
-
-    if (schemaJson != null) {
-      schema = Schema.parseJson(hConf.get(AvroOutputFormatProvider.SCHEMA_KEY));
-    }
-
-    StructuredToAvroTransformer transformer = new StructuredToAvroTransformer(schema);
+    StructuredToAvroTransformer transformer = new StructuredToAvroTransformer(null);
     return record -> {
       try {
         return new KeyValue<>(new AvroKey<>(transformer.transform(record)), NullWritable.get());

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/output/RuntimeSuppliedSchemaAvroOutputFormat.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/output/RuntimeSuppliedSchemaAvroOutputFormat.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2018-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.avro.output;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.lib.KeyValue;
+import io.cdap.plugin.format.avro.StructuredToAvroTransformer;
+import io.cdap.plugin.format.output.DelegatingOutputFormat;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * Converts StructuredRecord into GenericRecord before delegating to DelegatingAvroKeyOutputFormat.
+ */
+public class RuntimeSuppliedSchemaAvroOutputFormat extends
+  DelegatingOutputFormat<AvroKey<GenericRecord>, NullWritable> {
+
+  @Override
+  protected OutputFormat<AvroKey<GenericRecord>, NullWritable> createDelegate() {
+    return new DelegatingAvroKeyOutputFormat();
+  }
+
+  @Override
+  protected Function<StructuredRecord, KeyValue<AvroKey<GenericRecord>, NullWritable>> getConversion(
+    TaskAttemptContext context) throws IOException {
+
+    Configuration hConf = context.getConfiguration();
+
+    String schemaJson = hConf.get(AvroOutputFormatProvider.SCHEMA_KEY);
+    Schema schema = null;
+
+    if (schemaJson != null) {
+      schema = Schema.parseJson(hConf.get(AvroOutputFormatProvider.SCHEMA_KEY));
+    }
+
+    StructuredToAvroTransformer transformer = new StructuredToAvroTransformer(schema);
+    return record -> {
+      try {
+        return new KeyValue<>(new AvroKey<>(transformer.transform(record)), NullWritable.get());
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to transform structured record into a generic record", e);
+      }
+    };
+  }
+}


### PR DESCRIPTION
Refactored Abro Output Format to allow writing records with no predefined schema

Fixed small bug

Simplifying code

Some fixes.

Simplified solution

Removed configuration for the Schema relaxation.

Removed configuration for the Schema relaxation.