### PR TITLE
Add test case for BQ Aggregation pushdown for group by

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/batch/aggregator/GroupByRelationalTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/aggregator/GroupByRelationalTest.java
@@ -77,6 +77,20 @@ public class GroupByRelationalTest {
   }
 
   @Test
+  public void testMixedValidityGroupBy() {
+    GroupByConfig config = new GroupByConfig("profession",
+                                             "numEmployees: countif(*): condition(salary>100000)," +
+                                               "stddevSal: stddev(salary)," +
+                                               "maxSal: max(salary)");
+    GroupByAggregator aggregator = new GroupByAggregator(config);
+    Relation result = aggregator.transform(relationalTranformContext, relation);
+
+    Assert.assertFalse(result.isValid());
+    Assert.assertEquals("Unsupported aggregation definition",
+                        result.getValidationError());
+  }
+
+  @Test
   public void testConditionalGroupBy() throws Exception {
     GroupByConfig config = new GroupByConfig("profession",
                                              "numEmployees: countif(*): condition(salary>100000)");


### PR DESCRIPTION
This PR adds a test case for a `GroupByAggregationDefinition` with mixed validity, i.e. a definition in which some expressions are valid for pushdown and some aren't. The expected behaviour is that an invalid relation is generated as some of the expressions are not supported for pushdown.