### PR TITLE
[CDAP-19013] fix header not able to parse quotes when quoted values enabled

### DIFF
--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
@@ -203,7 +203,7 @@ public class DelimitedConfig extends PathTrackingConfig {
       for (int rowIndex = 0; rowIndex < getSampleSize() && (line = bufferedReader.readLine()) != null; rowIndex++) {
         rowValue = line.split(delimiter, -1);
         if (rowIndex == 0) {
-          columnNames = DataTypeDetectorUtils.setColumnNames(line, getSkipHeader(), delimiter);
+          columnNames = DataTypeDetectorUtils.setColumnNames(line, getSkipHeader(), getEnableQuotedValues(), delimiter);
           if (getSkipHeader()) {
             continue;
           }

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/SplitQuotesIterator.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/SplitQuotesIterator.java
@@ -36,7 +36,7 @@ public class SplitQuotesIterator extends AbstractIterator<String> {
   private int index;
   private boolean endingWithDelimiter = false;
 
-  SplitQuotesIterator(String delimitedString, String delimiter) {
+  public SplitQuotesIterator(String delimitedString, String delimiter) {
     this.delimitedString = delimitedString;
     this.delimiter = delimiter;
     index = 0;

--- a/format-delimited/src/test/java/io/cdap/plugin/format/delimited/common/DataTypeDetectorUtilsTest.java
+++ b/format-delimited/src/test/java/io/cdap/plugin/format/delimited/common/DataTypeDetectorUtilsTest.java
@@ -38,7 +38,7 @@ public class DataTypeDetectorUtilsTest {
   @Test
   public void testExtractedColumnNames() {
     String headerLine = "column_A;column_B;column_C";
-    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, ";");
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, false, ";");
     String[] expectedColumnNames = new String[]{"column_A", "column_B", "column_C"};
     assertArrayEquals(expectedColumnNames, actualColumnNames);
   }
@@ -46,7 +46,23 @@ public class DataTypeDetectorUtilsTest {
   @Test
   public void testExtractedColumnNamesRegexMetaCharacterDelimiter() {
     String headerLine = "column_A|column_B|column_C";
-    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, "|");
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, false, "|");
+    String[] expectedColumnNames = new String[]{"column_A", "column_B", "column_C"};
+    assertArrayEquals(expectedColumnNames, actualColumnNames);
+  }
+
+  @Test
+  public void testExtractedQuotedColumnNames() {
+    String headerLine = "\"column_A\";\"column_B\";\"column_C\"";
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, true, ";");
+    String[] expectedColumnNames = new String[]{"column_A", "column_B", "column_C"};
+    assertArrayEquals(expectedColumnNames, actualColumnNames);
+  }
+
+  @Test
+  public void testExtractedQuotedColumnNamesRegexMetaCharacterDelimiter() {
+    String headerLine = "\"column_A\"|\"column_B\"|\"column_C\"";
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(headerLine, true, true, "|");
     String[] expectedColumnNames = new String[]{"column_A", "column_B", "column_C"};
     assertArrayEquals(expectedColumnNames, actualColumnNames);
   }
@@ -54,7 +70,7 @@ public class DataTypeDetectorUtilsTest {
   @Test
   public void testGeneratedColumnNamesForRegexMetaCharacterDelimiter() {
     String dataLine = "John|Doe|27";
-    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(dataLine, false, "|");
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(dataLine, false, false, "|");
     String[] expectedColumnNames = new String[]{"body_0", "body_1", "body_2"};
     assertArrayEquals(expectedColumnNames, actualColumnNames);
   }
@@ -62,7 +78,7 @@ public class DataTypeDetectorUtilsTest {
   @Test
   public void testGeneratedColumnNames() {
     String dataLine = "John;Doe;27";
-    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(dataLine, false, ";");
+    String[] actualColumnNames = DataTypeDetectorUtils.setColumnNames(dataLine, false, false, ";");
     String[] expectedColumnNames = new String[]{"body_0", "body_1", "body_2"};
     assertArrayEquals(expectedColumnNames, actualColumnNames);
   }


### PR DESCRIPTION
# fix header not able to parse quotes when quoted values enabled

## Description
Add additional check for enableQuotedValues in setColumnNames to parse quotes if necessary; add two corresponding unit tests

## Link
[CDAP-19013](https://cdap.atlassian.net/browse/CDAP-19013)