### PR TITLE
Fix double type detection during getschema

### DIFF
--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/common/TypeInference.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/common/TypeInference.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.format.delimited.common;
 
+import java.math.BigDecimal;
 import java.util.regex.Pattern;
 
 /**
@@ -157,7 +158,7 @@ public class TypeInference {
   private static DataType deepInvestigateDouble(String value) {
     try {
       Double doubleValue = Double.parseDouble(value);
-      if (doubleValue.toString().equals(value)) {
+      if (doubleValue.toString().equals(new BigDecimal(value).stripTrailingZeros().toString())) {
         return DataType.DOUBLE;
       }
       return DataType.STRING;

--- a/format-delimited/src/test/java/io/cdap/plugin/format/delimited/dq/TypeInferenceTest.java
+++ b/format-delimited/src/test/java/io/cdap/plugin/format/delimited/dq/TypeInferenceTest.java
@@ -151,11 +151,15 @@ public class TypeInferenceTest {
     DataType secondDataType = TypeInference.getDataType(secondValue);
     assertEquals(secondDataType, DataType.DOUBLE);
 
+    String thirdValue = "1789.10";
+    DataType thirdDataType = TypeInference.getDataType(thirdValue);
+    assertEquals(thirdDataType, DataType.DOUBLE);
+
     // Every value that when parsed to Double gets the number of digits shorten, we consider it as a Big Decimal
     // number. Hence we keep it as a string.
-    String thirdValue = "13004.012312312423112122121121212";
-    DataType thirdDataType = TypeInference.getDataType(thirdValue);
-    assertEquals(thirdDataType, DataType.STRING);
+    String fourthValue = "13004.012312312423112122121121212";
+    DataType fourthDataType = TypeInference.getDataType(fourthValue);
+    assertEquals(fourthDataType, DataType.STRING);
   }
 
 


### PR DESCRIPTION
This PR fixes detection of Double types for values with trailing zeros after the decimal point.
Jira - https://cdap.atlassian.net/browse/PLUGIN-696