### PR TITLE
CDAP-20274 fix broken hbase tests

### DIFF
--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -61,6 +61,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
       <version>0.98.6.1-hadoop2</version>


### PR DESCRIPTION
HBase tests are failing with NoClassDefFoundError for an HDFS class.