### PR TITLE
 [PLUGIN-1742] Fix EmptyInputFormat failure outside of Core Plugins

### DIFF
--- a/format-common/src/main/java/io/cdap/plugin/format/input/AbstractEmptyInputFormat.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/input/AbstractEmptyInputFormat.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.format.input;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An InputFormat that returns no data.
+ * @param <K> the key class
+ * @param <V> the value class
+ */
+public abstract class AbstractEmptyInputFormat<K, V> extends InputFormat<K, V> {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public RecordReader<K, V> createRecordReader(InputSplit split, TaskAttemptContext context) {
+    return new RecordReader<K, V>() {
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) {
+        // do nothing
+      }
+
+      @Override
+      public boolean nextKeyValue() {
+        return false;
+      }
+
+      @Override
+      public K getCurrentKey() {
+        return null;
+      }
+
+      @Override
+      public V getCurrentValue() {
+        return null;
+      }
+
+      @Override
+      public float getProgress() {
+        return 1.0F;
+      }
+
+      @Override
+      public void close() {
+        // nothing to do
+      }
+    };
+  }
+}

--- a/format-common/src/main/java/io/cdap/plugin/format/input/EmptyInputFormat.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/input/EmptyInputFormat.java
@@ -15,60 +15,12 @@
  */
 
 package io.cdap.plugin.format.input;
-import org.apache.hadoop.mapreduce.InputFormat;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.RecordReader;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * An InputFormat that returns no data.
  * @param <K> the key class
  * @param <V> the value class
  */
-public class EmptyInputFormat<K, V> extends InputFormat<K, V> {
-
-  @Override
-  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public RecordReader<K, V> createRecordReader(InputSplit split, TaskAttemptContext context) {
-    return new RecordReader<K, V>() {
-      @Override
-      public void initialize(InputSplit split, TaskAttemptContext context) {
-        // do nothing
-      }
-
-      @Override
-      public boolean nextKeyValue() {
-        return false;
-      }
-
-      @Override
-      public K getCurrentKey() {
-        return null;
-      }
-
-      @Override
-      public V getCurrentValue() {
-        return null;
-      }
-
-      @Override
-      public float getProgress() {
-        return 1.0F;
-      }
-
-      @Override
-      public void close() {
-        // nothing to do
-      }
-    };
-  }
+public class EmptyInputFormat<K, V> extends AbstractEmptyInputFormat<K, V> {
+  // no-op
 }

--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java
@@ -81,6 +81,15 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     this.config = config;
   }
 
+  /**
+   * Override this to provide the class name of the Empty InputFormat
+   * to use when the input path does not exist.
+   * If not overridden, ClassNotFound exception will be thrown when the input path does not exist.
+   */
+  protected String getEmptyInputFormatClassName() {
+    return EmptyInputFormat.class.getName();
+  }
+
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     FailureCollector collector = pipelineConfigurer.getStageConfigurer().getFailureCollector();
@@ -203,7 +212,7 @@ public abstract class AbstractFileSource<T extends PluginConfig & FileSourceProp
     String inputFormatClass;
     if (fileStatus == null) {
       if (config.shouldAllowEmptyInput()) {
-        inputFormatClass = EmptyInputFormat.class.getName();
+        inputFormatClass = getEmptyInputFormatClassName();
       } else {
         throw new IOException(String.format("Input path %s does not exist", path));
       }


### PR DESCRIPTION
## Fix EmptyInputFormat failure outside of Core Plugins

### Description 
Plugins that extend from AbstractFileSource ([link](https://github.com/cdapio/hydrator-plugins/blob/923e603df5b464821ed25c9f88ab9ecee9f0255d/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java#L206)) which are outside of the Core Plugins module will not correctly export the EmptyInputFormat that is required when we need to handle the case where the source input is empty.


### Patch Description
- This PR adds a method `getEmptyInputFormatClassName` that class can override to provide their own implementation for an emptyInputFormat.

- Renamed `EmptyInputFormat` to `AbstractEmptyInputFormat` so this can be extended by other classes as their own `EmptyInputFormat` to reduce code duplication. 
 