### PR TITLE
CDAP-18060 fix getSchema issue at deploy time due to classloading

### DIFF
--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/input/AvroInputFormatProvider.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/input/AvroInputFormatProvider.java
@@ -124,7 +124,7 @@ public class AvroInputFormatProvider extends PathTrackingInputFormatProvider<Avr
       for (Map.Entry<String, String> entry : conf.getFileSystemProperties().entrySet()) {
         hconf.set(entry.getKey(), entry.getValue());
       }
-      Path file = conf.getFilePathForSchemaGeneration(filePath, ".+\\.avro", hconf);
+      Path file = conf.getFilePathForSchemaGeneration(filePath, ".+\\.avro", hconf, job);
       DatumReader<GenericRecord> dataReader = new GenericDatumReader<>();
       seekableInput = new FsInput(file, hconf);
       dataFileReader = DataFileReader.openReader(seekableInput, dataReader);

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
@@ -173,7 +173,7 @@ public class DelimitedConfig extends PathTrackingConfig {
     for (Map.Entry<String, String> entry : getFileSystemProperties().entrySet()) {
       configuration.set(entry.getKey(), entry.getValue());
     }
-    Path filePath = getFilePathForSchemaGeneration(path, regexPathFilter, configuration);
+    Path filePath = getFilePathForSchemaGeneration(path, regexPathFilter, configuration, job);
     DataTypeDetectorStatusKeeper dataTypeDetectorStatusKeeper = new DataTypeDetectorStatusKeeper();
     String line = null;
     String[] columnNames = null;

--- a/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
+++ b/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
@@ -99,7 +99,7 @@ public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<
       for (Map.Entry<String, String> entry : conf.getFileSystemProperties().entrySet()) {
         hconf.set(entry.getKey(), entry.getValue());
       }
-      final Path file = conf.getFilePathForSchemaGeneration(filePath, ".+\\.parquet", hconf);
+      final Path file = conf.getFilePathForSchemaGeneration(filePath, ".+\\.parquet", hconf, job);
       reader = AvroParquetReader.builder(file).build();
       GenericData.Record record = (GenericData.Record) reader.read();
       return Schema.parseJson(record.getSchema().toString());


### PR DESCRIPTION
This issue will make getSchema or validate or deploy never work for avro, delimited, parquet format. It is also causing ITN to fail. This issue persists in both 6.4 and 6.5