### PR TITLE
CDAP-18994 fix errors with nullable map values

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/transform/AvroToStructuredTest.java
@@ -96,27 +96,7 @@ public class AvroToStructuredTest {
     Assert.assertEquals(0, array1Result.<Integer>get("int").intValue());
   }
 
-  @Test
-  public void testAvroToStructuredConversionForMaps() throws IOException {
-    AvroToStructuredTransformer avroToStructuredTransformer = new AvroToStructuredTransformer();
-
-    String jsonSchema = "{\"type\":\"record\", \"name\":\"rec\"," +
-        "\"fields\":[{\"name\":\"mapfield\",\"type\":{\"type\":\"map\",\"values\":\"string\"}}]}";
-    org.apache.avro.Schema avroSchema = convertSchema(jsonSchema);
-
-    Schema cdapSchema = Schema.recordOf("rec",
-        Schema.Field.of(
-            "mapfield",
-            Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))));
-
-    Assert.assertEquals(avroToStructuredTransformer.convertSchema(avroSchema), cdapSchema);
-  }
-
   private org.apache.avro.Schema convertSchema(Schema cdapSchema) {
     return new org.apache.avro.Schema.Parser().parse(cdapSchema.toString());
-  }
-
-  private org.apache.avro.Schema convertSchema(String jsonSchema) {
-    return new org.apache.avro.Schema.Parser().parse(jsonSchema);
   }
 }

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
@@ -17,9 +17,6 @@
 package io.cdap.plugin.format.avro;
 
 import com.google.common.collect.Maps;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -36,9 +33,6 @@ import javax.annotation.Nullable;
  * Create StructuredRecords from GenericRecords
  */
 public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, StructuredRecord> {
-
-  private static final Gson GSON = new Gson();
-
   private final Map<Integer, Schema> schemaCache = Maps.newHashMap();
 
   public StructuredRecord transform(GenericRecord genericRecord) throws IOException {
@@ -96,57 +90,9 @@ public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, 
     if (schemaCache.containsKey(hashCode)) {
       structuredSchema = schemaCache.get(hashCode);
     } else {
-      JsonObject gsonSchema = GSON.fromJson(schema.toString(), JsonObject.class);
-      preprocessSchema(gsonSchema);
-      String processedJsonSchema = gsonSchema.toString();
-      structuredSchema = Schema.parseJson(processedJsonSchema);
+      structuredSchema = Schema.parseJson(schema.toString());
       schemaCache.put(hashCode, structuredSchema);
     }
     return structuredSchema;
-  }
-
-  private void preprocessSchema(JsonObject schema) {
-
-    if (!schema.has("type")) {
-      return;
-    }
-
-    JsonElement type = schema.get("type");
-
-    if (type.isJsonArray()) {   // Union
-      for (JsonElement subtype : type.getAsJsonArray()) {
-        if (!subtype.isJsonPrimitive()) {
-          preprocessSchema(subtype.getAsJsonObject());
-        }
-      }
-    } else if (type.isJsonObject()) {   // Unnamed Complex type
-      preprocessSchema(type.getAsJsonObject());
-    } else {
-      String typeName = type.getAsString();
-      switch (typeName) {
-        case "record":
-          for (JsonElement field : schema.get("fields").getAsJsonArray()) {
-            preprocessSchema(field.getAsJsonObject());
-          }
-          break;
-
-        case "map":
-          schema.addProperty("keys", "string");
-          if (!schema.get("values").isJsonPrimitive()) {
-            preprocessSchema(schema.getAsJsonObject("values"));
-          }
-          break;
-
-        case "array":
-          JsonElement items = schema.get("items");
-          if (!items.isJsonPrimitive()) {
-            preprocessSchema(schema.getAsJsonObject("items"));
-          }
-          break;
-
-        default:
-          break;
-      }
-    }
   }
 }


### PR DESCRIPTION
Remove schema preprocessing that was causing failures when a schema
had a map with nullable values. Manually modifying the schema json is
brittle, doesn't fix the issue for parquet, and is also not performant.

CDAP schema parsing now does the correct thing so no preprocessing
is needed.