### PR TITLE
Revert maven-javadoc-plugin version to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1030,7 +1030,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.2-SNAPSHOT</version>
+            <version>2.9.1</version>
             <configuration>
               <additionalparam>-Xdoclint:none</additionalparam>
               <failOnError>false</failOnError>


### PR DESCRIPTION
Revert maven-javadoc-plugin version to 2.9.1