### PR TITLE
CDAP-17945 fix broken unit tests due to bad YarnConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,14 @@
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
+          <!--
+                CDAP-17945: this has its own implementation of YarnConfiguration for some reason,
+                which breaks unit tests. Hive/Explore is really not used anymore, so excluding it.
+           -->
+          <exclusion>
+            <groupId>io.cdap.cdap</groupId>
+            <artifactId>cdap-explore-jdbc</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
cdap-explore-jdbc has its own implementation of YarnConfiguration
for some reason, which calls some method that doesn't exist in
all yarn versions. Excluding the dependency since it's not used
anywhere.