### PR TITLE
e2e tests - fix error collector scenarios as per latest updates in sandbox

### DIFF
--- a/core-plugins/src/e2e-test/features/errorcollector/ErrorCollector.feature
+++ b/core-plugins/src/e2e-test/features/errorcollector/ErrorCollector.feature
@@ -97,6 +97,7 @@ Feature: Error Collector - Verification of successful error emitted to ErrorColl
     Then Close the Plugin Properties page
     When Navigate to the properties page of plugin: "Wrangler"
     Then Enter textarea plugin property: "recipe" with value: "errorCollectorWranglerCondition"
+    Then Select radio button plugin property: "onError" with value: "send-to-error-port"
     Then Validate "Wrangler" plugin properties
     When Close the Plugin Properties page
     When Navigate to the properties page of plugin: "ErrorCollector"
@@ -149,6 +150,7 @@ Feature: Error Collector - Verification of successful error emitted to ErrorColl
     Then Close the Plugin Properties page
     When Navigate to the properties page of plugin: "Wrangler"
     Then Enter textarea plugin property: "recipe" with value: "errorCollectorWranglerCondition"
+    Then Select radio button plugin property: "onError" with value: "send-to-error-port"
     Then Validate "Wrangler" plugin properties
     When Close the Plugin Properties page
     When Navigate to the properties page of plugin: "ErrorCollector"

--- a/core-plugins/src/e2e-test/resources/pluginDataCyAttributes.properties
+++ b/core-plugins/src/e2e-test/resources/pluginDataCyAttributes.properties
@@ -48,3 +48,4 @@ errorMessageColumnName=messageField
 errorCodeColumnName=codeField
 errorEmitterNodeName=stageField
 recipe=directives
+onError=on-error


### PR DESCRIPTION
@itsankit-google Please review.

Added step to select "Send to error port" radio button in wrangler properties. In previous sandbox version it was default selection.
<img width="746" alt="image" src="https://user-images.githubusercontent.com/94541628/194859229-17c6dbcd-6522-4371-999b-d6337856bdda.png">
