### PR TITLE
CDAP-17607 add advanced join conditions

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
@@ -22,10 +22,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.join.JoinCondition;
 import io.cdap.cdap.etl.api.join.JoinField;
 import io.cdap.cdap.etl.api.join.JoinKey;
 import io.cdap.plugin.common.KeyValueListParser;
@@ -33,6 +35,7 @@ import io.cdap.plugin.common.KeyValueListParser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -46,92 +49,121 @@ import javax.annotation.Nullable;
  */
 public class JoinerConfig extends PluginConfig {
 
-  public static final String SELECTED_FIELDS = "selectedFields";
-  public static final String REQUIRED_INPUTS = "requiredInputs";
-  public static final String JOIN_KEYS = "joinKeys";
-  public static final String OUTPUT_SCHEMA = "schema";
+  public static final String CONDITION_TYPE = "conditionType";
+  public static final String CONDITION_EXPR = "conditionExpression";
+  public static final String DISTRIBUTION_ENABLED = "distributionEnabled";
   public static final String DISTRIBUTION_FACTOR = "distributionFactor";
   public static final String DISTRIBUTION_STAGE = "distributionStageName";
+  public static final String INPUT_ALIASES = "inputAliases";
+  public static final String JOIN_KEYS = "joinKeys";
+  public static final String JOIN_NULL_KEYS = "joinNullKeys";
   public static final String MEMORY_INPUTS = "inMemoryInputs";
-  private static final String NUM_PARTITIONS_DESC = "Number of partitions to use when joining. " +
-    "If not specified, the execution framework will decide how many to use.";
-  private static final String JOIN_KEY_DESC = "List of join keys to perform join operation. The list is " +
+  public static final String NUM_PARTITIONS = "numPartitions";
+  public static final String REQUIRED_INPUTS = "requiredInputs";
+  public static final String SELECTED_FIELDS = "selectedFields";
+  public static final String OUTPUT_SCHEMA = "schema";
+  private static final String BASIC = "basic";
+  private static final String ADVANCED = "advanced";
+
+  @Macro
+  @Nullable
+  @Name(NUM_PARTITIONS)
+  @Description("Number of partitions to use when joining. " +
+    "If not specified, the execution framework will decide how many to use.")
+  protected Integer numPartitions;
+
+  @Macro
+  @Nullable
+  @Name(JOIN_KEYS)
+  @Description("List of join keys to perform join operation. The list is " +
     "separated by '&'. Join key from each input stage will be prefixed with '<stageName>.' And the " +
     "relation among join keys from different inputs is represented by '='. For example: " +
     "customers.customer_id=items.c_id&customers.customer_name=items.c_name means the join key is a composite key" +
     " of customer id and customer name from customers and items input stages and join will be performed on equality " +
-    "of the join keys.";
-  private static final String SELECTED_FIELDS_DESC = "Comma-separated list of fields to be selected and renamed " +
+    "of the join keys.")
+  protected String joinKeys;
+
+  @Macro
+  @Name(SELECTED_FIELDS)
+  @Description("Comma-separated list of fields to be selected and renamed " +
     "in join output from each input stage. Each selected input field name needs to be present in the output must be " +
     "prefixed with '<input_stage_name>'. The syntax for specifying alias for each selected field is similar to sql. " +
     "For example: customers.id as customer_id, customer.name as customer_name, item.id as item_id, " +
     "<stageName>.inputFieldName as alias. The output will have same order of fields as selected in selectedFields." +
-    "There must not be any duplicate fields in output.";
-  private static final String REQUIRED_INPUTS_DESC = "Comma-separated list of stages." +
-    " Required input stages decide the type of the join. If all the input stages are present in required inputs, " +
-    "inner join will be performed. Otherwise, outer join will be performed considering non-required inputs as " +
-    "optional.";
-  private static final String DISTRIBUTION_STAGE_DESC =
-    "Name of the skewed input stage. The skewed input stage is the one that contains many rows that join "
-      + "to the same row in the non-skewed stage. Ex. If stage A has 10 rows that join on the same row in stage B, then"
-      + " stage A is the skewed input stage";
-  private static final String DISTRIBUTION_FACTOR_DESC =
-    "This controls the size of the salt that will be generated for distribution. The number of partitions "
-      + "should be greater than or equal to this number for optimal results. A larger value will lead to more "
-      + "parallelism but it will also grow the size of the non-skewed dataset by this factor.";
-
-  @Macro
-  @Nullable
-  @Description(NUM_PARTITIONS_DESC)
-  protected Integer numPartitions;
-
-  @Description(JOIN_KEY_DESC)
-  @Macro
-  protected String joinKeys;
-
-  @Description(SELECTED_FIELDS_DESC)
-  @Macro
+    "There must not be any duplicate fields in output.")
   protected String selectedFields;
 
-  @Nullable
-  @Description(REQUIRED_INPUTS_DESC)
   @Macro
+  @Nullable
+  @Name(REQUIRED_INPUTS)
+  @Description("Comma-separated list of stages." +
+    " Required input stages decide the type of the join. If all the input stages are present in required inputs, " +
+    "inner join will be performed. Otherwise, outer join will be performed considering non-required inputs as " +
+    "optional.")
   protected String requiredInputs;
 
-  @Nullable
   @Macro
+  @Nullable
+  @Name(OUTPUT_SCHEMA)
   @Description(OUTPUT_SCHEMA)
   private String schema;
 
-  @Nullable
   @Macro
+  @Nullable
+  @Name(MEMORY_INPUTS)
   @Description("Set of input stages to try to load completely in memory to perform an in-memory join. " +
     "This is just a hint to the underlying execution engine to try and perform an in-memory join. " +
     "Whether it is actually loaded into memory is up to the engine. This property is ignored when MapReduce is used.")
   private String inMemoryInputs;
 
-  @Nullable
   @Macro
+  @Nullable
+  @Name(JOIN_NULL_KEYS)
   @Description("Whether null values in the join key should be joined on. For example, if the join is on A.id = B.id " +
     "and this value is false, records with a null id from input stages A and B will not get joined together.")
   private Boolean joinNullKeys;
 
-  @Nullable
   @Macro
-  @Description(DISTRIBUTION_FACTOR_DESC)
+  @Nullable
+  @Name(DISTRIBUTION_FACTOR)
+  @Description("This controls the size of the salt that will be generated for distribution. The number of partitions "
+    + "should be greater than or equal to this number for optimal results. A larger value will lead to more "
+    + "parallelism but it will also grow the size of the non-skewed dataset by this factor.")
   private Integer distributionFactor;
 
-  @Nullable
   @Macro
-  @Description(DISTRIBUTION_STAGE_DESC)
+  @Nullable
+  @Name(DISTRIBUTION_STAGE)
+  @Description("Name of the skewed input stage. The skewed input stage is the one that contains many rows that join "
+    + "to the same row in the non-skewed stage. Ex. If stage A has 10 rows that join on the same row in stage B, then"
+    + " stage A is the skewed input stage")
   private String distributionStageName;
 
   @Macro
   @Nullable
+  @Name(DISTRIBUTION_ENABLED)
   @Description("Distribution is useful when the input data is skewed. Enabling distribution will allow you to "
     + "increase the parallelism for skewed data.")
   private Boolean distributionEnabled;
 
+  @Macro
+  @Nullable
+  @Name(CONDITION_TYPE)
+  @Description("Whether to join on equality or a more complex condition.")
+  private String conditionType;
+
+  @Macro
+  @Nullable
+  @Name(CONDITION_EXPR)
+  @Description("Join condition as a SQL expression.")
+  private String conditionExpression;
+
+  @Macro
+  @Nullable
+  @Name(INPUT_ALIASES)
+  @Description("Aliases for input data. " +
+    "Use this to give more readable names to input data when using advanced join conditions.")
+  private String inputAliases;
 
   public JoinerConfig() {
     this.joinKeys = "";
@@ -144,6 +176,14 @@ public class JoinerConfig extends PluginConfig {
     this.joinKeys = joinKeys;
     this.selectedFields = selectedFields;
     this.requiredInputs = requiredInputs;
+  }
+
+  @VisibleForTesting
+  JoinerConfig(String selectedFields, String conditionExpression) {
+    this.selectedFields = selectedFields;
+    this.requiredInputs = requiredInputs;
+    this.conditionType = ADVANCED;
+    this.conditionExpression = conditionExpression;
   }
 
   @Nullable
@@ -163,8 +203,55 @@ public class JoinerConfig extends PluginConfig {
   }
 
   boolean requiredPropertiesContainMacros() {
-    return containsMacro(SELECTED_FIELDS) || containsMacro(REQUIRED_INPUTS) || containsMacro(JOIN_KEYS) ||
-      containsMacro(OUTPUT_SCHEMA);
+    return containsMacro(SELECTED_FIELDS) || containsMacro(REQUIRED_INPUTS) ||
+      containsMacro(OUTPUT_SCHEMA) || containsMacro(CONDITION_TYPE) ||
+      (BASIC.equalsIgnoreCase(conditionType) && containsMacro(JOIN_KEYS)) ||
+      (ADVANCED.equalsIgnoreCase(conditionType) && containsMacro(CONDITION_EXPR));
+  }
+
+  private JoinCondition.Op getConditionType(FailureCollector failureCollector) {
+    if (conditionType == null || conditionType.isEmpty() || BASIC.equals(conditionType)) {
+      return JoinCondition.Op.KEY_EQUALITY;
+    }
+    if (ADVANCED.equalsIgnoreCase(conditionType)) {
+      return JoinCondition.Op.EXPRESSION;
+    }
+    failureCollector.addFailure("Invalid condition type " + conditionType, "Set it to 'basic' or 'advanced'.");
+    throw failureCollector.getOrThrowException();
+  }
+
+  private Map<String, String> getInputAliases(FailureCollector failureCollector) {
+    if (inputAliases == null || inputAliases.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> aliases = new HashMap<>();
+    KeyValueListParser kvParser = new KeyValueListParser(";", "=");
+    try {
+      for (KeyValue<String, String> alias : kvParser.parse(inputAliases)) {
+        aliases.put(alias.getKey(), alias.getValue());
+      }
+    } catch (Exception e) {
+      failureCollector.addFailure(e.getMessage(), null).withConfigProperty(INPUT_ALIASES);
+    }
+    return aliases;
+  }
+
+  JoinCondition getCondition(FailureCollector failureCollector) {
+    JoinCondition.Op conditionType = getConditionType(failureCollector);
+    switch (conditionType) {
+      case KEY_EQUALITY:
+        return JoinCondition.onKeys()
+          .setKeys(getJoinKeys(failureCollector))
+          .setNullSafe(isNullSafe())
+          .build();
+      case EXPRESSION:
+        return JoinCondition.onExpression()
+          .setExpression(conditionExpression)
+          .setDatasetAliases(getInputAliases(failureCollector))
+          .build();
+    }
+    // will never happen unless getConditionType() is changed without changing this
+    throw new IllegalStateException("Unsupported condition type " + conditionType);
   }
 
   Set<JoinKey> getJoinKeys(FailureCollector failureCollector) {

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerTestRun.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerTestRun.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/core-plugins/widgets/Joiner-batchjoiner.json
+++ b/core-plugins/widgets/Joiner-batchjoiner.json
@@ -22,10 +22,44 @@
           "description": "Type of joins to be performed. Inner join means all stages are required, while Outer join allows for 0 or more input stages to be required input."
         },
         {
+          "widget-type": "radio-group",
+          "name": "conditionType",
+          "label": "Join Condition Type",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "Basic",
+            "options": [
+              {
+                "id": "Basic"
+              },
+              {
+                "id": "Advanced"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "sql-conditions",
           "label": "Join Condition",
           "name": "joinKeys",
           "description": "List of join keys to perform join operation."
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "Input Aliases",
+          "name": "inputAliases",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "key-placeholder": "Input Name",
+            "value-placeholder": "Alias",
+            "kv-delimiter" : "=",
+            "delimiter" : ";"
+          }
+        },
+        {
+          "widget-type": "textarea",
+          "label": "Join Condition",
+          "name": "conditionExpression"
         },
         {
           "widget-type": "get-schema",
@@ -101,7 +135,9 @@
     {
       "name": "distribution rules",
       "condition": {
-        "expression": "distributionEnabled == true"
+        "property": "distributionEnabled",
+        "operator":  "equal to",
+        "value": "true"
       },
       "show": [
         {
@@ -109,6 +145,44 @@
         },
         {
           "name": "distributionStageName"
+        }
+      ]
+    },
+    {
+      "name": "basic condition",
+      "condition": {
+        "property": "conditionType",
+        "operator": "equal to",
+        "value": "Basic"
+      },
+      "show": [
+        {
+          "name": "distributionEnabled"
+        },
+        {
+          "name": "joinKeys"
+        },
+        {
+          "name": "numPartitions"
+        },
+        {
+          "name": "joinNullKeys"
+        }
+      ]
+    },
+    {
+      "name": "advanced condition",
+      "condition": {
+        "property": "conditionType",
+        "operator": "equal to",
+        "value": "Advanced"
+      },
+      "show": [
+        {
+          "name": "conditionExpression"
+        },
+        {
+          "name": "inputAliases"
         }
       ]
     }


### PR DESCRIPTION
Added a condition type property that toggles between basic and
advanced modes. Basic is the currently behavior that joins on
key equality, while advanced is an arbitrary SQL expression.

Most of the implementation is simply to add configuration
properties and pass them down to the underlying framework.
Also did some cleanup on the JoinerConfig to make all the
properties consistent in style.