### PR TITLE
Add e2e test for Joiner plugin

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -260,6 +260,7 @@
   </dependencies>
 
   <build>
+    <testSourceDirectory>${testSourceLocation}</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -289,4 +290,99 @@
     </plugins>
   </build>
 
+
+  <profiles>
+    <profile>
+      <id>e2e-tests</id>
+      <properties>
+        <testSourceLocation>src/e2e-test/java</testSourceLocation>
+      </properties>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/e2e-test/resources</directory>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>TestRunner.java</include>
+              </includes>
+              <environmentVariables>
+                <GOOGLE_APPLICATION_CREDENTIALS>
+                  ${GOOGLE_APPLICATION_CREDENTIALS}
+                </GOOGLE_APPLICATION_CREDENTIALS>
+              </environmentVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>net.masterthought</groupId>
+            <artifactId>maven-cucumber-reporting</artifactId>
+            <version>5.5.0</version>
+
+            <executions>
+              <execution>
+                <id>execution</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <projectName>Cucumber Reports</projectName> <!-- Replace with project name -->
+                  <outputDirectory>target/cucumber-reports/advanced-reports</outputDirectory>
+                  <buildNumber>1</buildNumber>
+                  <skip>false</skip>
+                  <inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+                  <jsonFiles> <!-- supports wildcard or name pattern -->
+                    <param>**/*.json</param>
+                  </jsonFiles> <!-- optional, defaults to outputDirectory if not specified -->
+                  <classificationDirectory>${project.build.directory}/cucumber-reports</classificationDirectory>
+                  <checkBuildResult>true</checkBuildResult>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.cdap.tests.e2e</groupId>
+          <artifactId>cdap-e2e-framework</artifactId>
+          <version>0.0.1-SNAPSHOT</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+          <version>1.2.8</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>27.0.1-jre</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/core-plugins/src/e2e-test/features/joiner/Joiner.feature
+++ b/core-plugins/src/e2e-test/features/joiner/Joiner.feature
@@ -1,0 +1,79 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Joiner
+Feature: Joiner analytics - Verify File source data transfer using Joiner analytics
+  @GCS_SOURCE_TEST @GCS_SOURCE_JOINER_TEST @GCS_SINK_TEST
+  Scenario: To verify data is getting transferred from File source to File sink plugin successfully with Joiner
+    Given Open Datafusion Project to configure pipeline
+    When Select plugin: "File" from the plugins list as: "Source"
+    When Select plugin: "File" from the plugins list as: "Source"
+    Then Move plugins: "File2" by xOffset 0 and yOffset 200
+    When Expand Plugin group in the LHS plugins list: "Analytics"
+    When Select plugin: "Joiner" from the plugins list as: "Analytics"
+    Then Connect plugins: "File" and "Joiner" to establish connection
+    Then Connect plugins: "File2" and "Joiner" to establish connection
+    When Expand Plugin group in the LHS plugins list: "Sink"
+    When Select plugin: "File" from the plugins list as: "Sink"
+    Then Connect plugins: "Joiner" and "File3" to establish connection
+    Then Navigate to the properties page of plugin: "File"
+    Then Enter input plugin property: "referenceName" with value: "firstName"
+    Then Enter input plugin property: "path" with value: "gcsSourceBucket1"
+    Then Select dropdown plugin property: "format" with option value: "csv"
+    Then Click plugin property: "skipHeader"
+    Then Click plugin property: "enableQuotedValues"
+    Then Click on the Get Schema button
+    Then Verify the Output Schema matches the Expected Schema: "firstNameOutputSchema"
+    Then Validate "File" plugin properties
+    Then Close the Plugin Properties page
+    Then Navigate to the properties page of plugin: "File2"
+    Then Enter input plugin property: "referenceName" with value: "lastName"
+    Then Enter input plugin property: "path" with value: "gcsSourceBucket2"
+    Then Select dropdown plugin property: "format" with option value: "csv"
+    Then Click plugin property: "skipHeader"
+    Then Click plugin property: "enableQuotedValues"
+    Then Click on the Get Schema button
+    Then Verify the Output Schema matches the Expected Schema: "lastNameOutputSchema"
+    Then Validate "File" plugin properties
+    Then Close the Plugin Properties page
+    Then Navigate to the properties page of plugin: "Joiner"
+    Then Expand fields
+    Then Uncheck plugin "File2" field "id" alias checkbox
+    Then Select joiner type "Inner"
+    Then Enter numPartitions 1
+    Then Select dropdown plugin property: "inputsToLoadMemory" with option value: "File"
+    Then Scroll to validation button and click
+    Then Validate "Joiner" plugin properties
+    Then Close the Plugin Properties page
+    Then Navigate to the properties page of plugin: "File3"
+    Then Enter input plugin property: "referenceName" with value: "result"
+    Then Enter input plugin property: "path" with value: "gcsTargetBucket"
+    Then Select dropdown plugin property: "format" with option value: "csv"
+    Then Close the Plugin Properties page
+    Then Save the pipeline
+    Then Preview and run the pipeline
+    Then Wait till pipeline preview is in running state
+    Then Open and capture pipeline preview logs
+    Then Verify the preview run status of pipeline in the logs is "succeeded"
+    Then Close the pipeline logs
+    Then Close the preview
+    Then Deploy the pipeline
+    Then Run the Pipeline in Runtime
+    Then Wait till pipeline is in running state
+    Then Open and capture logs
+    Then Verify the pipeline status is "Succeeded"
+    Then Verify the CSV Output File matches the Expected Output File With Expected Partition
+    Then Close the pipeline logs

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.common.stepsdesign;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.StorageException;
+import io.cdap.e2e.utils.PluginPropertyUtils;
+import io.cdap.e2e.utils.StorageClient;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import stepsdesign.BeforeActions;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+/**
+ * Joiner test hooks.
+ */
+public class TestSetupHooks {
+
+  public static String gcsSourceBucketName1 = StringUtils.EMPTY;
+  public static String gcsSourceBucketName2 = StringUtils.EMPTY;
+  public static String gcsTargetBucketName = StringUtils.EMPTY;
+
+  @Before(order = 1, value = "@GCS_SOURCE_TEST")
+  public static void createBucketWithCSVFile() throws IOException, URISyntaxException {
+    gcsSourceBucketName1 = createGCSBucketWithFile(PluginPropertyUtils.pluginProp("firstNameCsvFile"));
+    PluginPropertyUtils.addPluginProp("gcsSourceBucket1", "gs://" + gcsSourceBucketName1 + "/"  +
+      PluginPropertyUtils.pluginProp("firstNameCsvFile"));
+    BeforeActions.scenario.write("GCS source bucket1 name - " + gcsSourceBucketName1);
+  }
+
+  @Before(order = 1, value = "@GCS_SOURCE_JOINER_TEST")
+  public static void createBucketWithCSVFileForJoinerTest() throws IOException, URISyntaxException {
+    gcsSourceBucketName2 = createGCSBucketWithFile(PluginPropertyUtils.pluginProp("lastNameCsvFile"));
+    PluginPropertyUtils.addPluginProp("gcsSourceBucket2", "gs://" + gcsSourceBucketName2 + "/" +
+      PluginPropertyUtils.pluginProp("lastNameCsvFile"));
+    BeforeActions.scenario.write("GCS source bucket2 name - " + gcsSourceBucketName2);
+  }
+
+  @After(order = 1, value = "@GCS_SOURCE_TEST")
+  public static void deleteSourceBucketWithFile() {
+    deleteGCSBucket(gcsSourceBucketName1);
+    gcsSourceBucketName1 = StringUtils.EMPTY;
+  }
+
+  @After(order = 1, value = "@GCS_SOURCE_JOINER_TEST")
+  public static void deleteSourceBucketWithFileForJoinerTest() {
+    deleteGCSBucket(gcsSourceBucketName2);
+    gcsSourceBucketName2 = StringUtils.EMPTY;
+  }
+
+  @Before(order = 1, value = "@GCS_SINK_TEST")
+  public static void setTempTargetGCSBucketName() throws IOException {
+    gcsTargetBucketName = createGCSBucket();
+    PluginPropertyUtils.addPluginProp("gcsTargetBucket", "gs://" + gcsTargetBucketName);
+    BeforeActions.scenario.write("GCS target bucket name - " + gcsTargetBucketName);
+  }
+
+  @After(order = 1, value = "@GCS_SINK_TEST")
+  public static void deleteTargetBucketWithFile() {
+    deleteGCSBucket(gcsTargetBucketName);
+    gcsTargetBucketName = StringUtils.EMPTY;
+  }
+
+  private static String createGCSBucket() throws IOException {
+    return StorageClient.createBucket("e2e-test-" + UUID.randomUUID()).getName();
+  }
+
+  private static String createGCSBucketWithFile(String filePath) throws IOException, URISyntaxException {
+    String bucketName = StorageClient.createBucket("e2e-test-" + UUID.randomUUID()).getName();
+    StorageClient.uploadObject(bucketName, filePath, filePath);
+    return bucketName;
+  }
+
+  private static void deleteGCSBucket(String bucketName) {
+    try {
+      for (Blob blob : StorageClient.listObjects(bucketName).iterateAll()) {
+        StorageClient.deleteObject(bucketName, blob.getName());
+      }
+      StorageClient.deleteBucket(bucketName);
+      BeforeActions.scenario.write("Deleted GCS Bucket " + bucketName);
+    } catch (StorageException | IOException e) {
+      if (e.getMessage().contains("The specified bucket does not exist")) {
+        BeforeActions.scenario.write("GCS Bucket " + bucketName + " does not exist.");
+      } else {
+        Assert.fail(e.getMessage());
+      }
+    }
+  }
+}

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/package-info.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the stepDesign for the common features.
+ */
+package io.cdap.plugin.common.stepsdesign;

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/actions/JoinerActions.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/actions/JoinerActions.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.joiner.actions;
+
+import io.cdap.e2e.pages.locators.CdfPluginPropertiesLocators;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumHelper;
+import io.cdap.plugin.joiner.locators.JoinerLocators;
+
+/**
+ *  Joiner Related Actions.
+ */
+public class JoinerActions {
+  static {
+    SeleniumHelper.getPropertiesLocators(JoinerLocators.class);
+  }
+
+  public static void clickFieldsExpandButton() {
+    ElementHelper.clickOnElement(JoinerLocators.fieldsExpandButton);
+  }
+
+  public static void enterNumPartitions(String numPartitions) {
+    ElementHelper.sendKeys(JoinerLocators.numPartitions, numPartitions);
+  }
+
+  public static void uncheckPluginFieldAliasCheckBox(String plugin, String field) {
+    ElementHelper.selectCheckbox(JoinerLocators.fieldAliasCheckBox(plugin, field));
+  }
+
+  public static void selectJoinerType(String targetJoinerType) {
+    ElementHelper.selectDropdownOption(JoinerLocators.joinerTypeSelectDropdown,
+                                       CdfPluginPropertiesLocators.locateDropdownListItem(targetJoinerType));
+  }
+}

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/actions/package-info.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/actions/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the actions for the Joiner plugin.
+ */
+package io.cdap.plugin.joiner.actions;

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/locators/JoinerLocators.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/locators/JoinerLocators.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.joiner.locators;
+
+import io.cdap.e2e.utils.SeleniumDriver;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+/**
+ *  Joiner Related Locators.
+ */
+public class JoinerLocators {
+
+  public static WebElement fieldAliasCheckBox(String pluginName, String field) {
+    String xpath = "//*[@data-cy='" + pluginName + "-stage-expansion-panel']" + "//*[@data-cy='" + field +
+      "-field-selector-name']/..//*[@type='checkbox']";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+  }
+
+  @FindBy(how = How.XPATH, using = "//button[@data-cy='sql-selector-expand-collapse-btn']")
+  public static WebElement fieldsExpandButton;
+
+  @FindBy(how = How.XPATH, using = "//input[@data-cy='numPartitions']")
+  public static WebElement numPartitions;
+
+  @FindBy(how = How.XPATH, using = "//*[@data-cy='requiredInputs']//*[@title='Outer']")
+  public static WebElement joinerTypeSelectDropdown;
+}

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/locators/package-info.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/locators/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the locators for the Joiner plugin.
+ */
+package io.cdap.plugin.joiner.locators;

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/runners/TestRunner.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/runners/TestRunner.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.joiner.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute Joiner plugin test cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"stepsdesign", "io.cdap.plugin.joiner.stepsdesign", "io.cdap.plugin.common.stepsdesign"},
+  tags = {"@Joiner"},
+  plugin = {"pretty", "html:target/cucumber-html-report/joiner",
+    "json:target/cucumber-reports/cucumber-joiner.json",
+    "junit:target/cucumber-reports/cucumber-joiner.xml"}
+)
+public class TestRunner {
+}

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/runners/package-info.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/runners/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the runners for the Joiner plugin.
+ */
+package io.cdap.plugin.joiner.runners;

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/stepsdesign/Joiner.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/stepsdesign/Joiner.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.joiner.stepsdesign;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.StorageException;
+import io.cdap.e2e.pages.locators.CdfPluginPropertiesLocators;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.PluginPropertyUtils;
+import io.cdap.e2e.utils.StorageClient;
+import io.cdap.plugin.joiner.actions.JoinerActions;
+import io.cucumber.java.en.Then;
+import org.apache.directory.api.util.Strings;
+import org.junit.Assert;
+import stepsdesign.BeforeActions;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static io.cdap.plugin.common.stepsdesign.TestSetupHooks.gcsTargetBucketName;
+
+/**
+ *  Joiner Related Step Design.
+ */
+public class Joiner implements CdfHelper {
+  @Then("Expand fields")
+  public void expandFields() {
+    JoinerActions.clickFieldsExpandButton();
+  }
+
+  @Then("Uncheck plugin {string} field {string} alias checkbox")
+  public void uncheckPluginFieldAliasCheckBox(String plugin, String field) {
+    JoinerActions.uncheckPluginFieldAliasCheckBox(plugin, field);
+  }
+
+  @Then("Enter numPartitions {int}")
+  public void openJoinerProperties(int numPartitions) {
+    JoinerActions.enterNumPartitions(String.valueOf(numPartitions));
+  }
+
+  @Then("Select joiner type {string}")
+  public void selectJoinerType(String joinerType) {
+    JoinerActions.selectJoinerType(joinerType);
+  }
+
+  @Then("Scroll to validation button and click")
+  public void scrollToValidationButton() {
+    ElementHelper.clickUsingActions(CdfPluginPropertiesLocators.validateButton);
+  }
+
+  @Then("Verify the CSV Output File matches the Expected Output File With Expected Partition")
+  public void verifyCSVOutput() {
+    try {
+      // The output gcs folder will be like:
+      // e2e-test-[uuid]
+      // --2022-06-26-00-27/
+      // ----_SUCCESS
+      // ----part-r-0000
+      // ----part-r-0001
+      // ----part-r-...
+      // The number of part-r-* files should match the expected partitions.
+      int partitions = 0;
+      List<String> lst = new ArrayList<>();
+      for (Blob blob : StorageClient.listObjects(gcsTargetBucketName).iterateAll()) {
+        String name = blob.getName();
+        if (name.contains("part-r")) {
+          partitions++;
+          try (InputStream inputStream = new ByteArrayInputStream(blob.getContent())) {
+            readInputStream(inputStream, lst);
+          }
+        }
+      }
+      Path path = Paths.get(Objects.requireNonNull(Joiner.class.getResource
+        ("/" + PluginPropertyUtils.pluginProp("joinerOutput"))).getPath()).toAbsolutePath();
+      Assert.assertEquals("Output partition should match",
+                          partitions, Integer.parseInt(PluginPropertyUtils.pluginProp("expectedPartitions")));
+      Assert.assertTrue("Output content should match",
+                        Strings.equals(getSortedCSVContent(lst), new String(Files.readAllBytes(path))));
+    } catch (StorageException | IOException e) {
+      if (e.getMessage().contains("The specified bucket does not exist")) {
+        BeforeActions.scenario.write("GCS Bucket " + gcsTargetBucketName + " does not exist.");
+      } else {
+        Assert.fail(e.getMessage());
+      }
+    }
+  }
+  private String getSortedCSVContent(List<String> lst) {
+    // Since the spark output files aren't guaranteed to be ordered, the output entry with [id, first_name, last_name]
+    // schema needs to be sorted by id for comparison purpose.
+    lst.sort((s1, s2) -> {
+      String id1 = s1.split(",")[0], id2 = s2.split(",")[0];
+      return Integer.parseInt(id1) - Integer.parseInt(id2);
+    });
+    StringBuilder sb = new StringBuilder();
+    for (String s : lst) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+
+  private void readInputStream(InputStream input, List<String> lst) throws IOException {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        lst.add(line + "\n");
+      }
+    }
+  }
+}

