### PR TITLE
CDAP-19078 fix classloader for schema detection

### DIFF
--- a/format-common/src/main/java/io/cdap/plugin/format/SchemaDetector.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/SchemaDetector.java
@@ -75,8 +75,10 @@ public class SchemaDetector {
 
     Path fsPath = new Path(path);
 
-    FileSystem fs = JobUtils.applyWithExtraClassLoader(job, getClass().getClassLoader(),
-                                                       f -> FileSystem.get(fsPath.toUri(), configuration));
+    ClassLoader cl = configuration.getClassLoader();
+    configuration.setClassLoader(getClass().getClassLoader());
+    FileSystem fs = FileSystem.get(fsPath.toUri(), configuration);
+    configuration.setClassLoader(cl);
 
     if (!fs.exists(fsPath)) {
       throw new IOException("Input path not found");


### PR DESCRIPTION
now that filesystem traversal is happening in the connector and
in the file source instead of in the format plugins,
we should not be using a combine classloader
of the plugin classloader and the default classloader in the
Hadoop configuration. Instead, just the plugin classloader
should be used.

Without this, classes from the main classpath, like the s3
and gcs connectors, will be defined by the wrong classloader,
causing class cast exceptions.