### PR TITLE
Add logic to set the most skewed stage as the first stage in a join definition.

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
@@ -54,6 +54,7 @@ public class JoinerConfig extends PluginConfig {
   public static final String DISTRIBUTION_ENABLED = "distributionEnabled";
   public static final String DISTRIBUTION_FACTOR = "distributionFactor";
   public static final String DISTRIBUTION_STAGE = "distributionStageName";
+  public static final String MOST_SKEWED_INPUT = "mostSkewedInput";
   public static final String INPUT_ALIASES = "inputAliases";
   public static final String JOIN_KEYS = "joinKeys";
   public static final String JOIN_NULL_KEYS = "joinNullKeys";
@@ -165,6 +166,14 @@ public class JoinerConfig extends PluginConfig {
     "Use this to give more readable names to input data when using advanced join conditions.")
   private String inputAliases;
 
+  @Macro
+  @Nullable
+  @Name(MOST_SKEWED_INPUT)
+  @Description("Defines the most skewed stage for a join operation. You can select the most " +
+    "skewed input stage when executing join operations BigQuery ELT Transformation Pushdown, " +
+    "this may prevent a RESOURCE EXCEEDED error when executing join operations with skewed datasets")
+  private String mostSkewedInput;
+
   public JoinerConfig() {
     this.joinKeys = "";
     this.selectedFields = "";
@@ -176,6 +185,14 @@ public class JoinerConfig extends PluginConfig {
     this.joinKeys = joinKeys;
     this.selectedFields = selectedFields;
     this.requiredInputs = requiredInputs;
+  }
+
+  @VisibleForTesting
+  JoinerConfig(String joinKeys, String selectedFields, String requiredInputs, String mostSkewedInput) {
+    this.joinKeys = joinKeys;
+    this.selectedFields = selectedFields;
+    this.requiredInputs = requiredInputs;
+    this.mostSkewedInput = mostSkewedInput;
   }
 
   @VisibleForTesting
@@ -370,6 +387,11 @@ public class JoinerConfig extends PluginConfig {
     return distributionStageName;
   }
 
+  @Nullable
+  public String getMostSkewedInput() {
+    return mostSkewedInput;
+  }
+
   public boolean isDistributionValid(FailureCollector collector) {
     int startFailures = collector.getValidationFailures().size();
 
@@ -399,5 +421,9 @@ public class JoinerConfig extends PluginConfig {
     return containsMacro("distributionEnabled") ||
       containsMacro(DISTRIBUTION_FACTOR) ||
       containsMacro(DISTRIBUTION_STAGE);
+  }
+
+  public boolean mostSkewedInputContainsMacro() {
+    return containsMacro(MOST_SKEWED_INPUT);
   }
 }

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerConfigTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/joiner/JoinerConfigTest.java
@@ -440,4 +440,62 @@ public class JoinerConfigTest {
     }
   }
 
+  @Test
+  public void testJoinerConfigWithMostSkewedInput() {
+    JoinerConfig config;
+    Joiner joiner;
+    FailureCollector collector;
+    AutoJoinerContext autoJoinerContext;
+    JoinDefinition joinDefinition;
+
+    // Test stages reordering - film
+    config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
+                                "film.film_name=filmActor.film_name=filmCategory.film_name",
+                              SELECTED_FIELDS,
+                              "film,filmActor,filmCategory",
+                              "film");
+
+    joiner = new Joiner(config);
+    collector = new MockFailureCollector();
+    autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+
+    joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertNotNull(joinDefinition);
+    Assert.assertNotNull(joinDefinition.getStages());
+    Assert.assertEquals("film", joinDefinition.getStages().get(0).getStageName());
+
+    // Test stages reordering - filmActor
+    config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
+                                "film.film_name=filmActor.film_name=filmCategory.film_name",
+                              SELECTED_FIELDS,
+                              "film,filmActor,filmCategory",
+                              "filmActor");
+
+    joiner = new Joiner(config);
+    collector = new MockFailureCollector();
+    autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+
+    joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertNotNull(joinDefinition);
+    Assert.assertNotNull(joinDefinition.getStages());
+    Assert.assertEquals("filmActor", joinDefinition.getStages().get(0).getStageName());
+
+    // Test stages reordering - filmCategory
+    config = new JoinerConfig("film.film_id=filmActor.film_id=filmCategory.film_id&" +
+                                "film.film_name=filmActor.film_name=filmCategory.film_name",
+                              SELECTED_FIELDS,
+                              "film,filmActor,filmCategory",
+                              "filmCategory");
+
+    joiner = new Joiner(config);
+    collector = new MockFailureCollector();
+    autoJoinerContext = new MockAutoJoinerContext(INPUT_STAGES, collector);
+
+    joinDefinition = joiner.define(autoJoinerContext);
+    Assert.assertNotNull(joinDefinition);
+    Assert.assertNotNull(joinDefinition.getStages());
+    Assert.assertEquals("filmCategory", joinDefinition.getStages().get(0).getStageName());
+
+  }
+
 }

--- a/core-plugins/widgets/Joiner-batchjoiner.json
+++ b/core-plugins/widgets/Joiner-batchjoiner.json
@@ -131,6 +131,19 @@
           }
         }
       ]
+    },
+    {
+      "label": "ELT Transformation Pushdown",
+      "properties": [
+        {
+          "widget-type": "multiple-input-stage-selector",
+          "label": "Input with Larger Data Skew",
+          "name": "mostSkewedInput",
+          "widget-attributes": {
+            "singleSelectOnly": "true"
+          }
+        }
+      ]
     }
   ],
   "filters": [


### PR DESCRIPTION
Added logic to reorder stages when creating a join definition. This is useful when pushing down joins into BigQuery to prevent RESOURCE_EXCEEDED errors.

See https://cdap.atlassian.net/browse/PLUGIN-918 

![image](https://user-images.githubusercontent.com/7290959/139478518-2b606392-496f-4d78-871e-a6b6ac05f8a9.png)

![image](https://user-images.githubusercontent.com/7290959/139478711-faeb95a7-86a5-4892-a30c-1d1b00db8d4c.png)

