### PR TITLE
Support datetime for generic db source and sink. 

### DIFF
--- a/database-plugins/src/main/java/io/cdap/plugin/DBUtils.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/DBUtils.java
@@ -132,7 +132,7 @@ public final class DBUtils {
           resultsetField.getSchema().getNonNullable() : resultsetField.getSchema();
         Schema simpleSchema = field.getSchema().isNullable() ? field.getSchema().getNonNullable() : field.getSchema();
 
-        if (!resultsetFieldSchema.equals(simpleSchema)) {
+        if (!isCompatible(resultsetFieldSchema, simpleSchema)) {
           throw new IllegalArgumentException(String.format("Schema field '%s' has type '%s' but in input record " +
                                                              "found type '%s'.",
                                                            field.getName(), simpleSchema.getDisplayName(),
@@ -143,6 +143,18 @@ public final class DBUtils {
 
     }
     return resultsetSchema.getFields();
+  }
+
+  private static boolean isCompatible(Schema resultSetSchema, Schema mappedSchema) {
+    if (resultSetSchema.equals(mappedSchema)) {
+      return true;
+    }
+    //allow mapping from string to datetime, values will be validated for format
+    if (resultSetSchema.getType() == Schema.Type.STRING && mappedSchema
+      .getLogicalType() == Schema.LogicalType.DATETIME) {
+      return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
- Support datetime for generic db source and sink. 
- String columns can be mapped to datetime in source plugin
- datetime fields can be mapped to string columns in sink plugin.
- Automatic mapping of schema to datetime field type is not supported in generic db source , sink.