### PR TITLE
Datetime support for file source plugin

### DIFF
--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.format.delimited.input;
 import com.google.common.base.Splitter;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.common.SchemaValidator;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -99,10 +100,14 @@ public class PathTrackingDelimitedInputFormat extends PathTrackingInputFormat {
             throw new IOException(message + " Check that the schema contains the right number of fields.");
           }
 
+          Schema.Field nextField = fields.next();
           if (part.isEmpty()) {
-            builder.set(fields.next().getName(), null);
+            builder.set(nextField.getName(), null);
           } else {
-            builder.convertAndSet(fields.next().getName(), part);
+            String fieldName = nextField.getName();
+            //Ensure if date time field, value is in correct format
+            SchemaValidator.validateDateTimeField(nextField.getSchema(), fieldName, part);
+            builder.convertAndSet(fieldName, part);
           }
         }
         return builder;

--- a/format-json/src/main/java/io/cdap/plugin/format/json/input/PathTrackingJsonInputFormat.java
+++ b/format-json/src/main/java/io/cdap/plugin/format/json/input/PathTrackingJsonInputFormat.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.format.json.input;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
+import io.cdap.plugin.common.SchemaValidator;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
@@ -27,7 +28,6 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -91,7 +91,9 @@ public class PathTrackingJsonInputFormat extends PathTrackingInputFormat {
         StructuredRecord record = StructuredRecordStringConverter.fromJsonString(json, modifiedSchema);
         StructuredRecord.Builder builder = StructuredRecord.builder(schema);
         for (Schema.Field field : schema.getFields()) {
-          builder.set(field.getName(), record.get(field.getName()));
+          Object value = record.get(field.getName());
+          SchemaValidator.validateDateTimeField(field.getSchema(), field.getName(), value);
+          builder.set(field.getName(), value);
         }
         return builder;
       }

--- a/hydrator-common/src/test/java/io/cdap/plugin/common/SchemaValidatorTest.java
+++ b/hydrator-common/src/test/java/io/cdap/plugin/common/SchemaValidatorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.common;
+
+import io.cdap.cdap.api.data.format.UnexpectedFormatException;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for SchemaValidator
+ */
+public class SchemaValidatorTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+  private static Schema schema;
+  private static String validDate;
+  private static String inValidDate;
+
+  @BeforeClass
+  public static void init() {
+    schema = Schema.recordOf("record",
+                             Schema.Field.of("simplefield", Schema.of(Schema.LogicalType.DATETIME)),
+                             Schema.Field
+                               .of("unionfield", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))),
+                             Schema.Field
+                               .of("arrayfield", Schema.arrayOf(Schema.of(Schema.LogicalType.DATETIME))),
+                             Schema.Field.of("mapfield1", Schema
+                               .mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.LogicalType.DATETIME))),
+                             Schema.Field.of("mapfield2", Schema
+                               .mapOf(Schema.of(Schema.LogicalType.DATETIME), Schema.of(Schema.Type.STRING))),
+                             Schema.Field.of("stringfield", Schema.of(Schema.Type.STRING)));
+    validDate = LocalDateTime.now().toString();
+    //not in ISO 8601 format
+    inValidDate = "2020-10-01 10:10:10";
+  }
+
+  @Test
+  public void testValidateDateTimeFieldSimple() {
+    //no exception
+    SchemaValidator.validateDateTimeField(schema.getField("simplefield").getSchema(), "testdate", validDate);
+    expectedException.expect(UnexpectedFormatException.class);
+    SchemaValidator.validateDateTimeField(schema.getField("simplefield").getSchema(), "testdate", inValidDate);
+  }
+
+  @Test
+  public void testValidateDateTimeFieldUnion() {
+    //no exception
+    SchemaValidator.validateDateTimeField(schema.getField("unionfield").getSchema(), "unionfield", validDate);
+    expectedException.expect(UnexpectedFormatException.class);
+    SchemaValidator.validateDateTimeField(schema.getField("unionfield").getSchema(), "unionfield", inValidDate);
+  }
+
+  @Test
+  public void testValidateDateTimeFieldArray() {
+    //no exception
+    SchemaValidator
+      .validateDateTimeField(schema.getField("arrayfield").getSchema(), "arrayfield", new String[]{validDate});
+    expectedException.expect(UnexpectedFormatException.class);
+    SchemaValidator
+      .validateDateTimeField(schema.getField("arrayfield").getSchema(), "arrayfield",
+                             Collections.singletonList(inValidDate));
+  }
+
+  @Test
+  public void testValidateDateTimeFieldMap() {
+    //no exception
+    Map<String, String> testMap = new HashMap<>();
+    testMap.put("test", validDate);
+    SchemaValidator
+      .validateDateTimeField(schema.getField("mapfield1").getSchema(), "mapfield1", testMap);
+    testMap.put("test", inValidDate);
+    expectedException.expect(UnexpectedFormatException.class);
+    SchemaValidator
+      .validateDateTimeField(schema.getField("mapfield1").getSchema(), "mapfield1",
+                             testMap);
+  }
+
+  @Test
+  public void testValidateDateTimeFieldMap1() {
+    //no exception
+    Map<String, String> testMap = new HashMap<>();
+    testMap.put(validDate, "test");
+    SchemaValidator
+      .validateDateTimeField(schema.getField("mapfield2").getSchema(), "mapfield2", testMap);
+    testMap.put(inValidDate, "test");
+    expectedException.expect(UnexpectedFormatException.class);
+    SchemaValidator
+      .validateDateTimeField(schema.getField("mapfield2").getSchema(), "mapfield2",
+                             testMap);
+  }
+
+  @Test
+  public void testValidateDateTimeFieldString() {
+    //no exception for both valid and invalid
+    SchemaValidator.validateDateTimeField(schema.getField("stringfield").getSchema(), "stringfield", validDate);
+    SchemaValidator.validateDateTimeField(schema.getField("stringfield").getSchema(), "stringfield", inValidDate);
+  }
+}


### PR DESCRIPTION
- Validate datetime field format for FileSource. 
- Added checks for AVRO, delimited formats and JSON. Walk the schema for validating JSON.
- Tested Valid/Invalid datetime to string in AVRO, CSV, TSV, JSON and delimited formats
- Tested CDAP datetime field with FileSink (Automatically supported since datetime is string)
