### PR TITLE
Escaping regex sequences in schema column headers split.

### DIFF
--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/common/DataTypeDetectorUtils.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/common/DataTypeDetectorUtils.java
@@ -98,10 +98,13 @@ public class DataTypeDetectorUtils {
    */
   public static String[] setColumnNames(String rawLine, boolean skipHeader, String delimiter) {
     String[] columnNames;
+    final String quotedDelimiter = Pattern.quote(delimiter);
     if (skipHeader) {
-      columnNames = rawLine.split(delimiter);
+      // String.split uses regex. Here we safely escape regex sequences by using Pattern.quote
+      // Pattern.quote returns a literal pattern string
+      columnNames = rawLine.split(quotedDelimiter);
     } else {
-      columnNames = new String[rawLine.split(delimiter, -1).length];
+      columnNames = new String[rawLine.split(quotedDelimiter, -1).length];
       for (int j = 0; j < columnNames.length; j++) {
         columnNames[j] = String.format("%s_%s", "body", j);
       }

--- a/format-delimited/src/test/java/io/cdap/plugin/format/delimited/common/DataTypeDetectorUtilsTest.java
+++ b/format-delimited/src/test/java/io/cdap/plugin/format/delimited/common/DataTypeDetectorUtilsTest.java
@@ -44,6 +44,22 @@ public class DataTypeDetectorUtilsTest {
   }
 
   @Test
+  public void testExtractedColumnNamesRegexMetaCharacterDelimiter() {
+    String headerLine = "column_A|column_B|column_C";
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, "|");
+    String[] expectedColumnNames = new String[]{"column_A", "column_B", "column_C"};
+    assertArrayEquals(expectedColumnNames, actualColumnNames);
+  }
+
+  @Test
+  public void testGeneratedColumnNamesForRegexMetaCharacterDelimiter() {
+    String dataLine = "John|Doe|27";
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(dataLine, false, "|");
+    String[] expectedColumnNames = new String[]{"body_0", "body_1", "body_2"};
+    assertArrayEquals(expectedColumnNames, actualColumnNames);
+  }
+
+  @Test
   public void testGeneratedColumnNames() {
     String dataLine = "John;Doe;27";
     String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(dataLine, false, ";");


### PR DESCRIPTION
**Issue:**
https://cdap.atlassian.net/browse/PLUGIN-972
https://b.corp.google.com/issues/205116841

**Context:**

java's String::split is for regex expressions. Column headers are incorrectly split on regex metacharacters, thereby throwing an error. Escaping regex sequences safely is the solution.