### PR TITLE
[PLUGIN-1855] Add DBErrorDetailsProvider

### DIFF
--- a/database-plugins/src/main/java/io/cdap/plugin/StructuredRecordUtils.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/StructuredRecordUtils.java
@@ -34,9 +34,8 @@ public class StructuredRecordUtils {
    * @param input {@link StructuredRecord}
    * @param fieldCase {@link FieldCase}
    * @return {@link StructuredRecord} which contains field names confirming to the {@link FieldCase} passed in
-   * @throws Exception if there is a conflict in the field names while converting the case
    */
-  public static StructuredRecord convertCase(StructuredRecord input, FieldCase fieldCase) throws Exception {
+  public static StructuredRecord convertCase(StructuredRecord input, FieldCase fieldCase) {
     if (fieldCase.equals(FieldCase.NONE)) {
       return input;
     }

--- a/database-plugins/src/main/java/io/cdap/plugin/db/batch/sink/DBSink.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/db/batch/sink/DBSink.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProviderSpec;
 import io.cdap.plugin.DBManager;
 import io.cdap.plugin.DBRecord;
 import io.cdap.plugin.FieldCase;
@@ -50,6 +51,7 @@ import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.common.db.DBUtils;
 import io.cdap.plugin.db.batch.TransactionIsolationLevel;
 import io.cdap.plugin.db.common.DBBaseConfig;
+import io.cdap.plugin.db.common.DBErrorDetailsProvider;
 import io.cdap.plugin.db.common.FQNGenerator;
 import io.cdap.plugin.db.connector.DBConnector;
 import io.cdap.plugin.db.connector.DBConnectorConfig;
@@ -133,7 +135,8 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
     } finally {
       DBUtils.cleanup(driverClass);
     }
-
+    // set error details provider
+    context.setErrorDetailsProvider(new ErrorDetailsProviderSpec(DBErrorDetailsProvider.class.getName()));
     context.addOutput(Output.of(dbSinkConfig.getReferenceName(),
                                 new DBOutputFormatProvider(dbSinkConfig, driverClass, context.getArguments())));
 
@@ -152,7 +155,7 @@ public class DBSink extends ReferenceBatchSink<StructuredRecord, DBRecord, NullW
   }
 
   @Override
-  public void transform(StructuredRecord input, Emitter<KeyValue<DBRecord, NullWritable>> emitter) throws Exception {
+  public void transform(StructuredRecord input, Emitter<KeyValue<DBRecord, NullWritable>> emitter) {
     // Create StructuredRecord that only has the columns in this.columns
     List<Schema.Field> outputFields = new ArrayList<>();
     for (String column : columns) {

--- a/database-plugins/src/main/java/io/cdap/plugin/db/common/DBErrorDetailsProvider.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/db/common/DBErrorDetailsProvider.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.db.common;
+
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCodeType;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import io.cdap.cdap.etl.api.exception.ErrorContext;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A custom ErrorDetailsProvider for Database plugins.
+ */
+public class DBErrorDetailsProvider implements ErrorDetailsProvider {
+
+  private static final Map<String, ErrorType> ERROR_CODE_TO_ERROR_TYPE;
+  private static final Map<String, ErrorCategory> ERROR_CODE_TO_ERROR_CATEGORY;
+  private static final String ERROR_MESSAGE_FORMAT = "Error occurred in the phase: '%s'. Error message: %s";
+
+  static {
+    // https://en.wikipedia.org/wiki/SQLSTATE
+    ERROR_CODE_TO_ERROR_TYPE = new HashMap<>();
+    ERROR_CODE_TO_ERROR_TYPE.put("01", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("02", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("07", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("08", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("09", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0A", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("0D", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0E", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0F", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0K", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0L", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0M", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0N", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0P", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0S", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0T", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0U", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0V", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0W", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0X", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0Y", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("0Z", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("10", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("20", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("21", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("22", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("23", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("24", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("25", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("26", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("27", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("28", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("2B", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("2C", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("2D", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("2E", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("2F", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("2H", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("30", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("33", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("34", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("35", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("36", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("38", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("39", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("3B", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("3C", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("3D", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("3F", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("40", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("42", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("44", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("45", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("46", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("HW", ErrorType.SYSTEM);
+
+    ERROR_CODE_TO_ERROR_CATEGORY = new HashMap<>();
+    ErrorCategory.ErrorCategoryEnum plugin = ErrorCategory.ErrorCategoryEnum.PLUGIN;
+    ERROR_CODE_TO_ERROR_CATEGORY.put("01", new ErrorCategory(plugin, "DB Warning"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("02", new ErrorCategory(plugin, "DB No Data"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("07", new ErrorCategory(plugin, "DB Dynamic SQL error"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("08", new ErrorCategory(plugin, "DB Connection Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("09", new ErrorCategory(plugin, "DB Triggered Action Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0A", new ErrorCategory(plugin, "DB Feature Not Supported"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0D", new ErrorCategory(plugin, "DB Invalid Target Type Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0E", new ErrorCategory(plugin, "DB Invalid Schema Name List Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0F", new ErrorCategory(plugin, "DB Locator Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0K", new ErrorCategory(plugin, "DB Resignal When Handler Not Active"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0L", new ErrorCategory(plugin, "DB Invalid Grantor"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0M", new ErrorCategory(plugin, "DB Invalid SQL-Invoked Procedure Reference"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0N", new ErrorCategory(plugin, "DB SQL/XML Mapping Error"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0P", new ErrorCategory(plugin, "DB Invalid Role Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0S", new ErrorCategory(plugin, "DB Invalid Transform Group Name Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0T",
+      new ErrorCategory(plugin, "DB Target Table Disagrees With Cursor Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0U", new ErrorCategory(plugin, "DB Attempt To Assign To Non-Updatable Column"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0V", new ErrorCategory(plugin, "DB Attempt To Assign To Ordering Column"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0W", new ErrorCategory(plugin, "DB Prohibited Statement Encountered"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0X", new ErrorCategory(plugin, "DB Invalid Foreign Server Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0Y", new ErrorCategory(plugin, "DB Pass-Through Specific Condition"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0Z", new ErrorCategory(plugin, "DB Diagnostics Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("10", new ErrorCategory(plugin, "DB XQuery Error"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("20", new ErrorCategory(plugin, "DB Case Not Found For Case Statement"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("21", new ErrorCategory(plugin, "DB Cardinality Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("22", new ErrorCategory(plugin, "DB Data Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("23", new ErrorCategory(plugin, "DB Integrity Constraint Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("24", new ErrorCategory(plugin, "DB Invalid Cursor State"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("25", new ErrorCategory(plugin, "DB Invalid Transaction State"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("26", new ErrorCategory(plugin, "DB Invalid SQL Statement Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("27", new ErrorCategory(plugin, "DB Triggered Data Change Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("28", new ErrorCategory(plugin, "DB Invalid Authorization Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("2B", new ErrorCategory(plugin, "DB Dependent Privilege Descriptors Still Exist"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("2C", new ErrorCategory(plugin, "DB Invalid Character Set Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("2D", new ErrorCategory(plugin, "DB Invalid Transaction Termination"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("2E", new ErrorCategory(plugin, "DB Invalid Connection Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("2F", new ErrorCategory(plugin, "DB SQL Routine Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("2H", new ErrorCategory(plugin, "DB Invalid Collation Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("30", new ErrorCategory(plugin, "DB Invalid SQL Statement Identifier"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("33", new ErrorCategory(plugin, "DB Invalid SQL Descriptor Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("34", new ErrorCategory(plugin, "DB Invalid Cursor Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("35", new ErrorCategory(plugin, "DB Invalid Condition Number"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("36", new ErrorCategory(plugin, "DB Cursor Sensitivity Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("38", new ErrorCategory(plugin, "DB External Routine Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("39", new ErrorCategory(plugin, "DB External Routine Invocation Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("3B", new ErrorCategory(plugin, "DB Savepoint Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("3C", new ErrorCategory(plugin, "DB Ambiguous Cursor Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("3D", new ErrorCategory(plugin, "DB Invalid Catalog Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("3F", new ErrorCategory(plugin, "DB Invalid Schema Name"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("40", new ErrorCategory(plugin, "DB Transaction Rollback"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("42", new ErrorCategory(plugin, "DB Syntax Error or Access Rule Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("44", new ErrorCategory(plugin, "DB With Check Option Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("45", new ErrorCategory(plugin, "DB Unhandled User-Defined Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("46", new ErrorCategory(plugin, "DB JAVA DDL"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("HW", new ErrorCategory(plugin, "DB Datalink Exception"));
+  }
+
+  public ProgramFailureException getExceptionDetails(Exception e, ErrorContext errorContext) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    for (Throwable t : causalChain) {
+      if (t instanceof ProgramFailureException) {
+        // if causal chain already has program failure exception, return null to avoid double wrap.
+        return null;
+      }
+      if (t instanceof SQLException) {
+        return getProgramFailureException((SQLException) t, errorContext);
+      }
+      if (t instanceof IllegalArgumentException) {
+        return getProgramFailureException((IllegalArgumentException) t, errorContext, ErrorType.USER);
+      }
+      if (t instanceof IllegalStateException || t instanceof InstantiationException) {
+        return getProgramFailureException((Exception) t, errorContext, ErrorType.SYSTEM);
+      }
+    }
+    return null;
+  }
+
+  private ProgramFailureException getProgramFailureException(SQLException e, ErrorContext errorContext) {
+    String errorMessage = e.getMessage();
+    String sqlState = e.getSQLState();
+    int errorCode = e.getErrorCode();
+    String errorMessageWithDetails =
+      String.format("Error occurred in the phase: '%s' with sqlState: '%s', errorCode: '%s', errorMessage: %s",
+        errorContext.getPhase(), sqlState, errorCode, errorMessage);
+    String externalDocumentationLink = getExternalDocumentationLink();
+    if (!Strings.isNullOrEmpty(externalDocumentationLink)) {
+      if (!errorMessage.endsWith(".")) {
+        errorMessage = errorMessage + ".";
+      }
+      errorMessage = String.format("%s For more details, see %s", errorMessage, externalDocumentationLink);
+    }
+    return ErrorUtils.getProgramFailureException(
+      Strings.isNullOrEmpty(sqlState) ? new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN) :
+        getErrorCategoryFromSqlState(sqlState), errorMessage, errorMessageWithDetails,
+      getErrorTypeFromErrorCodeAndSqlState(errorCode, sqlState), true, ErrorCodeType.SQLSTATE, sqlState,
+      externalDocumentationLink, e);
+  }
+
+  private ProgramFailureException getProgramFailureException(Exception e, ErrorContext errorContext,
+                                                             ErrorType errorType) {
+    String errorMessage = e.getMessage();
+    return ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+      errorMessage, String.format(ERROR_MESSAGE_FORMAT, errorContext.getPhase(), errorMessage), errorType, false, e);
+  }
+
+  /**
+   * Get the external documentation link for the client errors if available.
+   *
+   * @return The external documentation link as a {@link String}.
+   */
+  protected String getExternalDocumentationLink() {
+    return "https://en.wikipedia.org/wiki/SQLSTATE";
+  }
+
+  /**
+   * Get the {@link ErrorType} for the given error code and SQL state.
+   * Override this method to provide custom error types based on the error code and SQL state.
+   *
+   * @param errorCode The error code.
+   * @param sqlState  The SQL state.
+   * @return The {@link ErrorType} for the given error code and SQL state.
+   */
+  protected ErrorType getErrorTypeFromErrorCodeAndSqlState(int errorCode, String sqlState) {
+    if (!Strings.isNullOrEmpty(sqlState) && sqlState.length() >= 2 &&
+      ERROR_CODE_TO_ERROR_TYPE.containsKey(sqlState.substring(0, 2))) {
+      return ERROR_CODE_TO_ERROR_TYPE.get(sqlState.substring(0, 2));
+    }
+    return ErrorType.UNKNOWN;
+  }
+
+  /**
+   * Get the {@link ErrorCategory} for the given SQL state.
+   * Implements generic error categories based on the SQL state.
+   * See <a href="https://en.wikipedia.org/wiki/SQLSTATE">SQLSTATE</a> for more information.
+   * Override this method to provide custom error categories based on the SQL state.
+   *
+   * @param sqlState The SQL state.
+   * @return The {@link ErrorCategory} for the given SQL state.
+   */
+  protected ErrorCategory getErrorCategoryFromSqlState(String sqlState) {
+    if (!Strings.isNullOrEmpty(sqlState) && sqlState.length() >= 2 &&
+      ERROR_CODE_TO_ERROR_CATEGORY.containsKey(sqlState.substring(0, 2))) {
+      return ERROR_CODE_TO_ERROR_CATEGORY.get(sqlState.substring(0, 2));
+    }
+    return new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN);
+  }
+}

--- a/hydrator-common/src/main/java/io/cdap/plugin/common/db/DBUtils.java
+++ b/hydrator-common/src/main/java/io/cdap/plugin/common/db/DBUtils.java
@@ -20,6 +20,9 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.FailureCollector;
@@ -281,7 +284,7 @@ public final class DBUtils {
    * @return the converted CDAP schema
    */
   public static Schema getSchema(String typeName, int sqlType, int precision, int scale, String columnName,
-                                 boolean isSigned, boolean handleAsDecimal) throws SQLException {
+                                 boolean isSigned, boolean handleAsDecimal) {
     // Type.STRING covers sql types - VARCHAR,CHAR,CLOB,LONGNVARCHAR,LONGVARCHAR,NCHAR,NCLOB,NVARCHAR
     Schema.Type type = Schema.Type.STRING;
     switch (sqlType) {
@@ -361,8 +364,9 @@ public final class DBUtils {
       case Types.REF:
       case Types.SQLXML:
       case Types.STRUCT:
-        throw new SQLException(new UnsupportedTypeException(
-          String.format("Column %s has unsupported SQL type of %s.", columnName, sqlType)));
+        String errorMessage = String.format("Column %s has unsupported SQL type of %s.", columnName, typeName);
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+          errorMessage, errorMessage, ErrorType.SYSTEM, true, null);
     }
 
     return Schema.of(type);
@@ -522,6 +526,8 @@ public final class DBUtils {
   }
 
   private DBUtils() {
-    throw new AssertionError("Should not instantiate static utility class.");
+    String errorMessage = "Should not instantiate static utility class.";
+    throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN), errorMessage,
+      errorMessage, ErrorType.SYSTEM, false, null);
   }
 }


### PR DESCRIPTION
## ErrorDetailsProvider - Generic Database [Source|Sink] plugin

Jira : [PLUGIN-1855](https://cdap.atlassian.net/browse/PLUGIN-1855)

### Description

Implement Program Failure Exception Handling in Generic Database Source/Sink plugin to catch known errors

### Code change

- Added `DBErrorDetailsProvider.java`
- Modified `StructuredRecordUtils.java`
- Modified `DBSink.java`
- Modified `DBSource.java`
- Modified `DBUtils.java`

### Tests [ MySql ]

 - Test Case (PK Violation)
  
<details>
  <summary>Raw Logs</summary>

  ```   

2025-01-27 13:46:49,670 - ERROR [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):o.a.s.u.Utils@98] - Aborting task
io.cdap.cdap.api.exception.WrappedStageException: Stage 'Database2' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '1062', errorMessage: Duplicate entry '5' for key 'PRIMARY'
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:67)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:145)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1538)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '1062', errorMessage: Duplicate entry '5' for key 'PRIMARY'
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:198)
	at io.cdap.plugin.db.common.DBErrorDetailsProvider.getProgramFailureException(DBErrorDetailsProvider.java:203)
	at io.cdap.plugin.db.common.DBErrorDetailsProvider.getExceptionDetails(DBErrorDetailsProvider.java:169)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:75)
	... 14 common frames omitted
Caused by: java.sql.BatchUpdateException: Duplicate entry '5' for key 'PRIMARY'
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.cj.util.Util.handleNewInstance(Util.java:192)
	at com.mysql.cj.util.Util.getInstance(Util.java:167)
	at com.mysql.cj.util.Util.getInstance(Util.java:174)
	at com.mysql.cj.jdbc.exceptions.SQLError.createBatchUpdateException(SQLError.java:224)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchSerially(ClientPreparedStatement.java:853)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchInternal(ClientPreparedStatement.java:435)
	at com.mysql.cj.jdbc.StatementImpl.executeBatch(StatementImpl.java:794)
	at io.cdap.plugin.db.batch.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:93)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	... 13 common frames omitted
Caused by: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '5' for key 'PRIMARY'
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:117)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1092)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchSerially(ClientPreparedStatement.java:832)
	... 18 common frames omitted
2025-01-27 13:46:49,674 - WARN  [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):i.c.p.d.b.s.ETLDBOutputFormat@101] - java.sql.SQLNonTransientConnectionException: No operations allowed after connection closed.
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:110)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:73)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:73)
	at com.mysql.cj.jdbc.ConnectionImpl.rollback(ConnectionImpl.java:1862)
	at io.cdap.plugin.db.batch.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:99)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$2(SparkHadoopWriter.scala:150)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1549)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: com.mysql.cj.exceptions.ConnectionIsClosedException: No operations allowed after connection closed.
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:105)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:151)
	at com.mysql.cj.NativeSession.checkClosed(NativeSession.java:1171)
	at com.mysql.cj.jdbc.ConnectionImpl.checkClosed(ConnectionImpl.java:573)
	at com.mysql.cj.jdbc.ConnectionImpl.rollback(ConnectionImpl.java:1816)
	... 16 more

  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
[
  {
    "stageName": "Database2",
    "errorCategory": "Plugin-'DB Integrity Constraint Violation'-'Database2'",
    "errorReason": "Duplicate entry '5' for key 'PRIMARY'. For more details, see https://en.wikipedia.org/wiki/SQLSTATE",
    "errorMessage": "Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '1062', errorMessage: Duplicate entry '5' for key 'PRIMARY'",
    "errorType": "USER",
    "dependency": "true",
    "errorCodeType": "SQLSTATE",
    "errorCode": "23000",
    "supportedDocumentationUrl": "https://en.wikipedia.org/wiki/SQLSTATE"
  }
]
  ```
</details>

![image](https://github.com/user-attachments/assets/d8f9a462-45a3-40b9-9e3d-5de60f1e6a7a)





[PLUGIN-1855]: https://cdap.atlassian.net/browse/PLUGIN-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