### PR TITLE
CDAP-20274 use datapipeline spark3 dependency instead of spark2

### DIFF
--- a/cassandra-plugins/pom.xml
+++ b/cassandra-plugins/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cdap.plugin</groupId>

--- a/mongodb-plugins/pom.xml
+++ b/mongodb-plugins/pom.xml
@@ -38,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cdap.plugin</groupId>

--- a/solrsearch-plugins/pom.xml
+++ b/solrsearch-plugins/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>


### PR DESCRIPTION
For some reason, this fixes pipeline deployment errors in unit tests in the cdap-build project due to ETLBatchPipelineSpec not being found. Probably related to the fact that datapipeline2 was removed from CDAP.