### PR TITLE
More fixes to migrate to spark 2 from spark 1

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -157,6 +157,12 @@
       <version>1.2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>1.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>format-avro</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -725,24 +725,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <!--
-      Spark dependencies are needed in unit-test.
-      They are not included from transitive dependencies because cdap-etl-api-spark is in provided scope
-    -->
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-  </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <properties>
-    <spark.version>1.6.1</spark.version>
+    <spark.version>2.1.3</spark.version>
   </properties>
 
   <name>Spark Hydrator Plugins</name>
@@ -86,7 +86,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_2.11</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>
@@ -143,19 +143,19 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.10</artifactId>
+      <artifactId>spark-mllib_2.11</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
+      <artifactId>spark-streaming_2.11</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_2.10</artifactId>
+      <artifactId>spark-repl_2.11</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -172,8 +172,9 @@
       <artifactId>twitter4j-stream</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-twitter_2.10</artifactId>
+      <groupId>org.apache.bahir</groupId>
+      <artifactId>spark-streaming-twitter_2.11</artifactId>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>


### PR DESCRIPTION
Fixes unit tests by proper migration to Spark 2 dependencies
Note: unit tests will fail in this build as we did not publish our cdap snapshots with spark 3 yet. To publish it we need to fix all the tests, so it should happen after this PR is merged. I've tested all failing tests locally, they pass with latest cdap artifacts