### PR TITLE
use plugin classloader for scripting engines

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/transform/JavaScriptTransform.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/transform/JavaScriptTransform.java
@@ -383,7 +383,7 @@ public class JavaScriptTransform extends Transform<StructuredRecord, StructuredR
   }
 
   private void init(@Nullable TransformContext context, FailureCollector collector) {
-    ScriptEngineManager manager = new ScriptEngineManager();
+    ScriptEngineManager manager = new ScriptEngineManager(getClass().getClassLoader());
     engine = manager.getEngineByName("JavaScript");
     try {
       engine.eval(ScriptConstants.HELPER_DEFINITION);


### PR DESCRIPTION
Fixed a bug that caused the transform to fail in java 11 execution environments like Dataproc 2.1.