### PR TITLE
[PLUGIN-754] Fix for certain avro schemas being parsed incorrectly

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
@@ -117,10 +117,12 @@ public class AvroToStructuredTest {
     AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();
 
     String jsonSchema = "{\"type\":\"record\", \"name\":\"rec\"," +
-        "\"fields\":[" +
+        "\"namespace\": \"com.google.test\", \"fields\":[" +
         "{\"name\": \"enumfield\", \"type\": " +
-        "{\"type\": \"enum\", \"name\": \"enumtype\", \"symbols\": [\"A\", \"B\", \"C\"]}}," +
-        "{\"name\": \"arr\", \"type\": {\"type\": \"array\", \"items\": \"enumtype\"}}]}";
+        "{\"type\": \"enum\", \"name\": \"enumtype\", \"namespace\": \"com.google.test.enum\"," +
+        "\"symbols\": [\"A\", \"B\", \"C\"]}}," +
+        "{\"name\": \"arr\", \"type\": {\"type\": \"array\", " +
+        "\"items\": \"com.google.test.enum.enumtype\"}}]}";
     org.apache.avro.Schema avroSchema = convertSchema(jsonSchema);
 
     Schema enumSchema = Schema.enumWith("A", "B", "C");
@@ -135,7 +137,7 @@ public class AvroToStructuredTest {
   public void testAvroToStructuredConversionForUnions() throws IOException {
     AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();
 
-    String jsonSchema = "{\"type\":\"record\", \"name\":\"rec\", \"fields\":[" +
+    String jsonSchema = "{\"type\":\"record\", \"name\":\"com.google.test.rec\", \"fields\":[" +
         "{\"name\": \"enumfield\", \"type\": " +
         "{\"type\": \"enum\", \"name\": \"enumtype\", \"symbols\": [\"A\", \"B\", \"C\"]}}," +
         "{\"name\": \"unionfield\", \"type\": [\"null\", \"string\", \"enumtype\"," +

--- a/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.transform;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.format.avro.AvroToStructuredTransformer;
@@ -55,10 +56,8 @@ public class AvroToStructuredTest {
       Schema.Field.of("int", Schema.of(Schema.Type.INT)),
       Schema.Field.of("double", Schema.of(Schema.Type.DOUBLE)),
       Schema.Field.of("array", Schema.arrayOf(Schema.of(Schema.Type.FLOAT))),
-      Schema.Field.of("array1", Schema.arrayOf(innerNestedSchema))
-
-      // uncomment this line once [CDAP - 2813 is fixed]. You might have to fix AvroToStructuredTransformer.java
-      // Schema.Field.of("map", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING)))
+      Schema.Field.of("array1", Schema.arrayOf(innerNestedSchema)),
+      Schema.Field.of("map", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING)))
     );
 
     Schema schema = Schema.recordOf(
@@ -83,8 +82,7 @@ public class AvroToStructuredTest {
              .set("double", 3.14159)
              .set("array", ImmutableList.of(1.0f, 2.0f))
              .set("array1", ImmutableList.of(inner, inner))
-               // uncomment this line once [CDAP - 2813 is fixed]. You might have to fix AvroToStructuredTransformer
-               // .set("map", ImmutableMap.of("key", "value"))
+             .set("map", ImmutableMap.of("key", "value"))
              .build())
       .build();
 
@@ -98,7 +96,46 @@ public class AvroToStructuredTest {
     Assert.assertEquals(0, array1Result.<Integer>get("int").intValue());
   }
 
+  @Test
+  public void testAvroToStructuredConversionForMaps() throws IOException {
+    AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();
+
+    String jsonSchema = "{\"type\":\"record\", \"name\":\"rec\"," +
+        "\"fields\":[{\"name\":\"mapfield\",\"type\":{\"type\":\"map\",\"values\":\"string\"}}]}";
+    org.apache.avro.Schema avroSchema = convertSchema(jsonSchema);
+
+    Schema cdapSchema = Schema.recordOf("rec",
+        Schema.Field.of(
+            "mapfield",
+            Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))));
+
+    Assert.assertEquals(avroToStructuredTransformer.convertSchema(avroSchema), cdapSchema);
+  }
+
+  @Test
+  public void testAvroToStructuredConversionForEnums() throws IOException {
+    AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();
+
+    String jsonSchema = "{\"type\":\"record\", \"name\":\"rec\"," +
+        "\"fields\":[" +
+        "{\"name\": \"enumfield\", \"type\": " +
+        "{\"type\": \"enum\", \"name\": \"enumtype\", \"symbols\": [\"A\", \"B\", \"C\"]}}," +
+        "{\"name\": \"arr\", \"type\": {\"type\": \"array\", \"items\": \"enumtype\"}}]}";
+    org.apache.avro.Schema avroSchema = convertSchema(jsonSchema);
+
+    Schema enumSchema = Schema.enumWith("A", "B", "C");
+    Schema cdapSchema = Schema.recordOf("rec",
+        Schema.Field.of("enumfield", enumSchema),
+        Schema.Field.of("arr", Schema.arrayOf(enumSchema)));
+
+    Assert.assertEquals(avroToStructuredTransformer.convertSchema(avroSchema), cdapSchema);
+  }
+
   private org.apache.avro.Schema convertSchema(Schema cdapSchema) {
     return new org.apache.avro.Schema.Parser().parse(cdapSchema.toString());
+  }
+
+  private org.apache.avro.Schema convertSchema(String jsonSchema) {
+    return new org.apache.avro.Schema.Parser().parse(jsonSchema);
   }
 }

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
@@ -98,18 +98,19 @@ public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, 
     if (schemaCache.containsKey(hashCode)) {
       structuredSchema = schemaCache.get(hashCode);
     } else {
-      String strSchema = schema.toString();
-      String jsonSchema = preprocessSchema(GSON.fromJson(strSchema, JsonObject.class)).toString();
-      structuredSchema = Schema.parseJson(jsonSchema);
+      JsonObject gsonSchema = GSON.fromJson(schema.toString(), JsonObject.class);
+      preprocessSchema(gsonSchema);
+      String processedJsonSchema = gsonSchema.toString();
+      structuredSchema = Schema.parseJson(processedJsonSchema);
       schemaCache.put(hashCode, structuredSchema);
     }
     return structuredSchema;
   }
 
