### PR TITLE
set cdap dependency version back to 6.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <commons-lang-version>2.6</commons-lang-version>
     <commons-lang3-version>3.5</commons-lang3-version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.8.0</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
     <es.version>1.6.0</es.version>


### PR DESCRIPTION
There have not been any API changes in 6.9.0-SNAPSHOT that would require the plugins to bump the version. Changing this back to a non-snapshot version. This also makes the dependency match the declared compatible range of [6.8.0,7.0.0) set in the parent artifacts.