### PR TITLE
CDAP-18918: add the key value pair limit to Deduplicate widget

### DIFF
--- a/core-plugins/widgets/Deduplicate-batchaggregator.json
+++ b/core-plugins/widgets/Deduplicate-batchaggregator.json
@@ -22,6 +22,7 @@
           "widget-attributes": {
             "showDelimiter": "false",
             "kv-delimiter" : ":",
+            "kv-pair-limit": 1,
             "delimiter" : ";",
             "dropdownOptions": [
               "Any",


### PR DESCRIPTION
Add count limit for key value pair filter operations in Deduplicate plugin widget. The sister PR: https://github.com/cdapio/cdap-ui/pull/391