### PR TITLE
CDAP-19461 fix schema detection with regex

### DIFF
--- a/format-common/pom.xml
+++ b/format-common/pom.xml
@@ -54,6 +54,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>hydrator-test</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/format-common/src/main/java/io/cdap/plugin/format/SchemaDetector.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/SchemaDetector.java
@@ -25,12 +25,16 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.mapreduce.Job;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -50,20 +54,38 @@ public class SchemaDetector {
    * @param formatContext format context
    * @param fileSystemProperties any properties that need to be set in order to read from the Hadoop FileSystem
    * @return the schema of files at the path, or null if the schema is not known.
-   * @throws IOException
+   * @throws IOException if there was an exception interacting with the filesystem
    */
   @Nullable
   public Schema detectSchema(String path, FormatContext formatContext,
+                             Map<String, String> fileSystemProperties) throws IOException {
+    return detectSchema(path, null, formatContext, fileSystemProperties);
+  }
+
+  /**
+   * Detect the schema for files at a specified path, where files need to match the specified pattern.
+   *
+   * @param path path to the files. Can be a file or a directory
+   * @param pattern pattern that the files much match in order to be considered for schema detection. Files that do not
+   *                match this pattern will be skipped. If none is given, any file can be used for schema detection.
+   * @param formatContext format context
+   * @param fileSystemProperties any properties that need to be set in order to read from the Hadoop FileSystem
+   * @return the schema of files at the path, or null if the schema is not known.
+   * @throws IOException if there was an exception interacting with the filesystem
+   */
+  @Nullable
+  public Schema detectSchema(String path, @Nullable Pattern pattern, FormatContext formatContext,
                              Map<String, String> fileSystemProperties) throws IOException {
     if (path == null) {
       return null;
     }
 
-    InputFiles inputFiles = getInputFiles(path, fileSystemProperties);
+    InputFiles inputFiles = getInputFiles(path, pattern, fileSystemProperties);
     return inputFormat.detectSchema(formatContext, inputFiles);
   }
 
-  private InputFiles getInputFiles(String path, Map<String, String> fileSystemProperties) throws IOException {
+  private InputFiles getInputFiles(String path, @Nullable Pattern pattern,
+                                   Map<String, String> fileSystemProperties) throws IOException {
     Job job = JobUtils.createInstance();
     Configuration configuration = job.getConfiguration();
     for (Map.Entry<String, String> entry : fileSystemProperties.entrySet()) {
@@ -73,6 +95,7 @@ public class SchemaDetector {
       configuration.set(entry.getKey(), entry.getValue());
     }
 
+    PathFilter pathFilter = getPathFilter(pattern, configuration);
     Path fsPath = new Path(path);
 
     ClassLoader cl = configuration.getClassLoader();
@@ -80,7 +103,7 @@ public class SchemaDetector {
     FileSystem fs = FileSystem.get(fsPath.toUri(), configuration);
     configuration.setClassLoader(cl);
 
-    if (!fs.exists(fsPath)) {
+    if (!fs.exists(fsPath) || !pathFilter.accept(fsPath)) {
       throw new IOException("Input path not found");
     }
 
@@ -99,6 +122,20 @@ public class SchemaDetector {
       throw new IllegalArgumentException("Provided directory '" + path + "' is empty");
     }
 
-    return new FileSystemInputFiles(fs, Arrays.asList(files));
+    List<FileStatus> filteredFiles = Arrays.stream(files)
+      .filter(fStatus -> pathFilter.accept(fStatus.getPath()))
+      .collect(Collectors.toList());
+
+    return new FileSystemInputFiles(fs, filteredFiles);
+  }
+
+  private PathFilter getPathFilter(@Nullable Pattern pattern, Configuration configuration) {
+    if (pattern == null) {
+      return p -> true;
+    }
+    RegexPathFilter.configure(configuration, pattern);
+    RegexPathFilter regexPathFilter = new RegexPathFilter();
+    regexPathFilter.setConf(configuration);
+    return regexPathFilter;
   }
 }

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
@@ -124,7 +124,8 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
       if (schema == null && shouldGetSchema()) {
         try {
           SchemaDetector schemaDetector = new SchemaDetector(validatingInputFormat);
-          schema = schemaDetector.detectSchema(config.getPath(), context, getFileSystemProperties(null));
+          schema = schemaDetector.detectSchema(config.getPath(), config.getFilePattern(),
+                                               context, getFileSystemProperties(null));
         } catch (IOException e) {
           context.getFailureCollector()
             .addFailure("Error when trying to detect schema: " + e.getMessage(), null)
@@ -161,9 +162,11 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     FormatContext formatContext = new FormatContext(collector, null);
     Schema schema = context.getOutputSchema() == null ?
       validatingInputFormat.getSchema(formatContext) : context.getOutputSchema();
+    Pattern pattern = config.getFilePattern();
     if (schema == null) {
       SchemaDetector schemaDetector = new SchemaDetector(validatingInputFormat);
-      schema = schemaDetector.detectSchema(config.getPath(context), formatContext, getFileSystemProperties(null));
+      schema = schemaDetector.detectSchema(config.getPath(context), pattern,
+                                           formatContext, getFileSystemProperties(null));
     }
     formatContext = new FormatContext(collector, schema);
     validateInputFormatProvider(formatContext, fileFormat, validatingInputFormat);
@@ -173,7 +176,6 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     Job job = JobUtils.createInstance();
     Configuration conf = job.getConfiguration();
 
-    Pattern pattern = config.getFilePattern();
     if (pattern != null) {
       RegexPathFilter.configure(conf, pattern);
       FileInputFormat.setInputPathFilter(job, RegexPathFilter.class);

--- a/format-common/src/test/java/io/cdap/plugin/format/SchemaDetectorTest.java
+++ b/format-common/src/test/java/io/cdap/plugin/format/SchemaDetectorTest.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright ©2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package io.cdap.plugin.format;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.FormatContext;
+import io.cdap.cdap.etl.api.validation.InputFile;
+import io.cdap.cdap.etl.api.validation.InputFiles;
+import io.cdap.cdap.etl.api.validation.ValidatingInputFormat;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Tests for {@link SchemaDetector}
+ */
+public class SchemaDetectorTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testRegexFiltering() throws IOException {
+    File inputDir = TMP_FOLDER.newFolder();
+
+    File usersFile = new File(inputDir, "users.txt");
+    try (FileOutputStream fos = new FileOutputStream(usersFile)) {
+      fos.write("id,name\n0,alice".getBytes(StandardCharsets.UTF_8));
+    }
+
+    File purchasesFile = new File(inputDir, "purchases.txt");
+    try (FileOutputStream fos = new FileOutputStream(purchasesFile)) {
+      fos.write("ts,item,count\n1234567890,donut,12".getBytes(StandardCharsets.UTF_8));
+    }
+
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), null);
+    TrackingFormat inputFormat = new TrackingFormat(inputDir);
+    SchemaDetector schemaDetector = new SchemaDetector(inputFormat);
+
+    schemaDetector.detectSchema(inputDir.getAbsolutePath(), Pattern.compile(".*users.*"),
+                                formatContext, Collections.emptyMap());
+    Iterator<InputFile> inputFiles = inputFormat.inputFiles.iterator();
+    Assert.assertEquals(usersFile.getName(), inputFiles.next().getName());
+    Assert.assertFalse(inputFiles.hasNext());
+
+    schemaDetector.detectSchema(inputDir.getAbsolutePath(), Pattern.compile(".*purchases.*"),
+                                formatContext, Collections.emptyMap());
+    inputFiles = inputFormat.inputFiles.iterator();
+    Assert.assertEquals(purchasesFile.getName(), inputFiles.next().getName());
+    Assert.assertFalse(inputFiles.hasNext());
+  }
+
+  /**
+   * Just tracks which input files are sent for schema detection
+   */
+  private static class TrackingFormat implements ValidatingInputFormat {
+    private final Map<String, String> conf;
+    private InputFiles inputFiles;
+
+    TrackingFormat(File baseDir) {
+      this.conf = Collections.singletonMap(FileSystem.FS_DEFAULT_NAME_KEY, baseDir.toURI().toString());
+    }
+
+    @Override
+    public void validate(FormatContext formatContext) {
+
+    }
+
+    @Nullable
+    @Override
+    public Schema getSchema(FormatContext formatContext) {
+      return null;
+    }
+
+    @Override
+    public String getInputFormatClassName() {
+      return null;
+    }
+
+    @Override
+    public Map<String, String> getInputFormatConfiguration() {
+      return conf;
+    }
+
+    @Nullable
+    @Override
+    public Schema detectSchema(FormatContext context, InputFiles inputFiles) {
+      this.inputFiles = inputFiles;
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Fix schema detection so that it properly uses the regex config
to filter out files that should be ignored.