### PR TITLE
[CDAP-20263] Remove unused kafka dependency from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
     <javamail.version>1.4.1</javamail.version>
     <junit.version>4.13.1</junit.version>
     <mockito.version>2.24.0</mockito.version>
-    <kafka.version>0.10.2.2</kafka.version>
     <mockftp.version>2.6</mockftp.version>
     <snappy.version>1.1.2</snappy.version>
     <slf4j.version>1.7.15</slf4j.version>
@@ -685,29 +684,6 @@
           <exclusion>
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka_2.12</artifactId>
-        <version>${kafka.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jdmk</groupId>
-            <artifactId>jmxtools</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jmx</groupId>
-            <artifactId>jmxri</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Remove unused `org.apache.kafka:kafka_2.12` dependency declared in `dependencyManagement`.