### PR TITLE
Initial commit for GCS Batch Source plugin metadata feature.

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
@@ -209,6 +209,18 @@ public class FTPBatchSource extends AbstractFileSource {
       return null;
     }
 
+    @Nullable
+    @Override
+    public String getLengthField() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public String getModificationTimeField() {
+      return null;
+    }
+
     @Override
     public boolean useFilenameAsPath() {
       return false;

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/ETLMapReduceTestRun.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/ETLMapReduceTestRun.java
@@ -52,7 +52,7 @@ import java.util.List;
  * Tests for ETLBatch.
  */
 public class ETLMapReduceTestRun extends ETLBatchTestBase {
-  private static final Schema TEXT_SCHEMA = TextInputFormatProvider.getDefaultSchema(null);
+  private static final Schema TEXT_SCHEMA = TextInputFormatProvider.getDefaultSchema(null, null, null);
 
   @Test
   public void testInvalidTransformConfigFailsToDeploy() {

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/AvroToStructuredTransformer.java
@@ -26,6 +26,7 @@ import org.apache.avro.generic.GenericRecord;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -51,11 +52,11 @@ public class AvroToStructuredTransformer extends RecordConverter<GenericRecord, 
   }
 
   public StructuredRecord.Builder transform(GenericRecord genericRecord, Schema structuredSchema,
-                                            @Nullable String skipField) throws IOException {
+                                            @Nullable List<String> skipFields) throws IOException {
     StructuredRecord.Builder builder = StructuredRecord.builder(structuredSchema);
     for (Schema.Field field : structuredSchema.getFields()) {
       String fieldName = field.getName();
-      if (!fieldName.equals(skipField)) {
+      if (!skipFields.contains(fieldName)) {
         builder.set(fieldName, convertField(genericRecord.get(fieldName), field));
       }
     }

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/input/PathTrackingAvroInputFormat.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/input/PathTrackingAvroInputFormat.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.format.avro.input;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.format.MetadataField;
 import io.cdap.plugin.format.avro.AvroToStructuredTransformer;
 import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import org.apache.avro.generic.GenericRecord;
@@ -31,7 +32,9 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -46,7 +49,17 @@ public class PathTrackingAvroInputFormat extends PathTrackingInputFormat {
 
     RecordReader<AvroKey<GenericRecord>, NullWritable> delegate = (new AvroKeyInputFormat<GenericRecord>())
       .createRecordReader(split, context);
-    return new AvroRecordReader(delegate, schema, pathField);
+    return new AvroRecordReader(delegate, schema, pathField, null);
+  }
+
+  @Override
+  protected RecordReader<NullWritable, StructuredRecord.Builder> createRecordReader(
+    FileSplit split, TaskAttemptContext context, @Nullable String pathField, Map<String, MetadataField> metadataFields,
+    @Nullable Schema schema) throws IOException, InterruptedException {
+
+    RecordReader<AvroKey<GenericRecord>, NullWritable> delegate = (new AvroKeyInputFormat<GenericRecord>())
+      .createRecordReader(split, context);
+    return new AvroRecordReader(delegate, schema, pathField, metadataFields);
   }
 
   /**
@@ -56,13 +69,15 @@ public class PathTrackingAvroInputFormat extends PathTrackingInputFormat {
     private final RecordReader<AvroKey<GenericRecord>, NullWritable> delegate;
     private final AvroToStructuredTransformer recordTransformer;
     private final String pathField;
+    private final Map<String, MetadataField> metadataFields;
     private Schema schema;
 
     AvroRecordReader(RecordReader<AvroKey<GenericRecord>, NullWritable> delegate, @Nullable Schema schema,
-                     @Nullable String pathField) {
+                     @Nullable String pathField, @Nullable Map<String, MetadataField> metadataFields) {
       this.delegate = delegate;
       this.schema = schema;
       this.pathField = pathField;
+      this.metadataFields = metadataFields == null ? Collections.EMPTY_MAP : metadataFields;
       this.recordTransformer = new AvroToStructuredTransformer();
     }
 
@@ -87,18 +102,25 @@ public class PathTrackingAvroInputFormat extends PathTrackingInputFormat {
       // if schema is null, but we're still able to read, that means the file contains the schema information
       // set the schema based on the schema of the record
       if (schema == null) {
-        if (pathField == null) {
+        if (pathField == null && metadataFields.isEmpty()) {
           schema = Schema.parseJson(genericRecord.getSchema().toString());
         } else {
           // if there is a path field, add the path as a field in the schema
           Schema schemaWithoutPath = Schema.parseJson(genericRecord.getSchema().toString());
           List<Schema.Field> fields = new ArrayList<>(schemaWithoutPath.getFields().size() + 1);
           fields.addAll(schemaWithoutPath.getFields());
-          fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+          if (pathField != null) {
+            fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+          }
+          for (String fieldName : metadataFields.keySet()) {
+            fields.add(Schema.Field.of(fieldName, Schema.of(metadataFields.get(fieldName).getSchemaType())));
+          }
           schema = Schema.recordOf(schemaWithoutPath.getRecordName(), fields);
         }
       }
-      return recordTransformer.transform(genericRecord, schema, pathField);
+      List<String> fieldsToExclude = new ArrayList<>(metadataFields.keySet());
+      fieldsToExclude.add(pathField);
+      return recordTransformer.transform(genericRecord, schema, fieldsToExclude);
     }
 
     @Override

--- a/format-common/src/main/java/io/cdap/plugin/format/FileFormat.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/FileFormat.java
@@ -60,10 +60,13 @@ public enum FileFormat {
    * not require a specific schema. Should only be called for formats that can read.
    *
    * @param pathField the field of the file path, if it exists.
+   * @param lengthField the field of the file length, if it exists.
+   * @param modificationTimeField the field of the file length, if it exists.
    * @return the schema required by the format, if it exists
    */
   @Nullable
-  public Schema getSchema(@Nullable String pathField) {
+  public Schema getSchema(@Nullable String pathField, @Nullable String lengthField,
+                          @Nullable String modificationTimeField) {
     // TODO: move into the plugin formats once it is possible to instantiate them in the get schema methods.
     List<Schema.Field> fields = new ArrayList<>(3);
     switch (this) {
@@ -73,11 +76,23 @@ public enum FileFormat {
         if (pathField != null) {
           fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
         }
+        if (lengthField != null) {
+          fields.add(Schema.Field.of(lengthField, Schema.of(Schema.Type.LONG)));
+        }
+        if (modificationTimeField != null) {
+          fields.add(Schema.Field.of(modificationTimeField, Schema.of(Schema.Type.LONG)));
+        }
         return Schema.recordOf("text", fields);
       case BLOB:
         fields.add(Schema.Field.of("body", Schema.of(Schema.Type.BYTES)));
         if (pathField != null) {
           fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+        }
+        if (lengthField != null) {
+          fields.add(Schema.Field.of(lengthField, Schema.of(Schema.Type.LONG)));
+        }
+        if (modificationTimeField != null) {
+          fields.add(Schema.Field.of(modificationTimeField, Schema.of(Schema.Type.LONG)));
         }
         return Schema.recordOf("text", fields);
       default:

--- a/format-common/src/main/java/io/cdap/plugin/format/MetadataField.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/MetadataField.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+/**
+ * Collects all metadata fields available to retrieve.
+ */
+public enum MetadataField {
+    FILE_LENGTH("path.tracking.length.field", Schema.Type.LONG),
+    FILE_MODIFICATION_TIME("path.tracking.mod.field", Schema.Type.LONG);
+
+    private final String confName;
+    private final Schema.Type schemaType;
+
+    public String getConfName() {
+        return confName;
+    }
+
+    public Schema.Type getSchemaType() {
+        return schemaType;
+    }
+
+    MetadataField(String confName, Schema.Type schemaType) {
+        this.confName = confName;
+        this.schemaType = schemaType;
+    }
+
+    public static MetadataField getMetadataField(String fieldName) {
+        for (MetadataField metadataField : MetadataField.values()) {
+            if (metadataField.name().equals(fieldName)) {
+                return metadataField;
+            }
+        }
+        throw new IllegalArgumentException("Invalid metadata field name: " + fieldName);
+    }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/MetadataRecordReader.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/MetadataRecordReader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import java.io.IOException;
+
+/**
+ * This class is wrapper for file metadata (file length and modification time).
+ * @param <KEYIN>
+ * @param <VALUEIN>
+ */
+public abstract class MetadataRecordReader<KEYIN, VALUEIN> extends RecordReader<KEYIN, VALUEIN> {
+    private long length;
+    private long modificationTime;
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        Path file = ((FileSplit) split).getPath();
+        final FileSystem fs = file.getFileSystem(context.getConfiguration());
+        final FileStatus fileStatus = fs.getFileStatus(file);
+
+        length = fileStatus.getLen();
+        modificationTime = fileStatus.getModificationTime();
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public long getModificationTime() {
+        return modificationTime;
+    }
+
+    public void populateMetadata(String fieldName, MetadataField metadataField,
+                                 StructuredRecord.Builder recordBuilder) {
+        Object result;
+        switch (metadataField) {
+            case FILE_LENGTH:
+                result = getLength();
+                break;
+            case FILE_MODIFICATION_TIME:
+                result = getModificationTime();
+                break;
+            default:
+                throw new IllegalArgumentException("Unable to populate metadata field: " + fieldName);
+        }
+        recordBuilder.set(fieldName, result);
+    }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/input/PathTrackingConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/input/PathTrackingConfig.java
@@ -51,6 +51,14 @@ public class PathTrackingConfig extends PluginConfig {
     "Output field to place the path of the file that the record was read from. "
       + "If not specified, the file path will not be included in output records. "
       + "If specified, the field must exist in the schema and be of type string.";
+  private static final String LENGTH_FIELD_DESC =
+    "Output field to place the length of the file that the record was read from. "
+      + "If not specified, the file length will not be included in output records. "
+      + "If specified, the field must exist in the schema and be of type long.";
+  private static final String MODIFICATION_TIME_FIELD_DESC =
+    "Output field to place the modification time of the file that the record was read from. "
+      + "If not specified, the file modification time will not be included in output records. "
+      + "If specified, the field must exist in the schema and be of type long.";
   private static final String FILENAME_ONLY_DESC =
     "Whether to only use the filename instead of the URI of the file path when a path field is given. "
       + "The default value is false.";
@@ -64,6 +72,10 @@ public class PathTrackingConfig extends PluginConfig {
     fields.put("schema", new PluginPropertyField("schema", SCHEMA_DESC, "string", false, true));
     fields.put("pathField",
                new PluginPropertyField("pathField", PATH_FIELD_DESC, "string", false, true));
+    fields.put("lengthField",
+               new PluginPropertyField("lengthField", LENGTH_FIELD_DESC, "string", false, true));
+    fields.put("modificationTimeField",
+               new PluginPropertyField("modificationTimeField", MODIFICATION_TIME_FIELD_DESC, "string", false, true));
     fields.put("filenameOnly",
                new PluginPropertyField("filenameOnly", FILENAME_ONLY_DESC, "boolean", false, true));
     FIELDS = Collections.unmodifiableMap(fields);
@@ -81,12 +93,32 @@ public class PathTrackingConfig extends PluginConfig {
 
   @Macro
   @Nullable
+  @Description(LENGTH_FIELD_DESC)
+  protected String lengthField;
+
+  @Macro
+  @Nullable
+  @Description(MODIFICATION_TIME_FIELD_DESC)
+  protected String modificationTimeField;
+
+  @Macro
+  @Nullable
   @Description(FILENAME_ONLY_DESC)
   protected Boolean filenameOnly;
 
   @Nullable
   public String getPathField() {
     return pathField;
+  }
+
+  @Nullable
+  public String getLengthField() {
+    return lengthField;
+  }
+
+  @Nullable
+  public String getModificationTimeField() {
+    return modificationTimeField;
   }
 
   public boolean useFilenameOnly() {

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
@@ -84,6 +84,22 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
     + "If specified, the field must exist in the output schema as a string.")
   private String pathField;
 
+  @Name(LENGTH_FIELD)
+  @Macro
+  @Nullable
+  @Description("Output field to place the length of the file that the record was read from. "
+    + "If not specified, the file length will not be included in output records. "
+    + "If specified, the field must exist in the output schema as a long.")
+  private String lengthField;
+
+  @Name(MODIFICATION_TIME_FIELD)
+  @Macro
+  @Nullable
+  @Description("Output field to place the modification time of the file that the record was read from. "
+    + "If not specified, the file modification time will not be included in output records. "
+    + "If specified, the field must exist in the output schema as a long.")
+  private String modificationTimeField;
+
   @Macro
   @Nullable
   @Description("Whether to only use the filename instead of the URI of the file path when a path field is given. "
@@ -212,6 +228,18 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   @Override
   public String getPathField() {
     return pathField;
+  }
+
+  @Nullable
+  @Override
+  public String getLengthField() {
+    return lengthField;
+  }
+
+  @Override
+  @Nullable
+  public String getModificationTimeField() {
+    return modificationTimeField;
   }
 
   @Override

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSourceProperties.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/FileSourceProperties.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
  */
 public interface FileSourceProperties {
   String PATH_FIELD = "pathField";
+  String LENGTH_FIELD = "lengthField";
+  String MODIFICATION_TIME_FIELD = "modificationTimeField";
 
   /**
    * Validates the properties.
@@ -121,6 +123,12 @@ public interface FileSourceProperties {
    */
   @Nullable
   String getPathField();
+
+  @Nullable
+  String getLengthField();
+
+  @Nullable
+  String getModificationTimeField();
 
   /**
    * Whether to only use the filename rather than the entire URI of the file path,

--- a/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
+++ b/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.plugin.PluginClass;
-import io.cdap.cdap.etl.api.validation.FormatContext;
 import io.cdap.cdap.etl.api.validation.ValidatingInputFormat;
 import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.format.input.PathTrackingConfig;
@@ -34,8 +33,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -46,6 +49,7 @@ import javax.annotation.Nullable;
 @Name(ParquetInputFormatProvider.NAME)
 @Description(ParquetInputFormatProvider.DESC)
 public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<ParquetInputFormatProvider.Conf> {
+  private static final Logger LOG = LoggerFactory.getLogger(PathTrackingInputFormatProvider.class);
   static final String NAME = "parquet";
   static final String DESC = "Plugin for reading files in text format.";
   public static final PluginClass PLUGIN_CLASS =
@@ -69,50 +73,6 @@ public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<
     }
   }
 
-  @Nullable
-  @Override
-  public Schema getSchema(FormatContext context) {
-    if (conf.containsMacro(PathTrackingConfig.NAME_SCHEMA) || !Strings.isNullOrEmpty(conf.schema)) {
-      return super.getSchema(context);
-    }
-    try {
-      return getDefaultSchema(context);
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Invalid schema: " + e.getMessage(), e);
-    }
-  }
-
-  /**
-   * Extract schema from file
-   *
-   * @param context {@link FormatContext}
-   * @return {@link Schema}
-   * @throws IOException raised when error occurs during schema extraction
-   */
-  public Schema getDefaultSchema(FormatContext context) throws IOException {
-    String filePath = conf.getProperties().getProperties().getOrDefault("path", null);
-    ParquetReader reader = null;
-    try {
-      Job job = JobUtils.createInstance();
-      Configuration hconf = job.getConfiguration();
-      // set entries here, before FileSystem is used
-      for (Map.Entry<String, String> entry : conf.getFileSystemProperties().entrySet()) {
-        hconf.set(entry.getKey(), entry.getValue());
-      }
-      final Path file = conf.getFilePathForSchemaGeneration(filePath, ".+\\.parquet", hconf, job);
-      reader = AvroParquetReader.builder(file).build();
-      GenericData.Record record = (GenericData.Record) reader.read();
-      return Schema.parseJson(record.getSchema().toString());
-    } catch (IOException e) {
-      context.getFailureCollector().addFailure("Schema error", e.getMessage());
-    } finally {
-      if (reader != null) {
-        reader.close();
-      }
-    }
-    return null;
-  }
-
   /**
    * Common config for Parquet format
    */
@@ -122,5 +82,76 @@ public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<
     @Nullable
     @Description(NAME_SCHEMA)
     public String schema;
+
+    @Override
+    public Schema getSchema() {
+      if (containsMacro(NAME_SCHEMA)) {
+        return null;
+      }
+      if (Strings.isNullOrEmpty(schema)) {
+        try {
+          String lengthFieldResolved = null;
+          String modificationTimeFieldResolved = null;
+
+          // this is required for back compatibility with File-based sources (File, FTP...)
+          try {
+            lengthFieldResolved = lengthField;
+            modificationTimeFieldResolved = modificationTimeField;
+          } catch (NoSuchFieldError e) {
+            LOG.warn("'Length' and 'Modification Time' properties are not supported by plugin.");
+          }
+          return getDefaultSchema(pathField, lengthFieldResolved, modificationTimeFieldResolved);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid schema: " + e.getMessage(), e);
+        }
+      }
+      try {
+        return Schema.parseJson(schema);
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Invalid schema: " + e.getMessage(), e);
+      }
+    }
+
+    /**
+     * Extract schema from file
+     *
+     * @return {@link Schema}
+     * @throws IOException raised when error occurs during schema extraction
+     */
+    public Schema getDefaultSchema(@Nullable String pathField, @Nullable String lengthField,
+                                   @Nullable String modificationTimeField) throws Exception {
+      String filePath = getProperties().getProperties().getOrDefault("path", null);
+      ParquetReader reader = null;
+      try {
+        Job job = JobUtils.createInstance();
+        Configuration hconf = job.getConfiguration();
+        // set entries here, before FileSystem is used
+        for (Map.Entry<String, String> entry : getFileSystemProperties().entrySet()) {
+          hconf.set(entry.getKey(), entry.getValue());
+        }
+        final Path file = getFilePathForSchemaGeneration(filePath, ".+\\.parquet", hconf, job);
+        reader = AvroParquetReader.builder(file).build();
+        GenericData.Record record = (GenericData.Record) reader.read();
+
+        Schema schema = Schema.parseJson(record.getSchema().toString());
+        List<Schema.Field> fields = new ArrayList<>(schema.getFields());
+
+        if (pathField != null && !pathField.isEmpty()) {
+          fields.add(Schema.Field.of(pathField, Schema.of(Schema.Type.STRING)));
+        }
+        if (lengthField != null && !lengthField.isEmpty()) {
+          fields.add(Schema.Field.of(lengthField, Schema.of(Schema.Type.LONG)));
+        }
+        if (modificationTimeField != null && !modificationTimeField.isEmpty()) {
+          fields.add(Schema.Field.of(modificationTimeField, Schema.of(Schema.Type.LONG)));
+        }
+
+        return Schema.recordOf("record", fields);
+      } finally {
+        if (reader != null) {
+          reader.close();
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This change extends functionality of GCS Batch Source plugin. There were added two new plugin parameters here:
- Length Field
- Modification Time Field

If a customer set values for these parameters, the plugin output schema will be extended with additional fields with appropriate names. In general the plugin works with these parameters in the same way as with "Path Field" parameter. Additionally was fixed "GET SCHEMA" functionality when "Path Field"/"Length Field"/"Modification Time Field" are set.

This change is supplied in two PRs, the second is .


There are open questions regarding the proposed change:

1. There are 4 tests in google-cloud module which are failing even before my changes:

```
Failed tests: 
  BigtableSourceConfigTest.testValidateMissingProjectId:95->validateConfigValidationFail:207->validateConfigValidationFail:191 expected:<1> but was:<0>
  BigtableSinkConfigTest.testValidateMissingProjectId:86->validateConfigValidationFail:116 expected:<1> but was:<0>
  DataplexBatchSourceTest.validateServiceAccountWhenIsServiceAccountJsonFalse:107 expected:<0> but was:<2>
  DataplexBatchSourceTest.validateServiceAccountWhenServiceAccountFilePathIsNull:121 expected:<0> but was:<2>

Tests run: 394, Failures: 4, Errors: 0, Skipped: 9
```
Should they be fixed before PR or there is no difference?

2. File Batch Source plugin had "GET SCHEMA" button for all formats in 2.7.1 version. But now this button is available for "delimited" format only. Does this functionality regress make any sense? (just faced this behavior during testing)

3. Noticed that in fact "length" and "modification time" fields functionality was implemented for all "AbstractFileSource" batch source plugins. Does it make sense to add these fields to File Batch Source plugin?

4. Initially all these changes were intended to create a customized GCS Source plugin which can be added to the current 6.5.1 CDAP cluster. As there were some changes of interfaces, it was required to support back-compatibility with unchanged version of File Batch Source and other possible plugins based on AbstractFileSource. Do we need this functionality now in future 6.7.0? (for example if we want use 6.7.0 CDAP with some old plugin based on AbstractFileSource and which uses old PathTrackingInputFormat.createRecordReader() without length and modification time support)