### PR TITLE
CDAP-19078 fix broken file connector sampling

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/batch/connector/FileConnectorTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/connector/FileConnectorTest.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.etl.api.connector.ConnectorContext;
 import io.cdap.cdap.etl.api.connector.ConnectorSpec;
 import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
 import io.cdap.cdap.etl.api.connector.SamplePropertyField;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
 import io.cdap.cdap.etl.mock.common.MockConnectorConfigurer;
 import io.cdap.cdap.etl.mock.common.MockConnectorContext;
 import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
@@ -45,6 +46,7 @@ import io.cdap.plugin.format.delimited.input.CSVInputFormatProvider;
 import io.cdap.plugin.format.delimited.input.DelimitedConfig;
 import io.cdap.plugin.format.delimited.input.DelimitedInputFormatProvider;
 import io.cdap.plugin.format.delimited.input.TSVInputFormatProvider;
+import io.cdap.plugin.format.input.PathTrackingInputFormat;
 import io.cdap.plugin.format.parquet.input.ParquetInputFormatProvider;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -266,6 +268,14 @@ public class FileConnectorTest {
     ConnectorContext context = new TestConnectorContext(plugin);
     ConnectorSpec spec = fileConnector.generateSpec(context, connectorSpecRequest);
     Assert.assertEquals(expectedSchema, spec.getSchema());
+
+    SampleRequest sampleRequest = SampleRequest.builder(10)
+      .setPath(parquetFile.getAbsolutePath())
+      .build();
+    InputFormatProvider inputFormatProvider = fileConnector.getInputFormatProvider(context, sampleRequest);
+    Map<String, String> formatConfigs = inputFormatProvider.getInputFormatConfiguration();
+    Assert.assertTrue(formatConfigs.containsKey(PathTrackingInputFormat.SCHEMA));
+    Assert.assertEquals(expectedSchema, Schema.parseJson(formatConfigs.get(PathTrackingInputFormat.SCHEMA)));
   }
 
   @Test
@@ -298,6 +308,14 @@ public class FileConnectorTest {
     ConnectorContext context = new TestConnectorContext(plugin);
     ConnectorSpec spec = fileConnector.generateSpec(context, connectorSpecRequest);
     Assert.assertEquals(expectedSchema, spec.getSchema());
+
+    SampleRequest sampleRequest = SampleRequest.builder(10)
+      .setPath(avroFile.getAbsolutePath())
+      .build();
+    InputFormatProvider inputFormatProvider = fileConnector.getInputFormatProvider(context, sampleRequest);
+    Map<String, String> formatConfigs = inputFormatProvider.getInputFormatConfiguration();
+    Assert.assertTrue(formatConfigs.containsKey(PathTrackingInputFormat.SCHEMA));
+    Assert.assertEquals(expectedSchema, Schema.parseJson(formatConfigs.get(PathTrackingInputFormat.SCHEMA)));
   }
 
   @Test
@@ -334,6 +352,14 @@ public class FileConnectorTest {
                                             Schema.Field.of("body_1", Schema.of(Schema.Type.STRING)),
                                             Schema.Field.of("body_2", Schema.of(Schema.Type.STRING)));
     Assert.assertEquals(expectedSchema, spec.getSchema());
+
+    SampleRequest sampleRequest = SampleRequest.builder(10)
+      .setPath(file.getAbsolutePath())
+      .build();
+    InputFormatProvider inputFormatProvider = fileConnector.getInputFormatProvider(context, sampleRequest);
+    Map<String, String> formatConfigs = inputFormatProvider.getInputFormatConfiguration();
+    Assert.assertTrue(formatConfigs.containsKey(PathTrackingInputFormat.SCHEMA));
+    Assert.assertEquals(expectedSchema, Schema.parseJson(formatConfigs.get(PathTrackingInputFormat.SCHEMA)));
   }
 
   private static class TestConnectorContext implements ConnectorContext {

--- a/format-common/src/main/java/io/cdap/plugin/format/input/PathTrackingInputFormat.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/input/PathTrackingInputFormat.java
@@ -49,7 +49,7 @@ public abstract class PathTrackingInputFormat extends FileInputFormat<NullWritab
   static final String PATH_FIELD = "path.tracking.path.field";
   static final String FILENAME_ONLY = "path.tracking.filename.only";
   public static final String SOURCE_FILE_ENCODING = "path.tracking.encoding";
-  static final String SCHEMA = "schema";
+  public static final String SCHEMA = "schema";
   public static final String TARGET_ENCODING = "utf-8";
 
   @Override


### PR DESCRIPTION
Fixed a bug introduced during schema detection refactoring that
caused sampling to break. Schema also needs to be detected during
sampling to maintain existing behavior.