### PR TITLE
[🍒][PLUGIN-1795] Override Array Max (Apache Poi) for large files

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -186,12 +186,12 @@
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>5.2.4</version>
+      <version>5.2.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
-      <version>5.2.4</version>
+      <version>5.2.5</version>
     </dependency>
     <dependency>
       <groupId>com.github.pjfanning</groupId>

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/ExcelInputReader.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/ExcelInputReader.java
@@ -318,11 +318,16 @@ public class ExcelInputReader extends BatchSource<LongWritable, Object, Structur
       processFiles = GSON.toJson(getAllProcessedFiles(batchSourceContext), ARRAYLIST_PREPROCESSED_FILES);
     }
 
+    Map<String, String> arguments = new HashMap<>(batchSourceContext.getArguments().asMap());
+    int byteArrayMaxOverride = arguments.containsKey(ExcelInputFormat.EXCEL_BYTE_ARRAY_MAX_OVERRIDE) ?
+      Integer.parseInt(arguments.get(ExcelInputFormat.EXCEL_BYTE_ARRAY_MAX_OVERRIDE)) :
+      ExcelInputFormat.EXCEL_BYTE_ARRAY_MAX_OVERRIDE_DEFAULT;
+
     ExcelInputFormat.setConfigurations(job, excelInputreaderConfig.filePattern, excelInputreaderConfig.sheet,
                                        excelInputreaderConfig.reprocess, excelInputreaderConfig.sheetValue,
                                        excelInputreaderConfig.columnList, excelInputreaderConfig.skipFirstRow,
                                        excelInputreaderConfig.terminateIfEmptyRow, excelInputreaderConfig.rowsLimit,
-                                       excelInputreaderConfig.ifErrorRecord, processFiles);
+                                       excelInputreaderConfig.ifErrorRecord, processFiles, byteArrayMaxOverride);
 
     // Sets the input path(s).
     ExcelInputFormat.addInputPaths(job, excelInputreaderConfig.filePath);


### PR DESCRIPTION
[Cherrypick]
Commit : 57df4b4e8bd3bfbcd5ac02a145813b762aa89781
PR: #1873

---

## Override Array Max (Apache Poi) for large files

Jira : [PLUGIN-1795](https://cdap.atlassian.net/browse/PLUGIN-1795)

### Description

A soft limit in set in apache poi to avoid OOM errors cause issue when working with large files.
This PR overrides the array max.


[PLUGIN-1795]: https://cdap.atlassian.net/browse/PLUGIN-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