### PR TITLE
[CDAP-19368] Pathfield column is added for Delimited,CSV,TSV,Parquet,Avro if pathfield value is given

### DIFF
--- a/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
@@ -841,8 +841,7 @@ public class FileBatchSourceTest extends ETLBatchTestBase {
     String appName = "FileSourceAvroNullSchema";
     Schema recordSchemaWithoutPathField = Schema.recordOf("record",
                                                           Schema.Field.of("i", Schema.of(Schema.Type.INT)),
-                                                          Schema.Field.of("l", Schema.of(Schema.Type.LONG)),
-                                                          Schema.Field.of("file", Schema.of(Schema.Type.STRING))
+                                                          Schema.Field.of("l", Schema.of(Schema.Type.LONG))
     );
 
     org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(recordSchemaWithoutPathField.
@@ -850,7 +849,6 @@ public class FileBatchSourceTest extends ETLBatchTestBase {
     GenericRecord record = new GenericRecordBuilder(avroSchema)
       .set("i", Integer.MAX_VALUE)
       .set("l", Long.MAX_VALUE)
-      .set("file", fileAvro.getAbsolutePath())
       .build();
 
     DataSetManager<TimePartitionedFileSet> inputManager = getDataset("TestFile");
@@ -976,15 +974,13 @@ public class FileBatchSourceTest extends ETLBatchTestBase {
     String appName = "FileSourceParquetNullSchema";
     Schema recordSchemaWithMissingField = Schema.recordOf("record",
                                                           Schema.Field.of("i", Schema.of(Schema.Type.INT)),
-                                                          Schema.Field.of("l", Schema.of(Schema.Type.LONG)),
-                                                          Schema.Field.of("file", Schema.of(Schema.Type.STRING))
+                                                          Schema.Field.of("l", Schema.of(Schema.Type.LONG))
     );
     org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(recordSchemaWithMissingField.
       toString());
     GenericRecord record = new GenericRecordBuilder(avroSchema)
       .set("i", Integer.MAX_VALUE)
       .set("l", Long.MAX_VALUE)
-      .set("file", fileParquet.getAbsoluteFile())
       .build();
     DataSetManager<TimePartitionedFileSet> inputManager = getDataset("TestFile");
     ParquetWriter<GenericRecord> parquetWriter = new AvroParquetWriter<>(new Path(fileParquet.getAbsolutePath()),

--- a/format-avro/src/main/java/io/cdap/plugin/format/avro/input/AvroInputFormatProvider.java
+++ b/format-avro/src/main/java/io/cdap/plugin/format/avro/input/AvroInputFormatProvider.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.format.avro.input;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -78,6 +79,14 @@ public class AvroInputFormatProvider extends PathTrackingInputFormatProvider<Avr
     @Description(NAME_SCHEMA)
     public String schema;
 
+    @VisibleForTesting
+    public Conf(String pathField) {
+      super(pathField);
+    }
+
+    public Conf() {
+      
+    }
   }
 
   @Nullable
@@ -89,7 +98,8 @@ public class AvroInputFormatProvider extends PathTrackingInputFormatProvider<Avr
         continue;
       }
       try (DataFileStream<GenericRecord> dataFileStream = new DataFileStream<>(inputFile.open(), datumReader)) {
-        return new AvroToStructuredTransformer().convertSchema(dataFileStream.getSchema());
+        Schema schema = new AvroToStructuredTransformer().convertSchema(dataFileStream.getSchema());
+        return addPathField(schema, context.getFailureCollector());
       }
     }
     throw new IOException("Unable to find any files that end in .avro");

--- a/format-avro/src/test/java/io/cdap/plugin/format/avro/input/AvroInputFormatProviderTest.java
+++ b/format-avro/src/test/java/io/cdap/plugin/format/avro/input/AvroInputFormatProviderTest.java
@@ -17,7 +17,9 @@
 package io.cdap.plugin.format.avro.input;
 
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.FormatContext;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.format.SchemaDetector;
 import org.apache.avro.file.DataFileWriter;
@@ -32,7 +34,9 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests for {@link AvroInputFormatProvider}
@@ -44,7 +48,7 @@ public class AvroInputFormatProviderTest {
   @Test
   public void testSchemaDetection() throws IOException {
     // write avro file
-    Schema expectedSchema = Schema.recordOf("x",
+    Schema expectedSchema = Schema.recordOf("Avro",
                                             Schema.Field.of("id", Schema.of(Schema.Type.INT)),
                                             Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
                                             Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)));
@@ -69,5 +73,80 @@ public class AvroInputFormatProviderTest {
     SchemaDetector schemaDetector = new SchemaDetector(formatProvider);
     Schema schema = schemaDetector.detectSchema(avroFile.getPath(), formatContext, Collections.emptyMap());
     Assert.assertEquals(expectedSchema, schema);
+    Assert.assertTrue(formatContext.getFailureCollector().getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testPathFieldAddition() throws IOException {
+    // write avro file
+    Schema expectedSchema = Schema.recordOf("Avro",
+                                            Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                            Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)),
+                                            Schema.Field.of("pathField", Schema.of(Schema.Type.STRING)));
+    Schema inputSchema = Schema.recordOf("Avro",
+                                          Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                          Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                          Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)));
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(inputSchema.toString());
+    File avroFile = new File(TMP_FOLDER.newFolder(), "testPathFieldAddition.avro");
+    GenericRecord record = new GenericRecordBuilder(avroSchema)
+      .set("id", 0)
+      .set("name", "alice")
+      .set("score", 1.0d)
+      .build();
+    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(avroSchema);
+    DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
+    dataFileWriter.create(avroSchema, avroFile);
+    dataFileWriter.append(record);
+    dataFileWriter.close();
+
+    // call detect schema
+    AvroInputFormatProvider.Conf conf = new AvroInputFormatProvider.Conf("pathField");
+    AvroInputFormatProvider formatProvider = new AvroInputFormatProvider(conf);
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), null);
+    SchemaDetector schemaDetector = new SchemaDetector(formatProvider);
+    Schema schema = schemaDetector.detectSchema(avroFile.getPath(), formatContext, Collections.emptyMap());
+    Assert.assertEquals(expectedSchema, schema);
+    Assert.assertTrue(formatContext.getFailureCollector().getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testPathFieldConflict() throws IOException {
+    // write avro file
+    Schema expectedSchema = Schema.recordOf("Avro",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("test", Schema.of(Schema.Type.STRING)));
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(expectedSchema.toString());
+    GenericRecord record = new GenericRecordBuilder(avroSchema)
+      .set("id", 0)
+      .set("name", "alice")
+      .set("score", 1.0d)
+      .set("test", "value")
+      .build();
+
+    File avroFile = new File(TMP_FOLDER.newFolder(), "test.avro");
+    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(avroSchema);
+    DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
+    dataFileWriter.create(avroSchema, avroFile);
+    dataFileWriter.append(record);
+    dataFileWriter.close();
+
+    // call detect schema
+    AvroInputFormatProvider.Conf conf = new AvroInputFormatProvider.Conf("test");
+    AvroInputFormatProvider formatProvider = new AvroInputFormatProvider(conf);
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), null);
+    SchemaDetector schemaDetector = new SchemaDetector(formatProvider);
+    schemaDetector.detectSchema(avroFile.getPath(), formatContext, Collections.emptyMap());
+    Assert.assertEquals(formatContext.getFailureCollector().getValidationFailures().size(), 1);
+    ValidationFailure validationFailure = formatContext.getFailureCollector().getValidationFailures().get(0);
+    List<ValidationFailure.Cause> actualCauses = validationFailure.getCauses();
+    ValidationFailure.Cause expectedCause = new ValidationFailure.Cause();
+    expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, "pathField");
+    List<ValidationFailure.Cause> expectedCauses = new ArrayList<>();
+    expectedCauses.add(expectedCause);
+    Assert.assertEquals(expectedCauses, actualCauses);
   }
 }

