### PR TITLE
Adding additional docs to the Hasher plugin : the fields must be non nullable

### DIFF
--- a/transform-plugins/README.rst
+++ b/transform-plugins/README.rst
@@ -201,7 +201,8 @@ Hasher
 :Configuration:
   - **fields:** Specifies the fields to be hashed
   - **hash:** Specifies the hashing algorithm
-
+:Prerequisites:
+    The **fields** to be hashed must be of type `string` and `non-nullable`.
 XMLToJSONConverter
 ------------------
 :ID:

--- a/transform-plugins/docs/Hasher-transform.md
+++ b/transform-plugins/docs/Hasher-transform.md
@@ -4,13 +4,10 @@
 Description
 -----------
 Hashes fields using a digest algorithm such as ``MD2``, ``MD5``, ``SHA1``, ``SHA256``, ``SHA384``, or ``SHA512``.<br>
+The **fields** to be hashed must be of type `string` and `non-nullable`.
 
 Configuration
 -------------
 **fields:** Specifies the fields to be hashed.
 
 **hash:** Specifies the hashing algorithm.
-
-Prerequisites
--------------
-The **fields** to be hashed must be of type `string` and `non-nullable`.

--- a/transform-plugins/docs/Hasher-transform.md
+++ b/transform-plugins/docs/Hasher-transform.md
@@ -3,11 +3,14 @@
 
 Description
 -----------
-Hashes fields using a digest algorithm such as ``MD2``, ``MD5``, ``SHA1``, ``SHA256``, ``SHA384``, or ``SHA512``.
-
+Hashes fields using a digest algorithm such as ``MD2``, ``MD5``, ``SHA1``, ``SHA256``, ``SHA384``, or ``SHA512``.<br>
 
 Configuration
 -------------
 **fields:** Specifies the fields to be hashed.
 
 **hash:** Specifies the hashing algorithm.
+
+Prerequisites
+-------------
+The **fields** to be hashed must be of type `string` and `non-nullable`.


### PR DESCRIPTION
When debugging the Hasher plugin, we found out that the `fields` must be `non nullable`, as well as being of type `string`.
This PR is to add that information in the plugin docs.