-  private JsonObject preprocessSchema(JsonObject schema) {
+  private void preprocessSchema(JsonObject schema) {
 
     if (!schema.has("type")) {
-      return schema;
+      return;
     }
 
     JsonElement type = schema.get("type");
@@ -155,8 +156,6 @@ public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, 
           break;
       }
     }
-
-    return schema;
   }
 
   private JsonArray preprocessUnion(JsonArray schema) {


### PR DESCRIPTION
This is a fix for the bug [PLUGIN-754](https://cdap.atlassian.net/browse/PLUGIN-754).

On investigation, the following issues were observed:
* **Missing key for map.** The map datatype is always assumed to have a key type and a value type in the CDAP schema, but in an avro schema the [key type of a map is assumed to be a string](https://avro.apache.org/docs/current/spec.html#Maps) and therefore not explicitly mentioned. This PR adds a string key to the JSON representation of an avro map schema before converting it into a CDAP schema.
* **No support for referencing custom types.** An enum or record type mentioned in an avro schema cannot be referenced within the same schema as it is not a registered type in the CDAP schema. This PR substitutes such referenced types in the JSON representation of the avro schema before converting it into a CDAP schema.

Output for the same file mentioned in the bug report after the fix:

![image](https://user-images.githubusercontent.com/1991785/133494421-cbf2ae2d-26d3-4b05-9509-57d400e98639.png)

Known issue: The array type reference ("Score" in the above image) is resolved in the AvroToStructuredTransformer class as per the debugger but the UI does not receive this information, [throwing an error](https://github.com/cdapio/ui-schema-parser/blob/7fa333e0fe1208de6adc17e597ec847f5ae84124/lib/types.js#L101). This will be handled in a follow-up PR if possible.

[PLUGIN-754]: https://cdap.atlassian.net/browse/PLUGIN-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