### PR TITLE
Fix security vulnerabilities due to netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <jython.version>2.5.2</jython.version>
     <json-path.version>2.2.0</json-path.version>
     <json.version>20160212</json.version>
-    <netty.version>4.1.16.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <netty-http.version>1.3.0</netty-http.version>
     <spark1.version>1.6.3</spark1.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>


### PR DESCRIPTION
## Vulnerability Details:
CVE-2019-20444
CVE-2019-20445
CVE-2015-2156
CVE-2019-16869
CVE-2019-9518
CVE-2020-7238
CVE-2021-37136
CVE-2021-37137
CVE-2021-43797
CVE-2021-21295
CVE-2021-21290
CVE-2014-0193

## Change:
updated `netty.version` from `4.1.16.Final` to `4.1.75.Final`