### PR TITLE
[PLUGIN-1876] Error management changes for FileDeleteAction

### DIFF
--- a/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileDeleteAction.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/action/FileDeleteAction.java
@@ -21,12 +21,16 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.StageConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.batch.source.FileErrorDetailsProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -66,7 +70,13 @@ public class FileDeleteAction extends Action {
   public void run(ActionContext context) throws Exception {
     Path path = new Path(config.path);
 
-    FileSystem fileSystem = path.getFileSystem(new Configuration());
+    FileSystem fileSystem;
+    try {
+      fileSystem = path.getFileSystem(new Configuration());
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to get FileSystem for path %s.", path);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
 
     FileStatus[] listFiles;
     if (config.fileRegex != null) {
@@ -78,9 +88,9 @@ public class FileDeleteAction extends Action {
           return pattern.matcher(path.getName()).matches();
         }
       };
-      listFiles = fileSystem.listStatus(path, filter);
+      listFiles = getFileStatuses(fileSystem, path, filter);
     } else {
-      listFiles = fileSystem.listStatus(path);
+      listFiles = getFileStatuses(fileSystem, path, null);
     }
 
     for (FileStatus file : listFiles) {
@@ -88,24 +98,45 @@ public class FileDeleteAction extends Action {
       removePath(fileSystem, currPath);
     }
 
-
-    if (fileSystem.isDirectory(path) && config.fileRegex == null) {
+    boolean isDirectory = false;
+    try {
+      isDirectory = fileSystem.isDirectory(path);
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to check if %s is a directory.", path);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
+    if (isDirectory && config.fileRegex == null) {
       removePath(fileSystem, path);
     }
 
+  }
+
+  private static FileStatus[] getFileStatuses(FileSystem fileSystem, Path path, @Nullable PathFilter filter) {
+    try {
+      if (filter == null) {
+        return fileSystem.listStatus(path);
+      }
+      return fileSystem.listStatus(path, filter);
+    } catch (IOException e) {
+      String errorReason = String.format("Failed to list files in %s.", path);
+      throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
+    }
   }
 
   public void removePath(FileSystem fileSystem, Path currPath) throws Exception {
     try {
       if (!fileSystem.delete(currPath, true)) {
         if (!config.continueOnError) {
-          throw new IOException(String.format("Removal of %s was unsuccessful.", currPath.toString()));
+          String error = String.format("Removal of %s was unsuccessful.", currPath.toString());
+          throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+              error, error, ErrorType.USER, false, null);
         }
         LOG.warn("Removal of {} was unsuccessful.", currPath.toString());
       }
     } catch (IOException e) {
       if (!config.continueOnError) {
-        throw e;
+        String errorReason = String.format("Removal of %s was unsuccessful.", currPath.toString());
+        throw FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(e, errorReason);
       }
       LOG.warn("Removal of {} was unsuccessful.", currPath.toString());
     }


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1876

## Sanity Happy Path
![image](https://github.com/user-attachments/assets/dff13d0c-8bcf-4051-ae39-177b5d540cfc)


## Failed Case 1 (source does not exist)

![image](https://github.com/user-attachments/assets/6234d803-357e-48d1-a624-87671732ea22)


```json
[
  {
    "stageName": "FileDelete",
    "errorCategory": "Plugin-'FileDelete'",
    "errorReason": "Failed to list files in /Users/pusaini/wsf/cdap/env/del_test/i_am_root.txt.",
    "errorMessage": "java.io.FileNotFoundException: File /Users/pusaini/wsf/cdap/env/del_test/i_am_root.txt does not exist",
    "errorType": "USER",
    "dependency": "true"
  }
]
```

```log
2025-04-24 11:19:20,569 - ERROR [WorkflowDriver:i.c.c.d.SmartWorkflow@542] - Pipeline 'file_delete_test' failed.
2025-04-24 11:19:20,582 - ERROR [WorkflowDriver:i.c.c.i.a.r.w.WorkflowProgramController@90] - Workflow service 'workflow.default.file_delete_test.DataPipelineWorkflow.db104126-20cf-11f0-b356-acde48001122' failed.
io.cdap.cdap.api.exception.WrappedStageException: Stage 'FileDelete' encountered : io.cdap.cdap.api.exception.ProgramFailureException: java.io.FileNotFoundException: File /Users/pusaini/wsf/cdap/env/del_test/i_am_root.txt does not exist
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:48)
	at io.cdap.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:91)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:90)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:449)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:489)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:669)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.run(WorkflowDriver.java:653)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: java.io.FileNotFoundException: File /Users/pusaini/wsf/cdap/env/del_test/i_am_root.txt does not exist
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.batch.source.FileErrorDetailsProvider.getProgramFailureException(FileErrorDetailsProvider.java:136)
	at io.cdap.plugin.batch.source.FileErrorDetailsProvider.getFileBasedExceptionDetails(FileErrorDetailsProvider.java:102)
	at io.cdap.plugin.batch.source.FileErrorDetailsProvider.getFileBasedProgramFailureExceptionDetailsFromChain(FileErrorDetailsProvider.java:117)
	at io.cdap.plugin.batch.action.FileDeleteAction.getFileStatuses(FileDeleteAction.java:122)
	at io.cdap.plugin.batch.action.FileDeleteAction.run(FileDeleteAction.java:93)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.lambda$run$1(WrappedAction.java:49)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 10 common frames omitted
Caused by: java.io.FileNotFoundException: File /Users/pusaini/wsf/cdap/env/del_test/i_am_root.txt does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.listStatus(RawLocalFileSystem.java:733)
	at org.apache.hadoop.fs.FileSystem.listStatus(FileSystem.java:2078)
	at org.apache.hadoop.fs.FileSystem.listStatus(FileSystem.java:2122)
	at org.apache.hadoop.fs.ChecksumFileSystem.listStatus(ChecksumFileSystem.java:970)
	at io.cdap.plugin.batch.action.FileDeleteAction.getFileStatuses(FileDeleteAction.java:117)
	... 14 common frames omitted
```

