### PR TITLE
Add javax.mail property as a configuration for Email Alert Plugin

### DIFF
--- a/core-plugins/docs/Email-postaction.md
+++ b/core-plugins/docs/Email-postaction.md
@@ -40,6 +40,10 @@ If set to 'failure', the action will only be executed if the pipeline run failed
 
 **includeWorkflowToken:** Whether to include the contents of the workflow token in the email message. Defaults to false.
 
+**configurableJavaMailProperties:** Optional property that can be used to pass specific set of javamail properties.
+The syntax is '<property_name>:<value>'. If this property is not set, default values are chosen.
+
+
 Example
 -------
 This example sends an email from 'team-ops@example.com' to 'team-alerts@example.com' whenever a run fails:

--- a/core-plugins/widgets/Email-postaction.json
+++ b/core-plugins/widgets/Email-postaction.json
@@ -79,6 +79,16 @@
             ],
             "default": "false"
           }
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "Configurable Java Mail Properties",
+          "name": "configurableJavaMailProperties",
+          "widget-attributes" : {
+            "placeholder": "Java Mail Properties.",
+            "delimiter": ",",
+            "kv-delimiter": "="
+          }
         }
       ]
     }


### PR DESCRIPTION
**Issue**
https://cdap.atlassian.net/browse/PLUGIN-1233

** Description **

Added a configuration to the Email Alert plugin that takes javax.mail properties as input from the user (https://www.educba.com/java-mail-properties/?source=leftnav). Also added the fix for the SSLv3- conscrypt issue (https://cdap.atlassian.net/browse/PLUGIN-1140)

** Testing **

https://dev651-apestel-dot-usw1.datafusion.googleusercontent.com/pipelines/ns/default/view/ephemeral_test_no_input_v3


