### PR TITLE
[PLUGIN-1875] Error management changes for FileMoveAction

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileActionUtils.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileActionUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.batch.action;
+
+import io.cdap.plugin.batch.source.FileErrorDetailsProvider;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class for common file action operations.
+ */
+public class FileActionUtils {
+
+  static FileStatus[] getFileStatuses(FileSystem fileSystem, Path path, @Nullable PathFilter filter) {
+    try {
+      if (filter == null) {
+        return fileSystem.listStatus(path);
+      }
+      return fileSystem.listStatus(path, filter);
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to list files in %s.", path);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
+  }
+}

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileDeleteAction.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileDeleteAction.java
@@ -88,9 +88,9 @@ public class FileDeleteAction extends Action {
           return pattern.matcher(path.getName()).matches();
         }
       };
-      listFiles = getFileStatuses(fileSystem, path, filter);
+      listFiles = FileActionUtils.getFileStatuses(fileSystem, path, filter);
     } else {
-      listFiles = getFileStatuses(fileSystem, path, null);
+      listFiles = FileActionUtils.getFileStatuses(fileSystem, path, null);
     }
 
     for (FileStatus file : listFiles) {
@@ -109,18 +109,6 @@ public class FileDeleteAction extends Action {
       removePath(fileSystem, path);
     }
 
-  }
-
-  private static FileStatus[] getFileStatuses(FileSystem fileSystem, Path path, @Nullable PathFilter filter) {
-    try {
-      if (filter == null) {
-        return fileSystem.listStatus(path);
-      }
-      return fileSystem.listStatus(path, filter);
-    } catch (IOException e) {
-      String errorReason = String.format("Failed to list files in %s.", path);
-      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
-    }
   }
 
   public void removePath(FileSystem fileSystem, Path currPath) throws Exception {

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileMoveAction.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileMoveAction.java
@@ -21,12 +21,16 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.StageConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.batch.source.FileErrorDetailsProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -69,21 +73,42 @@ public class FileMoveAction extends Action {
 
     Path dest = new Path(config.destPath);
 
-    FileSystem fileSystem = source.getFileSystem(new Configuration());
-    fileSystem.mkdirs(dest.getParent());
+    FileSystem fileSystem;
+    try {
+      fileSystem = source.getFileSystem(new Configuration());
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to get file system for source path %s", source);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
+    try {
+      fileSystem.mkdirs(dest.getParent());
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to create parent directory for dest path %s", dest);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
+    FileStatus fileStatus;
+    try {
+      fileStatus = fileSystem.getFileStatus(source);
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to get file status for source path %s", source);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
 
-    if (fileSystem.getFileStatus(source).isFile()) { //moving single file
+    if (fileStatus != null && fileStatus.isFile()) { //moving single file
 
       try {
         if (!fileSystem.rename(source, dest)) {
           if (!config.continueOnError) {
-            throw new IOException(String.format("Failed to rename file %s to %s", source, dest));
+            String error = String.format("Failed to move file %s to %s", source, dest);
+            throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                error, error, ErrorType.USER, false, null);
           }
           LOG.error("Failed to move file {} to {}", source, dest);
         }
       } catch (IOException e) {
         if (!config.continueOnError) {
-          throw e;
+          String errorReason = String.format("Failed to move file %s to %s", source, dest);
+          throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
         }
         LOG.error("Failed to move file {} to {}", source, dest, e);
       }
@@ -102,24 +127,31 @@ public class FileMoveAction extends Action {
         }
       };
 
-      listFiles = fileSystem.listStatus(source, filter);
+      listFiles = FileActionUtils.getFileStatuses(fileSystem, source, filter);
     } else {
-      listFiles = fileSystem.listStatus(source);
+      listFiles = FileActionUtils.getFileStatuses(fileSystem, source, null);
     }
 
     if (listFiles.length == 0) {
       if (config.fileRegex != null) {
-        LOG.warn("Not moving any files of type {} from source {}", config.fileRegex, source.toString());
+        LOG.warn("Not moving any files of type {} from source {}", config.fileRegex, source);
       } else {
-        LOG.warn("Not moving any files from source {}", source.toString());
+        LOG.warn("Not moving any files from source {}", source);
       }
     }
 
-    if (fileSystem.isFile(dest)) {
-      throw new IllegalArgumentException(String.format("destPath %s needs to be a directory since sourcePath is a " +
-                                                         "directory", config.destPath));
+    try {
+      if (fileSystem.isFile(dest)) {
+        String error = String.format("destPath %s needs to be a directory since sourcePath is a directory",
+            config.destPath);
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN), error,
+            error, ErrorType.USER, false, null);
+      }
+      fileSystem.mkdirs(dest); // create destination directory if necessary
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to create destination directory %s", dest);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
     }
-    fileSystem.mkdirs(dest); //create destination directory if necessary
 
     for (FileStatus file : listFiles) {
       source = file.getPath();
@@ -127,13 +159,16 @@ public class FileMoveAction extends Action {
       try {
         if (!fileSystem.rename(source, dest)) {
           if (!config.continueOnError) {
-            throw new IOException(String.format("Failed to rename file %s to %s", source, dest));
+            String error = String.format("Failed to rename  file %s to %s", source, dest);
+            throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                error, error, ErrorType.USER, false, null);
           }
           LOG.error("Failed to move file {} to {}", source, dest);
         }
       } catch (IOException e) {
         if (!config.continueOnError) {
-          throw e;
+          String errorReason = String.format("Failed to rename  file %s to %s", source, dest);
+          throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
         }
         LOG.error("Failed to move file {} to {}", source, dest, e);
       }


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1875

## Sanity Happy Path
![image](https://github.com/user-attachments/assets/426b59e4-dec6-40e0-813e-5379f179e9f7)


## Failed (source does not exist)

![image](https://github.com/user-attachments/assets/3a4825d2-4bea-4668-9f38-9657a0493bd6)


```json
[
  {
    "stageName": "FileMove",
    "errorCategory": "Plugin-'FileMove'",
    "errorReason": "Failed to get file status for source path /Volumes/psaini/tmp/move_test/sample.txt",
    "errorMessage": "java.io.FileNotFoundException: File /Volumes/psaini/tmp/move_test/sample.txt does not exist",
    "errorType": "USER",
    "dependency": "true"
  }
]
```

```log
2025-04-24 13:19:46,395 - ERROR [WorkflowDriver:i.c.c.d.SmartWorkflow@542] - Pipeline 'file_move_test' failed.
2025-04-24 13:19:46,408 - ERROR [WorkflowDriver:i.c.c.i.a.r.w.WorkflowProgramController@90] - Workflow service 'workflow.default.file_move_test.DataPipelineWorkflow.ae5c40f7-20e0-11f0-8ea3-acde48001122' failed.
io.cdap.cdap.api.exception.WrappedStageException: Stage 'FileMove' encountered : io.cdap.cdap.api.exception.ProgramFailureException: java.io.FileNotFoundException: File /Volumes/psaini/tmp/move_test/sample.txt does not exist
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:48)
	at io.cdap.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:91)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:90)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:449)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:489)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:669)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.run(WorkflowDriver.java:653)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: java.io.FileNotFoundException: File /Volumes/psaini/tmp/move_test/sample.txt does not exist
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.batch.source.FileErrorDetailsProvider.getProgramFailureException(FileErrorDetailsProvider.java:136)
	at io.cdap.plugin.batch.source.FileErrorDetailsProvider.getFileBasedExceptionDetails(FileErrorDetailsProvider.java:102)
	at io.cdap.plugin.batch.source.FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(FileErrorDetailsProvider.java:117)
	at io.cdap.plugin.batch.action.FileMoveAction.run(FileMoveAction.java:94)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.lambda$run$1(WrappedAction.java:49)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 10 common frames omitted
Caused by: java.io.FileNotFoundException: File /Volumes/psaini/tmp/move_test/sample.txt does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:915)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1236)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:905)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
	at io.cdap.plugin.batch.action.FileMoveAction.run(FileMoveAction.java:91)
	... 13 common frames omitted
```

