### PR TITLE
CDAP-20274 fix database-plugins tests

### DIFF
--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -55,10 +55,27 @@
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>hydrator-test</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-unit-test</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-unit-test-spark3_2.12</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
+    </dependency>
+    <!-- needs to be marked as test scope instead of provided, otherwise spark in unit test won't see it -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/database-plugins/src/test/java/io/cdap/plugin/DatabasePluginTestBase.java
+++ b/database-plugins/src/test/java/io/cdap/plugin/DatabasePluginTestBase.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginPropertyField;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.datapipeline.SmartWorkflow;
+import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.mock.test.HydratorTestBase;
 import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
@@ -270,10 +271,11 @@ public class DatabasePluginTestBase extends HydratorTestBase {
     throws Exception {
     ETLStage source = new ETLStage("source", sourcePlugin);
     ETLStage sink = new ETLStage("sink", sinkPlugin);
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);

--- a/database-plugins/src/test/java/io/cdap/plugin/db/batch/action/DBActionTestRun.java
+++ b/database-plugins/src/test/java/io/cdap/plugin/db/batch/action/DBActionTestRun.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.db.batch.action;
 
 import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
@@ -64,12 +65,13 @@ public class DBActionTestRun extends DatabasePluginTestBase {
         .build(),
       null));
 
-    ETLBatchConfig config = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig config = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addStage(action)
       .addConnection(sink.getName(), action.getName())
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);

--- a/database-plugins/src/test/java/io/cdap/plugin/db/batch/action/DBQueryActionTestRun.java
+++ b/database-plugins/src/test/java/io/cdap/plugin/db/batch/action/DBQueryActionTestRun.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.db.batch.action;
 
 import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.batch.PostAction;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
@@ -66,11 +67,12 @@ public class DBQueryActionTestRun extends DatabasePluginTestBase {
         .build(),
       null));
 
-    ETLBatchConfig config = ETLBatchConfig.builder("* * * * *")
+    ETLBatchConfig config = ETLBatchConfig.builder()
       .addStage(source)
       .addStage(sink)
       .addPostAction(action)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);


### PR DESCRIPTION
Switched the db unit tests over to use Spark instead of MapReduce, as MapReduce is deprecated and the tests are failing due to transitive dependency issues.

Also fixed a unit test that was using an invalid bounding query. Not sure how that was ever passing.