### PR TITLE
[CDAP-19665] FQN Generation in Generic DB PLugin

### DIFF
--- a/database-plugins/docs/Database-batchsink.md
+++ b/database-plugins/docs/Database-batchsink.md
@@ -16,7 +16,8 @@ of the FileSet to a database table where it can be served to your users.
 
 Properties
 ----------
-**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
+**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc. 
+Typically, the name of the table/view.
 
 **Use Connection** Whether to use a connection. If a connection is used, you do not need to provide the credentials.
 

--- a/database-plugins/docs/Database-batchsource.md
+++ b/database-plugins/docs/Database-batchsource.md
@@ -38,7 +38,8 @@ This is a semicolon-separated list of key-value pairs, where each pair is separa
 the key and value for the argument. For example, 'key1=value1;key2=value' specifies that the connection will be
 given arguments 'key1' mapped to 'value1' and the argument 'key2' mapped to 'value2'. (Macro-enabled)
 
-**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
+**Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc. 
+Typically, the name of the table/view.
 
 **Schema:** The schema of records output by the source. This will be used in place of whatever schema comes
 back from the query. However, it must match the schema that comes back from the query,

--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -27,6 +27,10 @@
   <artifactId>database-plugins</artifactId>
   <modelVersion>4.0.0</modelVersion>
 
+  <properties>
+    <opentracingjdbc.version>0.2.15</opentracingjdbc.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -40,6 +44,11 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-jdbc</artifactId>
+      <version>${opentracingjdbc.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/database-plugins/src/main/java/io/cdap/plugin/db/common/FQNGenerator.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/db/common/FQNGenerator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.db.common;
+
+import io.cdap.plugin.common.db.DBUtils;
+import io.opentracing.contrib.jdbc.ConnectionInfo;
+import io.opentracing.contrib.jdbc.parser.URLParser;
+
+/**
+ * Generate FQN from DB URL Connection
+ */
+
+public class FQNGenerator {
+
+  public static String constructFQN(String url, String tableName) {
+    // dbtype, host, port, db from the connection string
+    // table is the reference name
+    ConnectionInfo connectionInfo = URLParser.parse(url);
+    // DB type as set by library after extraction
+    if (DBUtils.POSTGRESQL_TAG.equals(connectionInfo.getDbType())) {
+      // FQN for Postgresql
+      return String.format("%s://%s/%s.%s.%s", connectionInfo.getDbType(), connectionInfo.getDbPeer(),
+                           connectionInfo.getDbInstance(), getPostgresqlSchema(url), tableName);
+    } else {
+      // FQN for MySQL, Oracle, SQLServer
+      return String.format("%s://%s/%s.%s", connectionInfo.getDbType(), connectionInfo.getDbPeer(),
+                           connectionInfo.getDbInstance(), tableName);
+    }
+  }
+
+  private static String getPostgresqlSchema(String url) {
+    /**
+     * Extract schema for PostgresSQL URL strings which can be of the following formats
+     * jdbc:postgresql://{host}:{port}/{db}?currentSchema={schema}
+     * jdbc:postgresql://{host}:{port}/{db}?searchpath={schema}
+     */
+    String dbSchema;
+    int offset =  0;
+    int startIndex = url.indexOf("connectionSchema=");
+    offset = 17;
+    if (startIndex == -1) {
+      startIndex = url.indexOf("searchpath=");
+      offset = 11;
+    }
+
+    int endIndex = url.indexOf("&", startIndex);
+    if (endIndex == -1) {
+      endIndex = url.length();
+    }
+    if (startIndex != -1 && endIndex != -1 && startIndex <= endIndex) {
+      dbSchema = url.substring(startIndex + offset, endIndex);
+    } else {
+      dbSchema = DBUtils.POSTGRESQL_DEFAULT_SCHEMA;
+    }
+    return dbSchema;
+  }
+}

--- a/database-plugins/src/test/java/io/cdap/plugin/db/batch/source/DBSourceTestRun.java
+++ b/database-plugins/src/test/java/io/cdap/plugin/db/batch/source/DBSourceTestRun.java
@@ -34,6 +34,7 @@ import io.cdap.plugin.ConnectionConfig;
 import io.cdap.plugin.DBConfig;
 import io.cdap.plugin.DatabasePluginTestBase;
 import io.cdap.plugin.common.Constants;
+import io.cdap.plugin.db.common.FQNGenerator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -455,5 +456,57 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
       .build();
     assertDeploymentFailure(appId, etlConfig, "ETL Application with DB Source should have failed because of a " +
       "non-existent source database.");
+  }
+
+  @Test
+  public void testMySQLFQN() throws Exception {
+    // Testcases consist of Connection URL, Table Name, Expected FQN String
+    String[][] testCases  = {{"jdbc:mysql://localhost:1111/db", "table1", "mysql://localhost:1111/db.table1"},
+                             {"jdbc:mysql://34.35.36.37/db?useSSL=false", "table2",
+                               "mysql://34.35.36.37:3306/db.table2"}};
+    for (int i = 0; i < testCases.length; i++) {
+      String fqn = FQNGenerator.constructFQN(testCases[i][0], testCases[i][1]);
+      Assert.assertEquals(testCases[i][2], fqn);
+    }
+  }
+
+  @Test
+  public void testSQLServerFQN() throws Exception {
+    // Testcases consist of Connection URL, Table Name, Expected FQN String
+    String[][] testCases  = {{"jdbc:sqlserver://;serverName=127.0.0.1;databaseName=DB",
+                               "table1", "sqlserver://127.0.0.1:1433/DB.table1"},
+                             {"jdbc:sqlserver://localhost:1111;databaseName=DB;encrypt=true;user=user;password=pwd;",
+                               "table2", "sqlserver://localhost:1111/DB.table2"}};
+    for (int i = 0; i < testCases.length; i++) {
+      String fqn = FQNGenerator.constructFQN(testCases[i][0], testCases[i][1]);
+      Assert.assertEquals(testCases[i][2], fqn);
+    }
+  }
+
+  @Test
+  public void testOracleFQN() throws Exception {
+    // Testcases consist of Connection URL, Table Name, Expected FQN String
+    String[][] testCases  = {{"jdbc:oracle:thin:@localhost:db", "table1", "oracle://localhost:1521/db.table1"},
+                             {"jdbc:oracle:thin:@test.server:1111/db",
+                               "table2", "oracle://test.server:1111/db.table2"}};
+    for (int i = 0; i < testCases.length; i++) {
+      String fqn = FQNGenerator.constructFQN(testCases[i][0], testCases[i][1]);
+      Assert.assertEquals(testCases[i][2], fqn);
+    }
+  }
+
+  @Test
+  public void testPostgresqlFQN() throws Exception {
+    // Testcases consist of Connection URL, Table Name, Expected FQN String
+    String[][] testCases  = {{"jdbc:postgresql://34.35.36.37/test?user=user&password=secret&ssl=true",
+                              "table1", "postgresql://34.35.36.37:5432/test.public.table1"},
+                            {"jdbc:postgresql://localhost/test?connectionSchema=schema",
+                              "table2", "postgresql://localhost:5432/test.schema.table2"},
+                            {"jdbc:postgresql://localhost/test?searchpath=schema",
+                              "table3", "postgresql://localhost:5432/test.schema.table3"}};
+    for (int i = 0; i < testCases.length; i++) {
+      String fqn = FQNGenerator.constructFQN(testCases[i][0], testCases[i][1]);
+      Assert.assertEquals(testCases[i][2], fqn);
+    }
   }
 }

