### PR TITLE
[CDAP-20224] Remove References of Explore from `hydrator-plugins`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 [submodule "wrangler-transform"]
 	path = wrangler-transform
 	url = ../../data-integrations/wrangler.git
-	branch = remove-explore
+	branch = develop
 [submodule "google-cloud"]
 	path = google-cloud
 	url = ../../data-integrations/google-cloud
@@ -26,7 +26,7 @@
 [submodule "kafka-plugins"]
 	path = kafka-plugins
 	url = ../../data-integrations/kafka-plugins
-	branch = remove-explore
+	branch = develop
 [submodule "amazon-s3-plugins"]
 	path = amazon-s3-plugins
 	url = ../../data-integrations/amazon-s3-plugins

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 [submodule "wrangler-transform"]
 	path = wrangler-transform
 	url = ../../data-integrations/wrangler.git
-	branch = develop
+	branch = remove-explore
 [submodule "google-cloud"]
 	path = google-cloud
 	url = ../../data-integrations/google-cloud
@@ -26,7 +26,7 @@
 [submodule "kafka-plugins"]
 	path = kafka-plugins
 	url = ../../data-integrations/kafka-plugins
-	branch = develop
+	branch = remove-explore
 [submodule "amazon-s3-plugins"]
 	path = amazon-s3-plugins
 	url = ../../data-integrations/amazon-s3-plugins

--- a/cassandra-plugins/src/test/java/io/cdap/plugin/test/ETLCassandraTest.java
+++ b/cassandra-plugins/src/test/java/io/cdap/plugin/test/ETLCassandraTest.java
@@ -42,7 +42,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.batch.sink.BatchCassandraSink;
 import io.cdap.plugin.batch.source.BatchCassandraSource;
@@ -86,9 +85,6 @@ public class ETLCassandraTest extends HydratorTestBase {
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static final String VERSION = "3.2.0";
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion(VERSION);

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/sink/SnapshotFileBatchTextSink.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/sink/SnapshotFileBatchTextSink.java
@@ -55,10 +55,7 @@ public class SnapshotFileBatchTextSink extends SnapshotFileBatchSink<SnapshotFil
   protected void addFileProperties(FileSetProperties.Builder propertiesBuilder) {
     propertiesBuilder
       .setInputFormat(TextInputFormat.class)
-      .setOutputFormat(TextOutputFormat.class)
-      .setEnableExploreOnCreate(true)
-      .setExploreFormat("text")
-      .setExploreSchema("text string");
+      .setOutputFormat(TextOutputFormat.class);
   }
 
   /**

--- a/core-plugins/src/main/java/io/cdap/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/common/FileSetUtil.java
@@ -85,6 +85,7 @@ public class FileSetUtil {
    */
   public static void configureAvroFileSet(String configuredSchema, FileSetProperties.Builder properties) {
     properties
+      .setTableProperty("avro.schema.literal", configuredSchema)
       .add(DatasetProperties.SCHEMA, configuredSchema);
   }
 

--- a/core-plugins/src/main/java/io/cdap/plugin/common/FileSetUtil.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/common/FileSetUtil.java
@@ -42,9 +42,6 @@ public class FileSetUtil {
     String hiveSchema = parseHiveSchema(configuredSchema, configuredSchema);
 
     properties
-      .setEnableExploreOnCreate(true)
-      .setExploreFormat("parquet")
-      .setExploreSchema(hiveSchema.substring(1, hiveSchema.length() - 1))
       .add(DatasetProperties.SCHEMA, configuredSchema);
   }
 
@@ -68,12 +65,7 @@ public class FileSetUtil {
     String hiveSchema = parseHiveSchema(lowerCaseSchema, configuredSchema);
     hiveSchema = hiveSchema.substring(1, hiveSchema.length() - 1);
 
-    properties.setExploreInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat")
-      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat")
-      .setSerDe("org.apache.hadoop.hive.ql.io.orc.OrcSerde")
-      .setExploreSchema(hiveSchema)
-      .setEnableExploreOnCreate(true)
-      .add(DatasetProperties.SCHEMA, configuredSchema)
+    properties.add(DatasetProperties.SCHEMA, configuredSchema)
       .build();
   }
 
@@ -93,11 +85,6 @@ public class FileSetUtil {
    */
   public static void configureAvroFileSet(String configuredSchema, FileSetProperties.Builder properties) {
     properties
-      .setEnableExploreOnCreate(true)
-      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
-      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
-      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
-      .setTableProperty("avro.schema.literal", configuredSchema)
       .add(DatasetProperties.SCHEMA, configuredSchema);
   }
 

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/ETLBatchTestBase.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/ETLBatchTestBase.java
@@ -35,7 +35,6 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.alert.TMSAlertPublisher;
 import io.cdap.plugin.batch.action.EmailAction;
@@ -90,7 +89,6 @@ import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.twill.filesystem.Location;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
@@ -105,9 +103,6 @@ import java.util.concurrent.TimeoutException;
  * Base test class that sets up plugin and the etl batch app artifacts.
  */
 public class ETLBatchTestBase extends HydratorTestBase {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", true);
 
   protected static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "3.2.0");

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/ETLTPFSTestRun.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/ETLTPFSTestRun.java
@@ -55,8 +55,6 @@ import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -235,25 +233,6 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
     // run the pipeline
     runETLOnce(appManager);
 
-    Connection connection = getQueryClient();
-    ResultSet results = connection.prepareStatement("select * from dataset_outputOrc").executeQuery();
-    results.next();
-
-    Assert.assertEquals("a", results.getString(1));
-    Assert.assertEquals(3.6f, results.getFloat(2), 0.1);
-    Assert.assertEquals(4.2, results.getDouble(3), 0.1);
-    Assert.assertEquals(true, results.getBoolean(4));
-    Assert.assertEquals(23456789, results.getLong(5));
-    Assert.assertArrayEquals(Bytes.toBytes("abcd"), results.getBytes(6));
-    Assert.assertEquals(12, results.getLong(7));
-    Assert.assertEquals("testUnion", results.getString(8));
-    Assert.assertNull(results.getString(9));
-    Assert.assertEquals(12, results.getLong(10));
-    Assert.assertEquals(0, results.getLong(11));
-    Assert.assertEquals(3.6f, results.getFloat(12), 0.1);
-    Assert.assertEquals(0.0, results.getFloat(13), 0.1);
-    Assert.assertEquals(4.2, results.getDouble(14), 0.1);
-    Assert.assertEquals(0, results.getDouble(15), 0.1);
   }
 
   @Test
@@ -271,11 +250,6 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .setOutputFormat(AvroKeyOutputFormat.class)
       .setInputProperty("schema", avroSchema.toString())
       .setOutputProperty("schema", avroSchema.toString())
-      .setEnableExploreOnCreate(true)
-      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
-      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
-      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
-      .setTableProperty("avro.schema.literal", (avroSchema.toString()))
       .build());
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);
     TimePartitionedFileSet tpfs = fileSetManager.get();
