### PR TITLE
[PLUGIN-1167-Cherry-Pick-2.9] Schema detection file path clarify with test case

### DIFF
--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -24,9 +24,18 @@ If the format is 'text', the schema must contain a field named 'body' of type 's
 
 **Get Schema:** Auto-detects schema from file. Supported formats are: avro, parquet, csv, delimited, tsv, blob 
 and text.
+
 Blob - is set by default as field named 'body' of type bytes.
+
 Text - is set by default as two fields: 'body' of type bytes and 'offset' of type 'long'.
+
 JSON - is not supported, user has to manually provide the output schema.
+
+Parquet - If the path is a directory, the plugin will look for files ending in '.parquet' to read the schema from. 
+If no such file can be found, an error will be returned.
+
+Avro - If the path is a directory, the plugin will look for files ending in '.avro' to read the schema from. 
+If no such file can be found, an error will be returned.
 
 **Override:** A list of columns with the corresponding data types for whom the automatic data type detection gets
  skipped. 

--- a/format-common/src/test/java/io/cdap/plugin/format/input/PathTrackingConfigTest.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/input/PathTrackingConfigTest.java
@@ -1,0 +1,163 @@
+/*
+ *  Copyright ©2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.plugin.format.input;
+
+import io.cdap.plugin.common.batch.JobUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Job;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PathTrackingConfigTest {
+  String pathStr;
+  Job job;
+  Configuration hconf;
+  PathTrackingConfig conf = new PathTrackingConfig();
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Before
+  public void init() throws IOException {
+    job = JobUtils.createInstance();
+    hconf = job.getConfiguration();
+  }
+  /**
+   * Check whether two list of Path are same, ignore the order.
+   */
+  public Boolean equalPaths(List<Path> paths1, List<Path> paths2) {
+    String p1;
+    String p2;
+    int l1 = paths1.size();
+    int l2 = paths2.size();
+    if (l1 != l2) {
+      return false;
+    }
+    for (int i = 0; i < l1; i++) {
+      p1 = paths1.get(i).toString();
+      p2 = paths2.get(i).toString();
+      if (!p1.equals(p2)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Test read all parquet file from a directory
+   */
+  @Test
+  public void testGetFilePathsForSchemaGeneration1() throws IOException {
+    File testDir = tmpFolder.newFolder("d");
+    File testFile1 = File.createTempFile("part-0", ".parquet", testDir);
+    File testFile2 = File.createTempFile("part-1", ".parquet", testDir);
+    pathStr = testDir.getAbsolutePath();
+
+    // Get List of Path from getFilePathsForSchemaGeneration
+    List<Path> filePaths = conf.getFilePathsForSchemaGeneration(pathStr, ".+\\.parquet$", hconf, job);
+
+    // Created Expected List of Path
+    List<Path> expectedPaths = new ArrayList<Path>();
+    expectedPaths.add(new Path("file:" + testFile1.getAbsolutePath()));
+    expectedPaths.add(new Path("file:" + testFile2.getAbsolutePath()));
+
+    Collections.sort(expectedPaths);
+    Collections.sort(filePaths);
+    Assert.assertTrue(equalPaths(expectedPaths, filePaths));
+  }
+
+  /**
+   * Test read all parquet file from a directory ending with .parquet
+   */
+  @Test
+  public void testGetFilePathsForSchemaGeneration2() throws IOException {
+    File testDir = tmpFolder.newFolder("d.parquet");
+    File testFile1 = File.createTempFile("part-0", ".parquet", testDir);
+    File testFile2 = File.createTempFile("part-1", ".parquet", testDir);
+    File testFile3 = File.createTempFile("part-2", ".txt", testDir);
+    pathStr = testDir.getAbsolutePath();
+
+    // Get List of Path from getFilePathsForSchemaGeneration
+    List<Path> filePaths = conf.getFilePathsForSchemaGeneration(pathStr, ".+\\.parquet$", hconf, job);
+
+    // Created Expected List of Path
+    List<Path> expectedPaths = new ArrayList<Path>();
+    expectedPaths.add(new Path("file:" + testFile1.getAbsolutePath()));
+    expectedPaths.add(new Path("file:" + testFile2.getAbsolutePath()));
+
+    Collections.sort(expectedPaths);
+    Collections.sort(filePaths);
+    Assert.assertTrue(equalPaths(expectedPaths, filePaths));
+  }
+
+  /**
+   * Test read all avro file from a directory
+   */
+  @Test
+  public void testGetFilePathsForSchemaGeneration3() throws IOException {
+    File testDir = tmpFolder.newFolder("d2");
+    File testFile1 = File.createTempFile("avro-0", ".avro", testDir);
+    File testFile2 = File.createTempFile("avro-1", ".avro", testDir);
+    pathStr = testDir.getAbsolutePath();
+
+    // Get List of Path from getFilePathsForSchemaGeneration
+    List<Path> filePaths = conf.getFilePathsForSchemaGeneration(pathStr, ".+\\.avro$", hconf, job);
+
+    // Created Expected List of Path
+    List<Path> expectedPaths = new ArrayList<Path>();
+    expectedPaths.add(new Path("file:" + testFile1.getAbsolutePath()));
+    expectedPaths.add(new Path("file:" + testFile2.getAbsolutePath()));
+
+    Collections.sort(expectedPaths);
+    Collections.sort(filePaths);
+    Assert.assertTrue(equalPaths(expectedPaths, filePaths));
+  }
+
+  /**
+   * Test read all avro file from a directory ending with .avro
+   */
+  @Test
+  public void testGetFilePathsForSchemaGeneration4() throws IOException {
+    File testDir = tmpFolder.newFolder("d.avro");
+    File testFile1 = File.createTempFile("avro-0", ".avro", testDir);
+    File testFile2 = File.createTempFile("avro-1", ".avro", testDir);
+    File testFile3 = File.createTempFile("avro-2", ".txt", testDir);
+    pathStr = testDir.getAbsolutePath();
+
+    // Get List of Path from getFilePathsForSchemaGeneration
+    List<Path> filePaths = conf.getFilePathsForSchemaGeneration(pathStr, ".+\\.avro$", hconf, job);
+
+    // Created Expected List of Path
+    List<Path> expectedPaths = new ArrayList<Path>();
+    expectedPaths.add(new Path("file:" + testFile1.getAbsolutePath()));
+    expectedPaths.add(new Path("file:" + testFile2.getAbsolutePath()));
+
+    Collections.sort(expectedPaths);
+    Collections.sort(filePaths);
+    Assert.assertTrue(equalPaths(expectedPaths, filePaths));
+  }
+}

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
@@ -188,7 +188,9 @@ public class DelimitedConfig extends PathTrackingConfig {
     for (Map.Entry<String, String> entry : getFileSystemProperties().entrySet()) {
       configuration.set(entry.getKey(), entry.getValue());
     }
-    Path filePath = getFilePathForSchemaGeneration(path, regexPathFilter, configuration, job);
+
+    List<Path> paths = getFilePathsForSchemaGeneration(path, regexPathFilter, configuration, job);
+    Path filePath = paths.get(0);
     DataTypeDetectorStatusKeeper dataTypeDetectorStatusKeeper = new DataTypeDetectorStatusKeeper();
     String line = null;
     String[] columnNames = null;


### PR DESCRIPTION
Solve the problem about detecting wrong file path when setting format as ".parquet" or ".avro".

PR: https://github.com/cdapio/hydrator-plugins/pull/1564
Jira: https://cdap.atlassian.net/browse/PLUGIN-1167