--- a/database-plugins/widgets/Database-batchsink.json
+++ b/database-plugins/widgets/Database-batchsink.json
@@ -76,7 +76,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this sink for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/database-plugins/widgets/Database-batchsource.json
+++ b/database-plugins/widgets/Database-batchsource.json
@@ -76,7 +76,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/hydrator-common/src/main/java/io/cdap/plugin/common/db/DBUtils.java
+++ b/hydrator-common/src/main/java/io/cdap/plugin/common/db/DBUtils.java
@@ -61,6 +61,8 @@ public final class DBUtils {
   public static final String REPLACE_WITH = "io.cdap.plugin.db.replace.with";
   public static final String CONNECTION_ARGUMENTS = "io.cdap.hydrator.db.connection.arguments";
   public static final String FETCH_SIZE = "io.cdap.hydrator.db.fetch.size";
+  public static final String POSTGRESQL_TAG = "postgresql";
+  public static final String POSTGRESQL_DEFAULT_SCHEMA = "public";
 
   /**
    * Performs any Database related cleanup


### PR DESCRIPTION
Changes: 
- Added FQN Generation for DB Connection Strings using [JDBC Parsing Library](https://github.com/opentracing-contrib/java-jdbc)
- Supported Databases: SQLServer, Postgresql, MySQL, Oracle
- Lineage Recording for DB Source
- Related Unit Tests
- Updated `Reference Name` label name in widget to `Table Name`.
- Jira:  https://cdap.atlassian.net/browse/CDAP-19665