### PR TITLE
PLUGIN-637: Date and time types don't work with delimited formats in File source - CherryPick for release/2.5

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -198,6 +198,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Date and time types don't work with delimited formats in File source.

JIRA Ticket: https://cdap.atlassian.net/browse/PLUGIN-637

Fix PR: https://github.com/cdapio/hydrator-plugins/pull/1370