@@ -367,11 +341,6 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .setOutputFormat(AvroKeyOutputFormat.class)
       .setInputProperty("schema", avroSchema.toString())
       .setOutputProperty("schema", avroSchema.toString())
-      .setEnableExploreOnCreate(true)
-      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
-      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
-      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
-      .setTableProperty("avro.schema.literal", (avroSchema.toString()))
       .build());
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);
     TimePartitionedFileSet tpfs = fileSetManager.get();

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/ETLTPFSTestRun.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/ETLTPFSTestRun.java
@@ -250,6 +250,7 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .setOutputFormat(AvroKeyOutputFormat.class)
       .setInputProperty("schema", avroSchema.toString())
       .setOutputProperty("schema", avroSchema.toString())
+      .setTableProperty("avro.schema.literal", (avroSchema.toString()))
       .build());
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);
     TimePartitionedFileSet tpfs = fileSetManager.get();
@@ -341,6 +342,7 @@ public class ETLTPFSTestRun extends ETLBatchTestBase {
       .setOutputFormat(AvroKeyOutputFormat.class)
       .setInputProperty("schema", avroSchema.toString())
       .setOutputProperty("schema", avroSchema.toString())
+      .setTableProperty("avro.schema.literal", (avroSchema.toString()))
       .build());
     DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);
     TimePartitionedFileSet tpfs = fileSetManager.get();

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/source/ExcelInputReaderTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/source/ExcelInputReaderTest.java
@@ -39,7 +39,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.common.Constants;
 import org.apache.commons.io.FileUtils;
