### PR TITLE
[PLUGIN-1723] Fix JavaScript Decimal Values

### DIFF
--- a/core-plugins/docs/JavaScript-transform.md
+++ b/core-plugins/docs/JavaScript-transform.md
@@ -63,6 +63,9 @@ or else scale the ``count`` field by 1024.
 **schema:** The schema of output objects. If no schema is given, it is assumed that the output
 schema is the same as the input schema.
 
+> for `Decimal` type the value is rounded using the `RoundingMode.HALF_EVEN` method if it does not fit within 
+the schema. This ensures that the value adheres to the precision and scale defined in the schema.
+
 **lookup:** The configuration of the lookup tables to be used in your script.
 For example, if lookup table "purchases" is configured, then you will be able to perform
 operations with that lookup table in your script: ``context.getLookup('purchases').lookup('key')``

--- a/core-plugins/src/main/java/io/cdap/plugin/transform/JavaScriptTransform.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/transform/JavaScriptTransform.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -270,6 +272,21 @@ public class JavaScriptTransform extends Transform<StructuredRecord, StructuredR
 
   private Object decode(Object object, Schema schema) {
     Schema.Type type = schema.getType();
+
+    Schema.LogicalType logicalType = schema.getLogicalType();
+    if (logicalType != null) {
+      switch (logicalType) {
+        case DECIMAL:
+          BigDecimal bigDecimal = null;
+          if (object instanceof Number) {
+            double doubleValue = ((Number) object).doubleValue();
+            bigDecimal = BigDecimal.valueOf(doubleValue).setScale(schema.getScale(), RoundingMode.HALF_EVEN);
+          }
+          if (bigDecimal != null) {
+            return bigDecimal.unscaledValue().toByteArray();
+          }
+      }
+    }
 
     switch (type) {
       case NULL:


### PR DESCRIPTION
## Fix JavaScript Decimal Values

Jira : [PLUGIN-1723](https://cdap.atlassian.net/browse/PLUGIN-1723)

### Description

When the output of the JS transform plugin is of Decimal data type, all the result records become null.

![image](https://github.com/cloudsufi/hydrator-plugins/assets/122770897/6bd0244c-0ae5-4aad-b436-787a24455c0a)

### After Fix
![image](https://github.com/cdapio/hydrator-plugins/assets/122770897/412ae52f-d74e-4f08-a394-93769882206c)
![image](https://github.com/cdapio/hydrator-plugins/assets/122770897/a120dfcd-6e46-4b3f-a100-86fa53bde543)


### Code change

- Modified `JavaScriptTransform.java`
  -  Add case to handle decimal type. 

### Unit Tests

- Modified `JavaScriptTransformTest.java`
  - Added Test `testDecimalTransform`
  -  <img width="432" alt="image" src="https://github.com/cloudsufi/hydrator-plugins/assets/122770897/acd7c807-2427-4c2e-92f1-9a984e30c90b">




[PLUGIN-1723]: https://cdap.atlassian.net/browse/PLUGIN-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