### PR TITLE
account for null reference names in validation

### DIFF
--- a/core-plugins/src/e2e-test/features/fileplugin/sink/FileSinkErrorScenarios.feature
+++ b/core-plugins/src/e2e-test/features/fileplugin/sink/FileSinkErrorScenarios.feature
@@ -8,6 +8,5 @@ Feature:File Sink - Verify File Sink Plugin Error scenarios
     Then Navigate to the properties page of plugin: "File"
     Then Click on the Validate button
     Then Verify mandatory property error for below listed properties:
-      | referenceName |
       | path          |
       | format        |

--- a/core-plugins/src/e2e-test/features/fileplugin/source/FileSourceErrorScenarios.feature
+++ b/core-plugins/src/e2e-test/features/fileplugin/source/FileSourceErrorScenarios.feature
@@ -8,7 +8,6 @@ Feature:File Source - Verify File Source Plugin Error scenarios
     Then Navigate to the properties page of plugin: "File"
     Then Click on the Validate button
     Then Verify mandatory property error for below listed properties:
-      | referenceName |
       | path          |
       | format        |
 

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSinkConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSinkConfig.java
@@ -41,6 +41,7 @@ public abstract class AbstractFileSinkConfig extends PluginConfig implements Fil
   public static final String NAME_SUFFIX = "suffix";
 
   @Description("Name be used to uniquely identify this sink for lineage, annotating metadata, etc.")
+  @Nullable
   private String referenceName;
 
   @Macro
@@ -85,7 +86,9 @@ public abstract class AbstractFileSinkConfig extends PluginConfig implements Fil
   }
 
   public void validate(FailureCollector collector, Map<String, String> arguments) {
-    IdUtils.validateReferenceName(referenceName, collector);
+    if (!Strings.isNullOrEmpty(referenceName)) {
+      IdUtils.validateReferenceName(referenceName, collector);
+    }
     if (suffix != null && !containsMacro(NAME_SUFFIX)) {
       try {
         new SimpleDateFormat(suffix);

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java
@@ -42,6 +42,7 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   public static final String DEFAULT_FILE_ENCODING = "UTF-8";
 
   @Description("Name be used to uniquely identify this source for lineage, annotating metadata, etc.")
+  @Nullable
   private String referenceName;
 
   @Macro
@@ -141,7 +142,9 @@ public abstract class AbstractFileSourceConfig extends PluginConfig implements F
   }
 
   public void validate(FailureCollector collector) {
-    IdUtils.validateReferenceName(referenceName, collector);
+    if (!Strings.isNullOrEmpty(referenceName)) {
+      IdUtils.validateReferenceName(referenceName, collector);
+    }
     try {
       getSchema();
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
This PR updates the validation methods to account for null reference names now that we are making them optional for certain plugins.