### PR TITLE
CDAP-19532 | Allow precision 0 for Oracle Number data type in generic database plugin

### DIFF
--- a/hydrator-common/src/main/java/io/cdap/plugin/common/db/DBUtils.java
+++ b/hydrator-common/src/main/java/io/cdap/plugin/common/db/DBUtils.java
@@ -322,11 +322,6 @@ public final class DBUtils {
 
       case Types.NUMERIC:
       case Types.DECIMAL:
-        // decimal type with precision 0 is not supported
-        if (precision == 0) {
-          throw new SQLException(new UnsupportedTypeException(
-            String.format("Column %s has unsupported SQL Type: %s with precision 0.", columnName, typeName)));
-        }
         if (handleAsDecimal) {
           return Schema.decimalOf(precision, scale);
         } else {


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-19532