### PR TITLE
Updated some of the SQL aggregator functions

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/GroupByAggregator.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/GroupByAggregator.java
@@ -113,16 +113,14 @@ implements LinearRelationalTransform {
     put(GroupByConfig.Function.COUNT, "COUNT(%s)");
     put(GroupByConfig.Function.MAX, "MAX(%s)");
     put(GroupByConfig.Function.MIN, "MIN(%s)");
-    put(GroupByConfig.Function.STDDEV, "STDDEV(%s)");
+    put(GroupByConfig.Function.STDDEV, "STDDEV_POP(%s)");
     put(GroupByConfig.Function.SUM, "SUM(%s)");
-    put(GroupByConfig.Function.VARIANCE, "VARIANCE(%s)");
-    put(GroupByConfig.Function.COLLECTLIST, "ARRAY_AGG(%s)");
-    put(GroupByConfig.Function.COLLECTSET, "ARRAY_AGG(DISTINCT %s)");
-    put(GroupByConfig.Function.COUNTDISTINCT, "COUNT(DISTINCT %s)");
-    put(GroupByConfig.Function.CONCAT, "STRING_AGG(CAST(%s AS STRING))");
-    put(GroupByConfig.Function.CONCATDISTINCT, "STRING_AGG(CAST(%s AS STRING))");
-    put(GroupByConfig.Function.LOGICALAND, "LOGICAL_AND(%s)");
-    put(GroupByConfig.Function.LOGICALOR, "LOGICAL_OR(%s)");
+    put(GroupByConfig.Function.VARIANCE, "VAR_POP(%s)");
+    put(GroupByConfig.Function.COUNTDISTINCT, "COUNT(DISTINCT %s) + IF(COUNTIF(%<s IS NULL) > 0, 1, 0)");
+    put(GroupByConfig.Function.CONCAT, "STRING_AGG(CAST(%s AS STRING), \", \")");
+    put(GroupByConfig.Function.CONCATDISTINCT, "STRING_AGG(DISTINCT CAST(%s AS STRING) , \", \")");
+    put(GroupByConfig.Function.LOGICALAND, "COALESCE(LOGICAL_AND(%s), TRUE)");
+    put(GroupByConfig.Function.LOGICALOR, "COALESCE(LOGICAL_OR(%s), FALSE)");
   }};
 
   private List<String> groupByFields;


### PR DESCRIPTION
Replaced some of the functions to match Spark behaviors:

- Using population STDDEV implementation to match Spark.
- Using population VARIANCE implementation to match Spark.
- Count distinct adds one extra count for null values to match Spark.
- Logical And will be `TRUE` if all inputs are null, or there are zero inputs.
- Logica Or will be `FALSE` if all inputs are null, or if there are zero inputs.
- Concat now uses `, ` as separator
- Concat distinct now works and uses `, ` as separator

Removed two unsupported functions
-  Collect List and Collect Set will fail if there are empty values in BigQuery, while in Spark the null values get collected.