### PR TITLE
[CDAP-19266] tied get schema button with format instead of delimiter

### DIFF
--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -28,17 +28,11 @@
           "name": "format",
           "widget-attributes": {
             "plugin-type": "validatingInputFormat"
-          },
-          "plugin-function": {
-            "method": "POST",
-            "widget": "outputSchema",
-            "label": "Get Schema Value",
-            "required-fields": [
-              "path"
-            ],
-            "missing-required-fields-message": "Please provide path field",
-            "plugin-method": "getSchema"
           }
+        },
+        {
+          "widget-type": "get-schema",
+          "widget-category": "plugin"
         },
         {
           "widget-type": "number",

--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -28,6 +28,16 @@
           "name": "format",
           "widget-attributes": {
             "plugin-type": "validatingInputFormat"
+          },
+          "plugin-function": {
+            "method": "POST",
+            "widget": "outputSchema",
+            "label": "Get Schema Value",
+            "required-fields": [
+              "path"
+            ],
+            "missing-required-fields-message": "Please provide path field",
+            "plugin-method": "getSchema"
           }
         },
         {
@@ -64,16 +74,6 @@
           "name": "delimiter",
           "widget-attributes": {
             "placeholder": "Delimiter if the format is 'delimited'"
-          },
-          "plugin-function": {
-            "method": "POST",
-            "widget": "outputSchema",
-            "label": "Get Schema Value",
-            "required-fields": [
-              "path"
-            ],
-            "missing-required-fields-message": "Please provide path field",
-            "plugin-method": "getSchema"
           }
         },
         {


### PR DESCRIPTION
File Source not showing `Get Schema` button. This Button is only visible when delimited format is selected. Ideally `Get Schema` should be allowed for every format.

Related PR: https://github.com/data-integrations/google-cloud/pull/981
Jira: https://cdap.atlassian.net/browse/CDAP-19266