### PR TITLE
[PLUGIN-1837] Error management for Analytics plugin i.e. GroupByAggregate, Deduplicate, Distinct and Joiner

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/AggregationUtils.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/AggregationUtils.java
@@ -17,6 +17,9 @@
 package io.cdap.plugin.batch.aggregator;
 
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 
 /**
  * Common functions for aggregation related functionalities.
@@ -69,8 +72,10 @@ public final class AggregationUtils {
                                         Schema.Type fieldType, String expectedType) {
     Schema.LogicalType logicalType = fieldSchema.isNullable() ? fieldSchema.getNonNullable().getLogicalType() :
       fieldSchema.getLogicalType();
-    throw new IllegalArgumentException(String.format(
+    String error = String.format(
       "Cannot compute %s on field %s because its type %s is not %s", functionName, fieldName,
-      logicalType == null ? fieldType : logicalType, expectedType));
+      logicalType == null ? fieldType : logicalType, expectedType);
+    throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN), error, error,
+                                                ErrorType.USER, false, null);
   }
 }

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/DistinctAggregator.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/DistinctAggregator.java
@@ -24,6 +24,9 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
@@ -36,7 +39,6 @@ import io.cdap.plugin.common.TransformLineageRecorderUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -170,8 +172,10 @@ public class DistinctAggregator extends RecordReducibleAggregator<StructuredReco
     for (String fieldName : fields) {
       Schema.Field field = inputSchema.getField(fieldName);
       if (field == null) {
-        throw new IllegalArgumentException(String.format("Field %s does not exist in input schema %s.",
-                                                         fieldName, inputSchema));
+        String error = String.format("Failed to fetch record schema due to field %s does not exist in" +
+          " input schema %s.", fieldName, inputSchema);
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+          error, error, ErrorType.USER, false, null);
       }
       outputFields.add(field);
     }

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/joiner/JoinerConfig.java
@@ -25,6 +25,9 @@ import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.join.JoinCondition;
@@ -264,7 +267,9 @@ public class JoinerConfig extends PluginConfig {
           .build();
     }
     // will never happen unless getConditionType() is changed without changing this
-    throw new IllegalStateException("Unsupported condition type " + conditionType);
+    String error = String.format("Unsupported condition type %s.", conditionType);
+    throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+      error, error, ErrorType.USER, false, null);
   }
 
   Set<JoinKey> getJoinKeys(FailureCollector failureCollector) {


### PR DESCRIPTION
Jira : [PLUGIN-1837](https://cdap.atlassian.net/browse/PLUGIN-1837)


## Test [ Distinct Aggregator ]

 - Test Case (Enter a field that does not exist in input schema)
  
<details>
  <summary>Raw Logs</summary>

  ```   
  Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'Distinct' encountered : io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. Field age_fake does not exist in input schema.
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedReduceAggregator.prepareRun(WrappedReduceAggregator.java:80)
	at io.cdap.cdap.etl.common.plugin.WrappedReduceAggregator.prepareRun(WrappedReduceAggregator.java:36)
	at io.cdap.cdap.etl.common.submit.SubmitterPlugin.lambda$prepareRun$2(SubmitterPlugin.java:74)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$execute$5(AbstractContext.java:558)
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.finishExecute(Transactions.java:234)
	... 21 common frames omitted
Caused by: io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. Field age_fake does not exist in input schema.
	at io.cdap.cdap.etl.validation.DefaultFailureCollector.getOrThrowException(DefaultFailureCollector.java:78)
	at io.cdap.cdap.etl.validation.LoggingFailureCollector.getOrThrowException(LoggingFailureCollector.java:50)
	at io.cdap.plugin.batch.aggregator.DistinctAggregator.prepareRun(DistinctAggregator.java:114)
	at io.cdap.cdap.etl.common.plugin.WrappedReduceAggregator.lambda$prepareRun$3(WrappedReduceAggregator.java:81)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 26 common frames omitted

  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
  [
  {
    "stageName": "Distinct",
    "errorCategory": "Plugin-'Validation'-'Distinct'",
    "errorReason": "Stage 'Distinct' encountered 1 validation failures.",
    "errorMessage": "Stage 'Distinct' encountered : io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. Field age_fake does not exist in input schema.",
    "errorType": "USER",
    "dependency": "false"
  }
]
  ```
</details>

![image](https://github.com/user-attachments/assets/c5afb500-d2c3-4851-9584-d02807f18485)
![image](https://github.com/user-attachments/assets/d4c01db8-55a8-4e34-8a3f-2a0639c0e3c4)



[PLUGIN-1837]: https://cdap.atlassian.net/browse/PLUGIN-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