### PR TITLE
fix parent class method definition

### DIFF
--- a/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSink.java
+++ b/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSink.java
@@ -142,7 +142,8 @@ public abstract class AbstractFileSink<T extends PluginConfig & FileSinkProperti
     return null;
   }
 
-  protected ValidatingOutputFormat getOutputFormatForRun(BatchSinkContext context) {
+  protected ValidatingOutputFormat getOutputFormatForRun(BatchSinkContext context)
+      throws InstantiationException {
     FailureCollector collector = context.getFailureCollector();
     String fileFormat = config.getFormatName();
     try {


### PR DESCRIPTION
```
2025-01-27T17:33:16.0679424Z [[1;31mERROR[m] [1;31m/runner/_work/cdap-build/cdap-build/cdap-build/app-artifacts/hydrator-plugins/google-cloud/src/main/java/io/cdap/plugin/gcp/gcs/sink/GCSBatchSink.java:[110,33] getOutputFormatForRun(io.cdap.cdap.etl.api.batch.BatchSinkContext) in io.cdap.plugin.gcp.gcs.sink.GCSBatchSink cannot override getOutputFormatForRun(io.cdap.cdap.etl.api.batch.BatchSinkContext) in io.cdap.plugin.format.plugin.AbstractFileSink[m
2025-01-27T17:33:16.0686092Z [[1;31mERROR[m] [1;31m  overridden method does not throw java.lang.InstantiationException[m
2025-01-27T17:33:16.0687454Z [[1;31mERROR[m] [1;31m[m
2025-01-27T17:33:16.0688261Z [[1;31mERROR[m] -> [1m[Help 1][m
```