### PR TITLE
[CDAP-20235] App fabric logs exposing database username and password

### DIFF
--- a/database-plugins/src/main/java/io/cdap/plugin/db/batch/source/DBSource.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/db/batch/source/DBSource.java
@@ -188,10 +188,11 @@ public class DBSource extends ReferenceBatchSource<LongWritable, DBRecord, Struc
     if (sourceConfig.fetchSize != null) {
       hConf.setInt(DBUtils.FETCH_SIZE, sourceConfig.fetchSize);
     }
+
+    // Create the external dataset before setting context properties
+    emitLineage(context);
     context.setInput(Input.of(sourceConfig.getReferenceName(),
                               new SourceInputFormatProvider(DataDrivenETLDBInputFormat.class, hConf)));
-
-    emitLineage(context);
   }
 
   @Override


### PR DESCRIPTION
For database plugin, when input is added on the context, it will add an external dataset if not already present (https://github.com/cdapio/cdap/blob/develop/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ExternalDatasets.java#L78). Here, all the properties are added to dataset properties including username/password.
To fix this, we are adding the external dataset before calling the above logic. 