### PR TITLE
[🍒][PLUGIN-1862] Error management for row denormalizer aggregator

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/RowDenormalizerAggregator.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/aggregator/RowDenormalizerAggregator.java
@@ -21,6 +21,9 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
@@ -92,18 +95,24 @@ public class RowDenormalizerAggregator extends BatchAggregator<String, Structure
   public void groupBy(StructuredRecord record, Emitter<String> emitter) throws Exception {
     if (record.get(keyField) == null) {
       if (record.getSchema().getField(keyField) == null) {
-        throw new IllegalArgumentException(
-          String.format("Keyfield '%s' does not exist in input schema %s", keyField, record.getSchema()));
+        String error = String.format("Keyfield '%s' does not exist in input schema %s",
+                keyField, record.getSchema());
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                error, error, ErrorType.USER, false, null);
       }
       return;
     }
     if (record.get(nameField) == null && record.getSchema().getField(nameField) == null) {
-      throw new IllegalArgumentException(
-        String.format("Namefield '%s' does not exist in input schema %s", nameField, record.getSchema()));
+      String error = String.format("Namefield '%s' does not exist in input schema %s",
+              nameField, record.getSchema());
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+              error, error, ErrorType.USER, false, null);
     }
     if (record.get(valueField) == null && record.getSchema().getField(valueField) == null) {
-      throw new IllegalArgumentException(
-        String.format("Valuefield '%s' does not exist in input schema %s", valueField, record.getSchema()));
+      String error = String.format("Valuefield '%s' does not exist in input schema %s",
+              valueField, record.getSchema());
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+              error, error, ErrorType.USER, false, null);
     }
     emitter.emit((String) record.get(keyField));
   }


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - a10944562b1fb1bbc2942390af6068bbcd3d9bbb

### PR:
 - #1936 [ Reviewer @itsankit-google ]
 
---

Description
Error Management for row denormaliser aggregator exceptions
https://cdap.atlassian.net/browse/PLUGIN-1862

Code change
Modified RowDenormalizerAggregator.java

Tests
Test Case - tested with Incorrect key, name and value field

### 1. Valid parameters
<img width="1440" alt="Screenshot 2025-01-23 at 5 47 06 PM" src="https://github.com/user-attachments/assets/92f95ed6-3176-49eb-a6e9-b02e1f4dd2f0" />

### 2. Incorrect key field
POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify

```json
[
    {
        "stageName": "RowDenormalizer",
        "errorCategory": "Plugin-\u0027RowDenormalizer\u0027",
        "errorReason": "Keyfield \u0027idrf\u0027 does not exist in input schema {\"type\":\"record\",\"name\":\"text\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"attribute\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]}",
        "errorMessage": "Keyfield \u0027idrf\u0027 does not exist in input schema {\"type\":\"record\",\"name\":\"text\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"attribute\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]}",
        "errorType": "USER",
        "dependency": "false"
    }
]
```
<img width="1413" alt="Screenshot 2025-01-27 at 3 51 57 PM" src="https://github.com/user-attachments/assets/f4b161ab-6a75-415d-8803-634285359808" />

<img width="1387" alt="Screenshot 2025-01-24 at 4 36 48 PM" src="https://github.com/user-attachments/assets/7bb8b585-2197-4e33-9d5a-cd9d66f118ce" />

### 3. Incorrect attribute field
POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify
```json
[
    {
        "stageName": "RowDenormalizer",
        "errorCategory": "Plugin-\u0027RowDenormalizer\u0027",
        "errorReason": "Namefield \u0027cdcdvdvdv\u0027 does not exist in input schema {\"type\":\"record\",\"name\":\"text\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"attribute\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]}",
        "errorMessage": "Namefield \u0027cdcdvdvdv\u0027 does not exist in input schema {\"type\":\"record\",\"name\":\"text\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"attribute\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]}",
        "errorType": "USER",
        "dependency": "false"
    }
]
```
<img width="1426" alt="Screenshot 2025-01-27 at 3 55 21 PM" src="https://github.com/user-attachments/assets/fc81b8cb-afba-4c6b-8a12-eb5d4f639434" />

<img width="1412" alt="Screenshot 2025-01-24 at 4 39 39 PM" src="https://github.com/user-attachments/assets/a316eb13-7d6a-4ebb-b237-1d5b9c86245f" />

### 4. Incorrect value field
POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify
```json
[
    {
        "stageName": "RowDenormalizer",
        "errorCategory": "Plugin-\u0027RowDenormalizer\u0027",
        "errorReason": "Valuefield \u0027csdcdddv\u0027 does not exist in input schema {\"type\":\"record\",\"name\":\"text\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"attribute\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]}",
        "errorMessage": "Valuefield \u0027csdcdddv\u0027 does not exist in input schema {\"type\":\"record\",\"name\":\"text\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"attribute\",\"type\":\"string\"},{\"name\":\"value\",\"type\":\"string\"}]}",
        "errorType": "USER",
        "dependency": "false"
    }
]
```
<img width="1424" alt="Screenshot 2025-01-27 at 3 57 42 PM" src="https://github.com/user-attachments/assets/dba79268-570f-4554-85ac-b6e799ccaa66" />

<img width="1418" alt="Screenshot 2025-01-24 at 4 40 35 PM" src="https://github.com/user-attachments/assets/a3597b53-fc51-4ce3-a4a3-06491e7a0790" />

