### PR TITLE
[🍒] [PLUGIN-1886] Error Management Generic-DBAction

### DIFF
--- a/database-plugins/src/main/java/io/cdap/plugin/db/batch/action/DBAction.java
+++ b/database-plugins/src/main/java/io/cdap/plugin/db/batch/action/DBAction.java
@@ -25,7 +25,9 @@ import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
 import io.cdap.plugin.DBManager;
 
+import io.cdap.plugin.common.db.DBErrorDetailsProvider;
 import java.sql.Driver;
+import java.sql.SQLException;
 
 /**
  * Action that runs a db command
@@ -52,6 +54,17 @@ public class DBAction extends Action {
   public void run(ActionContext context) throws Exception {
     Class<? extends Driver> driverClass = context.loadPluginClass(JDBC_PLUGIN_ID);
     DBRun executeQuery = new DBRun(config, driverClass);
-    executeQuery.run();
+    try {
+      executeQuery.run();
+    } catch (Exception e) {
+      if (e instanceof SQLException) {
+        DBErrorDetailsProvider dbe = new DBErrorDetailsProvider();
+        throw dbe.getProgramFailureException((SQLException) e, null);
+      }
+      FailureCollector collector = context.getFailureCollector();
+      collector.addFailure("Failed to execute query with message: " + e.getMessage(), null)
+          .withStacktrace(e.getStackTrace());
+      collector.getOrThrowException();
+    }
   }
 }


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 4914e8ff588c469fb2b42cfb8efb4cd79333e149

### PR:
 - #1960 [ Reviewer @itsankit-google ]
 
 ---
 
 https://cdap.atlassian.net/browse/PLUGIN-1886

Similar changes were done for abstract db action : https://github.com/data-integrations/database-plugins/pull/568

## Tests ( Tested with MariaDB )

- Test Case [sanity] ( Insert one record )
![image](https://github.com/user-attachments/assets/d0159a5e-d361-4715-851b-4e26235ee613)
![image](https://github.com/user-attachments/assets/8ba8b4f3-2f6a-4105-b73c-96f9dd342105)


- Test Case [ProgramFailureException] (wrong gender)
![image](https://github.com/user-attachments/assets/45fcda4b-f16d-4a95-8f10-8567af6b50ee)
![image](https://github.com/user-attachments/assets/28c2a705-59fb-4212-a0f1-979ad292d7e6)
![image](https://github.com/user-attachments/assets/51919a57-0f94-45c8-87bd-acf7657b9007)


- API Response 
```json
[
  {
    "stageName": "Database",
    "errorCategory": "Plugin-'DB Warning'-'Database'",
    "errorReason": "SQL Exception occurred: [Message='(conn=63) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265']. For more details, see https://en.wikipedia.org/wiki/SQLSTATE",
    "errorMessage": "SQL Error occurred, sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=63) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].",
    "errorType": "USER",
    "dependency": "true",
    "errorCodeType": "SQLSTATE",
    "errorCode": "01000",
    "supportedDocumentationUrl": "https://en.wikipedia.org/wiki/SQLSTATE"
  }
]
```

- LOGS

```
2025-04-21 11:22:40,255 - WARN  [WorkflowDriver:o.m.j.m.s.ErrorPacket@99] - Error: 1265-01000: Data truncated for column 'gender' at row 1
2025-04-21 11:22:40,268 - ERROR [WorkflowDriver:i.c.c.d.SmartWorkflow@542] - Pipeline 'gen-db-action' failed.
2025-04-21 11:22:40,281 - ERROR [WorkflowDriver:i.c.c.i.a.r.w.WorkflowProgramController@90] - Workflow service 'workflow.default.gen-db-action.DataPipelineWorkflow.d3df1ee7-1e74-11f0-8582-acde48001122' failed.
io.cdap.cdap.api.exception.WrappedStageException: Stage 'Database' encountered : io.cdap.cdap.api.exception.ProgramFailureException: SQL Error occurred, sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=63) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:48)
	at io.cdap.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:91)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:90)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:449)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:489)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:669)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.run(WorkflowDriver.java:653)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: SQL Error occurred, sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=63) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:198)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getProgramFailureException(DBErrorDetailsProvider.java:202)
	at io.cdap.plugin.db.batch.action.DBAction.run(DBAction.java:62)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.lambda$run$1(WrappedAction.java:49)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 10 common frames omitted
Caused by: java.sql.SQLTransientConnectionException: (conn=63) Data truncated for column 'gender' at row 1
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:309)
	at org.mariadb.jdbc.export.ExceptionFactory.create(ExceptionFactory.java:378)
	at org.mariadb.jdbc.message.ClientMessage.readPacket(ClientMessage.java:187)
	at org.mariadb.jdbc.client.impl.StandardClient.readPacket(StandardClient.java:1364)
	at org.mariadb.jdbc.client.impl.StandardClient.readResults(StandardClient.java:1303)
	at org.mariadb.jdbc.client.impl.StandardClient.readResponse(StandardClient.java:1222)
	at org.mariadb.jdbc.client.impl.StandardClient.execute(StandardClient.java:1146)
	at org.mariadb.jdbc.Statement.executeInternal(Statement.java:1003)
	at org.mariadb.jdbc.Statement.execute(Statement.java:1132)
	at org.mariadb.jdbc.Statement.execute(Statement.java:471)
	at io.cdap.plugin.db.batch.action.DBRun.run(DBRun.java:54)
	at io.cdap.plugin.db.batch.action.DBAction.run(DBAction.java:58)
	... 13 common frames omitted
2025-04-21 11:22:40,282 - DEBUG [WorkflowDriver:i.c.c.c.l.c.UncaughtExceptionHandler@40] - Uncaught exception in thread Thread[WorkflowDriver,5,main]
io.cdap.cdap.api.exception.WrappedStageException: Stage 'Database' encountered : io.cdap.cdap.api.exception.ProgramFailureException: SQL Error occurred, sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=63) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.run(WrappedAction.java:48)
	at io.cdap.cdap.etl.batch.customaction.PipelineAction.run(PipelineAction.java:91)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.workflow.CustomActionExecutor.execute(CustomActionExecutor.java:90)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeCustomAction(WorkflowDriver.java:449)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeNode(WorkflowDriver.java:489)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.executeAll(WorkflowDriver.java:669)
	at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.run(WorkflowDriver.java:653)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: SQL Error occurred, sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=63) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:198)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getProgramFailureException(DBErrorDetailsProvider.java:202)
	at io.cdap.plugin.db.batch.action.DBAction.run(DBAction.java:62)
	at io.cdap.cdap.etl.common.plugin.WrappedAction.lambda$run$1(WrappedAction.java:49)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 10 common frames omitted
Caused by: java.sql.SQLTransientConnectionException: (conn=63) Data truncated for column 'gender' at row 1
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:309)
	at org.mariadb.jdbc.export.ExceptionFactory.create(ExceptionFactory.java:378)
	at org.mariadb.jdbc.message.ClientMessage.readPacket(ClientMessage.java:187)
	at org.mariadb.jdbc.client.impl.StandardClient.readPacket(StandardClient.java:1364)
	at org.mariadb.jdbc.client.impl.StandardClient.readResults(StandardClient.java:1303)
	at org.mariadb.jdbc.client.impl.StandardClient.readResponse(StandardClient.java:1222)
	at org.mariadb.jdbc.client.impl.StandardClient.execute(StandardClient.java:1146)
	at org.mariadb.jdbc.Statement.executeInternal(Statement.java:1003)
	at org.mariadb.jdbc.Statement.execute(Statement.java:1132)
	at org.mariadb.jdbc.Statement.execute(Statement.java:471)
	at io.cdap.plugin.db.batch.action.DBRun.run(DBRun.java:54)
	at io.cdap.plugin.db.batch.action.DBAction.run(DBAction.java:58)
	... 13 common frames omitted
```