### PR TITLE
[CDAP-19665] Fix PSQL schema generation in FQN

### DIFF
--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -75,7 +75,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
-      <version>2.10.0</version>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/database-plugins/src/main/java/io/cdap/plugin/db/common/FQNGenerator.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/db/common/FQNGenerator.java
@@ -50,8 +50,8 @@ public class FQNGenerator {
      */
     String dbSchema;
     int offset =  0;
-    int startIndex = url.indexOf("connectionSchema=");
-    offset = 17;
+    int startIndex = url.indexOf("currentSchema=");
+    offset = 14;
     if (startIndex == -1) {
       startIndex = url.indexOf("searchpath=");
       offset = 11;

--- a/database-plugins/src/test/java/io/cdap/plugin/db/batch/source/DBSourceTestRun.java
+++ b/database-plugins/src/test/java/io/cdap/plugin/db/batch/source/DBSourceTestRun.java
@@ -506,7 +506,7 @@ public class DBSourceTestRun extends DatabasePluginTestBase {
     // Testcases consist of Connection URL, Table Name, Expected FQN String
     String[][] testCases  = {{"jdbc:postgresql://34.35.36.37/test?user=user&password=secret&ssl=true",
                               "table1", "postgresql://34.35.36.37:5432/test.public.table1"},
-                            {"jdbc:postgresql://localhost/test?connectionSchema=schema",
+                            {"jdbc:postgresql://localhost/test?currentSchema=schema",
                               "table2", "postgresql://localhost:5432/test.schema.table2"},
                             {"jdbc:postgresql://localhost/test?searchpath=schema",
                               "table3", "postgresql://localhost:5432/test.schema.table3"}};

--- a/http-plugins/pom.xml
+++ b/http-plugins/pom.xml
@@ -68,7 +68,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
-      <version>2.10.0</version>
+      <version>2.13.4.2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <commons-lang-version>2.6</commons-lang-version>
     <commons-lang3-version>3.5</commons-lang3-version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.9.1</cdap.version>
     <datastax.version>2.0.5</datastax.version>
     <dumbster.version>1.6</dumbster.version>
     <es.version>1.6.0</es.version>
@@ -124,7 +124,7 @@
     <json.version>20160212</json.version>
     <netty.version>4.1.75.Final</netty.version>
     <netty-http.version>1.3.0</netty-http.version>
-    <spark.version>3.1.1</spark.version>
+    <spark.version>3.3.2</spark.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
   </properties>
 
@@ -775,8 +775,24 @@
             <artifactId>log4j</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+          </exclusion>
+          <!--
+            We still use hadoop2,
+            so excluding hadoop3 dependencies from spark
+          -->
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.esotericsoftware.reflectasm</groupId>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -72,7 +72,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
-      <version>2.10.0</version>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>


### PR DESCRIPTION
Schema can be specified in JDBC URL for PSQL with the help of `currentSchema` parameter.

ref: https://stackoverflow.com/questions/4168689/is-it-possible-to-specify-the-schema-when-connecting-to-postgres-with-jdbc