@@ -72,9 +71,6 @@ public class ExcelInputReaderTest extends HydratorTestBase {
     NamespaceId.DEFAULT.artifact("data-pipeline", CURRENT_VERSION.getVersion());
   private static final ArtifactSummary BATCH_ARTIFACT =
     new ArtifactSummary(BATCH_APP_ARTIFACT_ID.getArtifact(), BATCH_APP_ARTIFACT_ID.getVersion());
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/source/FileBatchSourceTest.java
@@ -44,7 +44,6 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.batch.ETLBatchTestBase;
 import io.cdap.plugin.common.Constants;
@@ -90,8 +89,6 @@ import javax.annotation.Nullable;
  */
 public class FileBatchSourceTest extends ETLBatchTestBase {
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
   private static final Schema RECORD_SCHEMA = Schema.recordOf("record",
                                                               Schema.Field.of("i", Schema.of(Schema.Type.INT)),
                                                               Schema.Field.of("l", Schema.of(Schema.Type.LONG)),

--- a/core-plugins/src/test/java/io/cdap/plugin/batch/source/XMLReaderBatchSourceTest.java
+++ b/core-plugins/src/test/java/io/cdap/plugin/batch/source/XMLReaderBatchSourceTest.java
@@ -39,7 +39,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.common.Constants;
 import org.apache.commons.io.FileUtils;
@@ -76,9 +75,6 @@ public class XMLReaderBatchSourceTest extends HydratorTestBase {
     new ArtifactSummary(BATCH_APP_ARTIFACT_ID.getArtifact(), BATCH_APP_ARTIFACT_ID.getVersion());
   private static final String CATALOG_LARGE_XML_FILE_NAME = "catalogLarge.xml";
   private static final String CATALOG_SMALL_XML_FILE_NAME = "catalogSmall.xml";
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/database-plugins/src/test/java/io/cdap/plugin/DatabasePluginTestBase.java
+++ b/database-plugins/src/test/java/io/cdap/plugin/DatabasePluginTestBase.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.db.batch.action.DBAction;
 import io.cdap.plugin.db.batch.action.QueryAction;
@@ -89,9 +88,6 @@ public class DatabasePluginTestBase extends HydratorTestBase {
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/hbase-plugins/src/test/java/io/cdap/plugin/HBaseTest.java
+++ b/hbase-plugins/src/test/java/io/cdap/plugin/HBaseTest.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.sink.HBaseSink;
@@ -92,9 +91,6 @@ public class HBaseTest extends HydratorTestBase {
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion("3.2.0");
 

--- a/http-plugins/src/test/java/io/cdap/plugin/batch/HttpCallbackActionTest.java
+++ b/http-plugins/src/test/java/io/cdap/plugin/batch/HttpCallbackActionTest.java
@@ -38,7 +38,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.TestBase;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.NettyHttpService;
@@ -47,7 +46,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -67,9 +65,6 @@ import javax.ws.rs.HttpMethod;
 /**
  */
 public class HttpCallbackActionTest extends HydratorTestBase {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   protected static final ArtifactId BATCH_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("data-pipeline", "3.2.0");
   protected static final ArtifactSummary BATCH_ARTIFACT = new ArtifactSummary("data-pipeline", "3.2.0");

--- a/solrsearch-plugins/src/test/java/io/cdap/plugin/SolrSearchSinkTest.java
+++ b/solrsearch-plugins/src/test/java/io/cdap/plugin/SolrSearchSinkTest.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.batch.SolrSearchSink;
 import io.cdap.plugin.common.Constants;
@@ -68,8 +67,6 @@ import java.util.concurrent.TimeUnit;
  * Test cases for {@link SolrSearchSink}.
  */
 public class SolrSearchSinkTest extends HydratorTestBase {
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
   private static final Schema inputSchema = Schema.recordOf(
     "input-record",
     Schema.Field.of("id", Schema.of(Schema.Type.STRING)),

--- a/spark-plugins/src/test/java/io/cdap/plugin/spark/test/SparkPluginTest.java
+++ b/spark-plugins/src/test/java/io/cdap/plugin/spark/test/SparkPluginTest.java
@@ -47,7 +47,6 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
 import io.cdap.cdap.test.SparkManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.NettyHttpService;
 import io.cdap.plugin.common.http.HTTPPollConfig;
@@ -79,9 +78,6 @@ import javax.ws.rs.HttpMethod;
  * Tests for Spark plugins.
  */
 public class SparkPluginTest extends HydratorTestBase {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   protected static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "3.2.0");

--- a/transform-plugins/src/test/java/io/cdap/plugin/TransformPluginsTestBase.java
+++ b/transform-plugins/src/test/java/io/cdap/plugin/TransformPluginsTestBase.java
@@ -22,7 +22,6 @@ import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.etl.mock.test.HydratorTestBase;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.common.KeystoreConf;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.csv.CSVFormat;
@@ -37,9 +36,6 @@ public class TransformPluginsTestBase extends HydratorTestBase {
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static final ArtifactVersion CURRENT_VERSION = new ArtifactVersion("3.2.0");
 


### PR DESCRIPTION
- As part of cdapio/cdap/pull/14802, the module `cdap-explore` and its references and occurrences are removed from CDAP repository.
- Similar references in `hydrators-plugins` need to be removed.
[JIRA](https://cdap.atlassian.net/browse/CDAP-20224)