### PR TITLE
[CDAP-20238] Remove Spark2 references and update dependencies

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -50,15 +50,10 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-unit-test-spark3_2.12</artifactId>
-    </dependency>
     <!-- Spark3.1.1 uses constant JavaVersion.JAVA_9 that is only there in newer versions of commons-lang3 -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -33,6 +33,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
     </dependency>
@@ -61,10 +65,6 @@
           <artifactId>cdap-unit-test</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-unit-test-spark3_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -114,6 +114,14 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/http-plugins/pom.xml
+++ b/http-plugins/pom.xml
@@ -63,10 +63,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-unit-test-spark3_2.12</artifactId>
-    </dependency>
     <!-- needs to be marked as test scope instead of provided, otherwise spark in unit test won't see it -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
     <commons-lang-version>2.6</commons-lang-version>
+    <commons-lang3-version>3.5</commons-lang3-version>
     <cdap.version>6.9.0-SNAPSHOT</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
@@ -113,7 +114,6 @@
     <javamail.version>1.4.1</javamail.version>
     <junit.version>4.13.1</junit.version>
     <mockito.version>2.24.0</mockito.version>
-    <kafka.version>0.8.2.2</kafka.version>
     <mockftp.version>2.6</mockftp.version>
     <snappy.version>1.1.2</snappy.version>
     <slf4j.version>1.7.15</slf4j.version>
@@ -211,19 +211,7 @@
       </dependency>
       <dependency>
         <groupId>io.cdap.cdap</groupId>
-        <artifactId>cdap-data-pipeline2_2.11</artifactId>
-        <version>${cdap.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.cdap.cdap</groupId>
         <artifactId>cdap-data-pipeline3_2.12</artifactId>
-        <version>${cdap.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.cdap.cdap</groupId>
-        <artifactId>cdap-data-streams2_2.11</artifactId>
         <version>${cdap.version}</version>
         <scope>test</scope>
       </dependency>
@@ -294,6 +282,11 @@
         <version>${commons-lang-version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3-version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-minicluster</artifactId>
         <version>${hadoop.version}</version>
@@ -330,6 +323,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>log4j</groupId>
@@ -402,6 +399,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -412,6 +415,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -419,6 +428,10 @@
         <version>${hadoop.version}</version>
         <scope>provided</scope>
         <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -701,29 +714,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka_2.10</artifactId>
-        <version>${kafka.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jdmk</groupId>
-            <artifactId>jmxtools</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jmx</groupId>
-            <artifactId>jmxri</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm-commons</artifactId>
         <version>${asm.version}</version>
@@ -756,13 +746,13 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-streaming-twitter_2.10</artifactId>
-        <version>${spark1.version}</version>
+        <artifactId>spark-streaming-twitter_2.12</artifactId>
+        <version>${spark.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_2.10</artifactId>
-        <version>${spark1.version}</version>
+        <artifactId>spark-core_2.12</artifactId>
+        <version>${spark.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -801,12 +791,16 @@
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-streaming_2.10</artifactId>
-        <version>${spark1.version}</version>
+        <artifactId>spark-streaming_2.12</artifactId>
+        <version>${spark.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -822,6 +816,13 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-unit-test-spark3_2.12</artifactId>
+    </dependency>
+  </dependencies>
 
   <build>
     <testSourceDirectory>${testSourceLocation}</testSourceDirectory>

--- a/solrsearch-plugins/src/test/java/io/cdap/plugin/SolrSearchSinkTest.java
+++ b/solrsearch-plugins/src/test/java/io/cdap/plugin/SolrSearchSinkTest.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.datapipeline.SmartWorkflow;
+import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
@@ -120,10 +121,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     ETLStage sink = new ETLStage("SolrSink", new ETLPlugin("SolrSearch", BatchSink.PLUGIN_TYPE, sinkConfigproperties,
                                                            null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrSink");
@@ -187,10 +189,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     ETLStage sink = new ETLStage("SolrSink", new ETLPlugin("SolrSearch", BatchSink.PLUGIN_TYPE, sinkConfigproperties,
                                                            null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrCloudSink");
@@ -260,10 +263,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     ETLStage sink = new ETLStage("SolrSink", new ETLPlugin("SolrSearch", BatchSink.PLUGIN_TYPE, sinkConfigproperties,
                                                            null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrSink");
@@ -338,10 +342,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     ETLStage sink = new ETLStage("SolrSink", new ETLPlugin("SolrSearch", BatchSink.PLUGIN_TYPE, sinkConfigproperties,
                                                            null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrSinkWrongHost");
@@ -380,10 +385,11 @@ public class SolrSearchSinkTest extends HydratorTestBase {
     ETLStage sink = new ETLStage("SolrSink", new ETLPlugin("SolrSearch", BatchSink.PLUGIN_TYPE, sinkConfigproperties,
                                                            null));
 
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     ApplicationId appId = NamespaceId.DEFAULT.app("testBatchSolrSink");

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -68,10 +68,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-unit-test-spark3_2.12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>
       <version>${project.version}</version>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>7.1</version>
+      <version>${asm.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- needs to be marked as test scope. Otherwise it will be provided and spark in unit test won't see it -->


### PR DESCRIPTION
As part of cdapio/cdap/pull/14797, the spark2 modules and references have been removed. Similar references in this repo need to be done and subsequent dependencies need to be updated.