### PR TITLE
Bump org.apache.parquet:parquet-avro to v1.15.2

### DIFF
--- a/format-parquet/pom.xml
+++ b/format-parquet/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <version>1.12.0</version>
+      <version>1.15.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Bump due to a [security vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEPARQUET-9638681)