### PR TITLE
[CDAP-20222] Overwrite org.apache.ivy:ivy dependency to 2.5.1 to remediate CVE-2022-37866

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -788,6 +788,13 @@
         <version>${netty-http.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <!-- Overwrite Apache Ivy version to 2.5.1 for remediating CVE-2022-37866 -->
+        <groupId>org.apache.ivy</groupId>
+        <artifactId>ivy</artifactId>
+        <version>2.5.1</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Cherry-pick of #1723 for 6.8