### PR TITLE
[CDAP-15794] making the error message consistent when delimited schema is wrong

### DIFF
--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
@@ -80,10 +80,14 @@ public class PathTrackingDelimitedInputFormat extends PathTrackingInputFormat {
 
         StructuredRecord.Builder builder = StructuredRecord.builder(schema);
         Iterator<Schema.Field> fields = schema.getFields().iterator();
+        Iterable<String> splitDelimitedString = Splitter.on(delimiter).split(delimitedString);
+        int numDataFields = 0;
+        for (String part : splitDelimitedString) {
+          numDataFields++;
+        }
 
-        for (String part : Splitter.on(delimiter).split(delimitedString)) {
+        for (String part : splitDelimitedString) {
           if (!fields.hasNext()) {
-            int numDataFields = delimitedString.split(delimiter).length;
             int numSchemaFields = schema.getFields().size();
             String message = String.format("Found a row with %d fields when the schema only contains %d field%s.",
                                            numDataFields, numSchemaFields, numSchemaFields == 1 ? "" : "s");

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/PathTrackingDelimitedInputFormat.java
@@ -81,13 +81,13 @@ public class PathTrackingDelimitedInputFormat extends PathTrackingInputFormat {
         StructuredRecord.Builder builder = StructuredRecord.builder(schema);
         Iterator<Schema.Field> fields = schema.getFields().iterator();
         Iterable<String> splitDelimitedString = Splitter.on(delimiter).split(delimitedString);
-        int numDataFields = 0;
-        for (String part : splitDelimitedString) {
-          numDataFields++;
-        }
 
         for (String part : splitDelimitedString) {
           if (!fields.hasNext()) {
+            int numDataFields = 0;
+            for (String temp : splitDelimitedString) {
+              numDataFields++;
+            }
             int numSchemaFields = schema.getFields().size();
             String message = String.format("Found a row with %d fields when the schema only contains %d field%s.",
                                            numDataFields, numSchemaFields, numSchemaFields == 1 ? "" : "s");


### PR DESCRIPTION
This change is for making the error message consistent when the data has more fields than the schema by using the same lib to print the length of data fields in splitted delimited string. 
Previously, splitting of every row was implemented using Splitter library of Guava but while printing the error message the length was being printed using java String.split() method.

Added a loop for counting the no of fields in the splitted data and removed the String.split() method.

Before-
<img width="1227" alt="Screen Shot 2021-08-20 at 6 18 57 PM" src="https://user-images.githubusercontent.com/88528384/130567804-b6a3e6fa-edb6-4650-8dd1-6d97f1a447a4.png">

After-
![Screen Shot 2021-08-23 at 9 57 13 AM](https://user-images.githubusercontent.com/88528384/130567867-a97ee07d-3ec8-4941-a28f-7cb7c05658f1.png)

JIRA - https://cdap.atlassian.net/browse/CDAP-15794