### PR TITLE
CDAP-18048 use unique name for output fileset in test

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
@@ -743,7 +743,7 @@ public class FileBatchSourceTest extends ETLBatchTestBase {
   public void testFileBatchInputFormatMacro() throws Exception {
     File outputFolder = temporaryFolder.newFolder();
     File fileText = new File(outputFolder, "test.txt");
-    String outputDatasetName = "test-filesource-text";
+    String outputDatasetName = UUID.randomUUID().toString();
 
     Schema textSchema = Schema.recordOf("file.record",
                                         Schema.Field.of("offset", Schema.of(Schema.Type.LONG)),


### PR DESCRIPTION
Fixed a test bug where multiple tests were writing to the same
dataset, causing unexpected data in the output.