--- a/format-blob/pom.xml
+++ b/format-blob/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2018-2019 Cask Data, Inc.
+  ~ Copyright © 2018-2022 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -43,6 +43,11 @@
           <artifactId>avro</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>hydrator-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.cdap.plugin</groupId>

--- a/format-blob/src/main/java/io/cdap/plugin/format/blob/input/BlobInputFormatProvider.java
+++ b/format-blob/src/main/java/io/cdap/plugin/format/blob/input/BlobInputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.format.blob.input;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
@@ -152,6 +153,15 @@ public class BlobInputFormatProvider extends PathTrackingInputFormatProvider<Blo
   public static class BlobConfig extends PathTrackingConfig {
     static final String NAME_SCHEMA = "schema";
     static final String NAME_BODY = "body";
+
+    @VisibleForTesting
+    public BlobConfig(String pathField) {
+      super(pathField);
+    }
+
+    public BlobConfig() {
+      super();
+    }
 
     /**
      * Return the configured schema, or the default schema if none was given. Should never be called if the

--- a/format-blob/src/test/java/io/cdap/plugin/format/blob/input/BlobInputFormatProviderTest.java
+++ b/format-blob/src/test/java/io/cdap/plugin/format/blob/input/BlobInputFormatProviderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.blob.input;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.FormatContext;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BlobInputFormatProviderTest {
+  @Test
+  public void testValidate() {
+    BlobInputFormatProvider.BlobConfig blobConfig = new BlobInputFormatProvider.BlobConfig("pathField");
+    Schema schema = blobConfig.getSchema();
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), schema);
+    BlobInputFormatProvider provider = new BlobInputFormatProvider(blobConfig);
+    provider.validate(formatContext);
+    Assert.assertTrue(formatContext.getFailureCollector().getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testSchemaAddingPathField() {
+    BlobInputFormatProvider.BlobConfig blobConfig = new BlobInputFormatProvider.BlobConfig("pathField");
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), blobConfig.getSchema());
+    BlobInputFormatProvider provider = new BlobInputFormatProvider(blobConfig);
+    Schema providerSchema = provider.getSchema(formatContext);
+    Schema expected = Schema.recordOf("blob",
+                                      Schema.Field.of("body", Schema.of(Schema.Type.BYTES)),
+                                      Schema.Field.of("pathField", Schema.of(Schema.Type.STRING)));
+    Assert.assertEquals(expected, providerSchema);
+  }
+
+  @Test
+  public void testSchemaWithoutPathField() {
+    BlobInputFormatProvider.BlobConfig blobConfig = new BlobInputFormatProvider.BlobConfig();
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), blobConfig.getSchema());
+    BlobInputFormatProvider provider = new BlobInputFormatProvider(blobConfig);
+    Schema providerSchema = provider.getSchema(formatContext);
+    Schema expected = Schema.recordOf("blob",
+                                       Schema.Field.of("body", Schema.of(Schema.Type.BYTES)));
+    Assert.assertEquals(expected, providerSchema);
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/input/PathTrackingConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/input/PathTrackingConfig.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.format.input;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -104,7 +105,14 @@ public class PathTrackingConfig extends PluginConfig {
     }
   }
 
+  public PathTrackingConfig() {
 
+  }
+
+  @VisibleForTesting
+  public PathTrackingConfig(String pathField) {
+    this.pathField = pathField;
+  }
   /**
    * Checks whether provided path is directory or file and returns file based on the following
    * conditions: if provided path directs to file - file from the provided path will be returned if

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/CSVInputFormatProvider.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/CSVInputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -83,6 +83,6 @@ public class CSVInputFormatProvider extends PathTrackingInputFormatProvider<Deli
   @Nullable
   @Override
   public Schema detectSchema(FormatContext context, InputFiles inputFiles) throws IOException {
-    return DelimitedInputFormatProvider.detectSchema(conf, ",", inputFiles);
+    return DelimitedInputFormatProvider.detectSchema(conf, ",", inputFiles, context);
   }
 }

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/DelimitedConfig.java
@@ -77,6 +77,10 @@ public class DelimitedConfig extends PathTrackingConfig {
     return Long.parseLong(getProperties().getProperties().getOrDefault(NAME_SAMPLE_SIZE, "1000"));
   }
 
+  public DelimitedConfig() {
+    super();
+  }
+
   /**
    * Parses a list of key-value items of column names and their corresponding data types, manually set by the user.
    *

--- a/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/TSVInputFormatProvider.java
+++ b/format-delimited/src/main/java/io/cdap/plugin/format/delimited/input/TSVInputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -85,6 +85,6 @@ public class TSVInputFormatProvider extends PathTrackingInputFormatProvider<Deli
   @Nullable
   @Override
   public Schema detectSchema(FormatContext context, InputFiles inputFiles) throws IOException {
-    return DelimitedInputFormatProvider.detectSchema(conf, "\t", inputFiles);
+    return DelimitedInputFormatProvider.detectSchema(conf, "\t", inputFiles, context);
   }
 }

--- a/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
+++ b/format-parquet/src/main/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2021 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.format.parquet.input;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -37,6 +38,7 @@ import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.schema.MessageType;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -80,7 +82,9 @@ public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<
       }
       try (ParquetFileReader parquetFileReader = ParquetFileReader.open(new HadoopInputFile(inputFile), readOptions)) {
         MessageType parquetSchema = parquetFileReader.getFooter().getFileMetaData().getSchema();
-        return new AvroToStructuredTransformer().convertSchema(new AvroSchemaConverter().convert(parquetSchema));
+        Schema schema = new AvroToStructuredTransformer()
+          .convertSchema(new AvroSchemaConverter().convert(parquetSchema));
+        return addPathField(schema, context.getFailureCollector());
       }
     }
     throw new IOException("Unable to find any files that end with .parquet");
@@ -125,5 +129,14 @@ public class ParquetInputFormatProvider extends PathTrackingInputFormatProvider<
     @Nullable
     @Description(NAME_SCHEMA)
     public String schema;
+
+    @VisibleForTesting
+    public Conf(String pathField) {
+      super(pathField);
+    }
+
+    public Conf() {
+
+    }
   }
 }

--- a/format-parquet/src/test/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProviderTest.java
+++ b/format-parquet/src/test/java/io/cdap/plugin/format/parquet/input/ParquetInputFormatProviderTest.java
@@ -17,7 +17,9 @@
 package io.cdap.plugin.format.parquet.input;
 
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.CauseAttributes;
 import io.cdap.cdap.etl.api.validation.FormatContext;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.format.SchemaDetector;
 import org.apache.avro.generic.GenericRecord;
@@ -34,7 +36,9 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests for {@link ParquetInputFormatProvider}.
@@ -48,7 +52,6 @@ public class ParquetInputFormatProviderTest {
     Configuration hConf = new Configuration();
     File parquetFile = new File(TMP_FOLDER.newFolder(), "test.parquet");
     Path parquetPath = new Path(parquetFile.toURI());
-
     Schema expectedSchema = Schema.recordOf("x",
                                             Schema.Field.of("id", Schema.of(Schema.Type.INT)),
                                             Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
@@ -73,5 +76,82 @@ public class ParquetInputFormatProviderTest {
     SchemaDetector schemaDetector = new SchemaDetector(formatProvider);
     Schema schema = schemaDetector.detectSchema(parquetFile.getAbsolutePath(), formatContext, Collections.emptyMap());
     Assert.assertEquals(expectedSchema, schema);
+    Assert.assertTrue(formatContext.getFailureCollector().getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testPathFieldAddition() throws IOException {
+    Configuration hConf = new Configuration();
+    File parquetFile = new File(TMP_FOLDER.newFolder(), "pathFieldTest.parquet");
+    Path parquetPath = new Path(parquetFile.toURI());
+    Schema expectedSchema = Schema.recordOf("x",
+                                            Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                            Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)),
+                                            Schema.Field.of("pathField", Schema.of(Schema.Type.STRING)));
+    Schema inputSchema = Schema.recordOf("x",
+                                         Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                         Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                         Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)));
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(inputSchema.toString());
+    GenericRecord record = new GenericRecordBuilder(avroSchema)
+      .set("id", 0)
+      .set("name", "alice")
+      .set("score", 1.0d)
+      .build();
+
+    ParquetWriter<GenericRecord> parquetWriter =
+      AvroParquetWriter.<GenericRecord>builder(HadoopOutputFile.fromPath(parquetPath, hConf))
+        .withSchema(avroSchema)
+        .build();
+    parquetWriter.write(record);
+    parquetWriter.close();
+
+    ParquetInputFormatProvider.Conf conf = new ParquetInputFormatProvider.Conf("pathField");
+    ParquetInputFormatProvider formatProvider = new ParquetInputFormatProvider(conf);
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), null);
+    SchemaDetector schemaDetector = new SchemaDetector(formatProvider);
+    Schema schema = schemaDetector.detectSchema(parquetFile.getAbsolutePath(), formatContext, Collections.emptyMap());
+    Assert.assertEquals(expectedSchema, schema);
+    Assert.assertTrue(formatContext.getFailureCollector().getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testPathFieldConflict() throws IOException {
+    Configuration hConf = new Configuration();
+    File parquetFile = new File(TMP_FOLDER.newFolder(), "test.parquet");
+    Path parquetPath = new Path(parquetFile.toURI());
+    Schema expectedSchema = Schema.recordOf("x",
+                                            Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                            Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE)),
+                                            Schema.Field.of("pathField", Schema.of(Schema.Type.STRING)));
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(expectedSchema.toString());
+    GenericRecord record = new GenericRecordBuilder(avroSchema)
+      .set("id", 0)
+      .set("name", "alice")
+      .set("score", 1.0d)
+      .set("pathField", "value")
+      .build();
+    ParquetWriter<GenericRecord> parquetWriter =
+      AvroParquetWriter.<GenericRecord>builder(HadoopOutputFile.fromPath(parquetPath, hConf))
+        .withSchema(avroSchema)
+        .build();
+    parquetWriter.write(record);
+    parquetWriter.close();
+
+    ParquetInputFormatProvider.Conf conf = new ParquetInputFormatProvider.Conf("pathField");
+    ParquetInputFormatProvider formatProvider = new ParquetInputFormatProvider(conf);
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), null);
+    SchemaDetector schemaDetector = new SchemaDetector(formatProvider);
+    schemaDetector.detectSchema(parquetFile.getAbsolutePath(), formatContext, Collections.emptyMap());
+    Assert.assertEquals(formatContext.getFailureCollector().getValidationFailures().size(), 1);
+    ValidationFailure validationFailure = formatContext.getFailureCollector().getValidationFailures().get(0);
+    List<ValidationFailure.Cause> actualCauses = validationFailure.getCauses();
+    ValidationFailure.Cause expectedCause = new ValidationFailure.Cause();
+    expectedCause.addAttribute(CauseAttributes.STAGE_CONFIG, "pathField");
+    List<ValidationFailure.Cause> expectedCauses = new ArrayList<>();
+    expectedCauses.add(expectedCause);
+    Assert.assertEquals(expectedCauses, actualCauses);
   }
 }

--- a/format-text/pom.xml
+++ b/format-text/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2018-2019 Cask Data, Inc.
+  ~ Copyright © 2018-2022 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -61,8 +61,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+       <groupId>io.cdap.cdap</groupId>
+       <artifactId>hydrator-test</artifactId>
+       <scope>test</scope>
+    </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/format-text/src/main/java/io/cdap/plugin/format/text/input/TextInputFormatProvider.java
+++ b/format-text/src/main/java/io/cdap/plugin/format/text/input/TextInputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.format.text.input;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -245,6 +246,15 @@ public class TextInputFormatProvider extends PathTrackingInputFormatProvider<Tex
       fields.put("skipHeader", new PluginPropertyField("skipHeader", SKIP_HEADER_DESC,
                                                        "boolean", false, true));
       TEXT_FIELDS = Collections.unmodifiableMap(fields);
+    }
+
+    public TextConfig() {
+      super();
+    }
+
+    @VisibleForTesting
+    public TextConfig(String pathField) {
+      super(pathField);
     }
 
     @Macro

--- a/format-text/src/test/java/io/cdap/plugin/format/text/TextInputFormatProviderTest.java
+++ b/format-text/src/test/java/io/cdap/plugin/format/text/TextInputFormatProviderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.text;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.validation.FormatContext;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.format.text.input.TextInputFormatProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TextInputFormatProviderTest {
+  @Test
+  public void testValidateNoOfFields() {
+    TextInputFormatProvider.TextConfig textConfig = new TextInputFormatProvider.TextConfig("pathField");
+    Schema schema = textConfig.getSchema();
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), schema);
+    TextInputFormatProvider provider = new TextInputFormatProvider(textConfig);
+    provider.validate(formatContext);
+    Assert.assertTrue(formatContext.getFailureCollector().getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testSchemaAddingPathField() {
+    TextInputFormatProvider.TextConfig textConfig = new TextInputFormatProvider.TextConfig("pathField");
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), textConfig.getSchema());
+    TextInputFormatProvider provider = new TextInputFormatProvider(textConfig);
+    Schema providerSchema = provider.getSchema(formatContext);
+    Schema expected = Schema.recordOf("textfile",
+                                      Schema.Field.of("offset", Schema.of(Schema.Type.LONG)),
+                                      Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
+                                      Schema.Field.of("pathField", Schema.of(Schema.Type.STRING)));
+    Assert.assertEquals(expected, providerSchema);
+  }
+
+  @Test
+  public void testSchemaWithoutPathField() {
+    TextInputFormatProvider.TextConfig textConfig = new TextInputFormatProvider.TextConfig();
+    FormatContext formatContext = new FormatContext(new MockFailureCollector(), textConfig.getSchema());
+    TextInputFormatProvider provider = new TextInputFormatProvider(textConfig);
+    Schema providerSchema = provider.getSchema(formatContext);
+    Schema expected = Schema.recordOf("textfile",
+                                      Schema.Field.of("offset", Schema.of(Schema.Type.LONG)),
+                                      Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
+    Assert.assertEquals(expected, providerSchema);
+  }
+}


### PR DESCRIPTION
https://cdap.atlassian.net/browse/CDAP-19368. 
Schema detection for path field is done for the format Delimited,CSV,TSV,Parquet,Avro if pathfield value is given