--- a/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/stepsdesign/package-info.java
+++ b/core-plugins/src/e2e-test/java/io/cdap/plugin/joiner/stepsdesign/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the stepDesign for the Joiner features.
+ */
+package io.cdap.plugin.joiner.stepsdesign;

--- a/core-plugins/src/e2e-test/resources/errorMessage.properties
+++ b/core-plugins/src/e2e-test/resources/errorMessage.properties
@@ -1,0 +1,1 @@
+validationSuccessMessage=No errors found.

--- a/core-plugins/src/e2e-test/resources/pluginDataCyAttributes.properties
+++ b/core-plugins/src/e2e-test/resources/pluginDataCyAttributes.properties
@@ -1,0 +1,4 @@
+referenceName=referenceName
+skipHeader=switch-skipHeader
+enableQuotedValues=switch-enableQuotedValues
+inputsToLoadMemory=inMemoryInputs

--- a/core-plugins/src/e2e-test/resources/pluginParameters.properties
+++ b/core-plugins/src/e2e-test/resources/pluginParameters.properties
@@ -1,0 +1,12 @@
+projectId=odf-integration-test
+## GCS-PLUGIN-PROPERTIES
+gcsSourceBucket1=dummy
+gcsSourceBucket2=dummy
+gcsTargetBucket=dummy
+
+firstNameCsvFile=testdata/first_name.csv
+lastNameCsvFile=testdata/last_name.csv
+firstNameOutputSchema=[{"key":"id","value":"int"},{"key":"first_name","value":"string"}]
+lastNameOutputSchema=[{"key":"id","value":"int"},{"key":"last_name","value":"string"}]
+joinerOutput=testdata/joiner_output.csv
+expectedPartitions=1

--- a/core-plugins/src/e2e-test/resources/testdata/first_name.csv
+++ b/core-plugins/src/e2e-test/resources/testdata/first_name.csv
@@ -1,0 +1,11 @@
+id,first_name
+1,Crichton
+2,Monty
+3,Terese
+4,Mozes
+5,Christian
+6,Caro
+7,Maye
+8,Bernie
+9,Heidie
+10,Lurette

--- a/core-plugins/src/e2e-test/resources/testdata/joiner_output.csv
+++ b/core-plugins/src/e2e-test/resources/testdata/joiner_output.csv
@@ -1,0 +1,10 @@
+1,Crichton,Caveill
+2,Monty,Harrisson
+3,Terese,Bignall
+4,Mozes,Seleway
+5,Christian,Melton
+6,Caro,Duck
+7,Maye,Ferraretto
+8,Bernie,Catterick
+9,Heidie,Weafer
+10,Lurette,Ivasechko

--- a/core-plugins/src/e2e-test/resources/testdata/last_name.csv
+++ b/core-plugins/src/e2e-test/resources/testdata/last_name.csv
@@ -1,0 +1,11 @@
+id,last_name
+1,Caveill
+2,Harrisson
+3,Bignall
+4,Seleway
+5,Melton
+6,Duck
+7,Ferraretto
+8,Catterick
+9,Weafer
+10,Ivasechko


### PR DESCRIPTION
add e2e test for joiner and file plugins.

Pipeline:
![image](https://user-images.githubusercontent.com/25891353/176743419-b9135455-3d18-409e-b9cf-b4b17185b22e.png)

Since there is a [bug](https://cdap.atlassian.net/browse/CDAP-19382) for running CDAP on K8S, the pipeline hasn't been tested on K8S and only on 6.8.0-snapshot sandbox and the result is below:

![image](https://user-images.githubusercontent.com/25891353/175450946-55c78605-5bf2-4c14-98ae-bdb1908eab4a.png)