### PR TITLE
[🍒][Plugin-1730] Adding XLS UI elements for file source

### DIFF
--- a/core-plugins/docs/File-batchsource.md
+++ b/core-plugins/docs/File-batchsource.md
@@ -15,14 +15,14 @@ Properties
 **Path:** Path to read from. For example, s3a://<bucket>/path/to/input
 
 **Format:** Format of the data to read.
-The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv', or the
+The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv', 'xls', or the
 name of any format plugin that you have deployed to your environment.
 If the format is a macro, only the pre-packaged formats can be used.
 If the format is 'blob', every input file will be read into a separate record.
 The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
 If the format is 'text', the schema must contain a field named 'body' of type 'string'.
 
-**Get Schema:** Auto-detects schema from file. Supported formats are: avro, parquet, csv, delimited, tsv, blob 
+**Get Schema:** Auto-detects schema from file. Supported formats are: avro, parquet, csv, delimited, tsv, blob, xls
 and text.
 
 Blob - is set by default as field named 'body' of type bytes.
@@ -37,14 +37,22 @@ If no such file can be found, an error will be returned.
 Avro - If the path is a directory, the plugin will look for files ending in '.avro' to read the schema from. 
 If no such file can be found, an error will be returned.
 
+**Sample Size:** The maximum number of rows that will get investigated for automatic data type detection.
+The default value is 1000. This is only used when the format is 'xls'.
+
 **Override:** A list of columns with the corresponding data types for whom the automatic data type detection gets
- skipped. 
- 
-**Sample Size:** The maximum number of rows in a file that will get investigated for automatic data type detection.
+skipped. This is only used when the format is 'xls'.
+
+**Terminate Reading After Empty Row:** Specify whether to stop reading after encountering the first empty row. Defaults to false. When false the reader will read all rows in the sheet. This is only used when the format is 'xls'.
+
+**Select Sheet Using:** Select the sheet by name or number. Default is 'Sheet Number'. This is only used when the format is 'xls'.
+
+**Sheet Value:** The name/number of the sheet to read from. If not specified, the first sheet will be read.
+Sheet Numbers are 0 based, ie first sheet is 0. This is only used when the format is 'xls'.
 
 **Delimiter:** Delimiter to use when the format is 'delimited'. This will be ignored for other formats.
 
-**Use First Row as Header:** Whether to use the first line of each file as the column headers. Supported formats are 'text', 'csv', 'tsv', 'delimited'.
+**Use First Row as Header:** Whether to use the first line of each file as the column headers. Supported formats are 'text', 'csv', 'tsv', 'xls', 'delimited'.
 
 **Enable Quoted Values** Whether to treat content between quotes as a value. This value will only be used if the format
 is 'csv', 'tsv' or 'delimited'. For example, if this is set to true, a line that looks like `1, "a, b, c"` will output two fields.

--- a/core-plugins/src/main/java/io/cdap/plugin/batch/source/FileSourceConfig.java
+++ b/core-plugins/src/main/java/io/cdap/plugin/batch/source/FileSourceConfig.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.format.FileFormat;
@@ -37,6 +38,9 @@ public class FileSourceConfig extends AbstractFileSourceConfig {
   public static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
   public static final String NAME_PATH = "path";
   public static final String NAME_FILE_ENCODING = "fileEncoding";
+  public static final String NAME_SHEET = "sheet";
+  public static final String NAME_SHEET_VALUE = "sheetValue";
+  public static final String NAME_TERMINATE_IF_EMPTY_ROW = "terminateIfEmptyRow";
 
   private static final Gson GSON = new Gson();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
@@ -64,6 +68,25 @@ public class FileSourceConfig extends AbstractFileSourceConfig {
   @Nullable
   @Description("The maximum number of rows that will get investigated for automatic data type detection.")
   private Long sampleSize;
+
+  @Name(NAME_SHEET)
+  @Macro
+  @Nullable
+  @Description("Select the sheet by name or number. Default is 'Sheet Number'.")
+  private String sheet;
+
+  @Name(NAME_SHEET_VALUE)
+  @Macro
+  @Nullable
+  @Description("The name/number of the sheet to read from. If not specified, the first sheet will be read." +
+          "Sheet Numbers are 0 based, ie first sheet is 0.")
+  private String sheetValue;
+
+  @Name(NAME_TERMINATE_IF_EMPTY_ROW)
+  @Macro
+  @Nullable
+  @Description("Specify whether to stop reading after encountering the first empty row. Defaults to false.")
+  private String terminateIfEmptyRow;
   
   FileSourceConfig() {
     super();

--- a/core-plugins/widgets/File-batchsource.json
+++ b/core-plugins/widgets/File-batchsource.json
@@ -101,6 +101,42 @@
               "label": "False"
             }
           }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Terminate Reading After Empty Row",
+          "name": "terminateIfEmptyRow",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Select Sheet Using",
+          "name": "sheet",
+          "widget-attributes": {
+            "values": [
+              "Sheet Name",
+              "Sheet Number"
+            ],
+            "default": "Sheet Number"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Sheet Value",
+          "name": "sheetValue",
+          "widget-attributes": {
+            "default": "0"
+          }
         }
       ]
     },
@@ -499,11 +535,44 @@
     {
       "name": "skipHeader",
       "condition": {
-        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv'"
+        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv' || format == 'xls'"
       },
       "show": [
         {
           "name": "skipHeader"
+        }
+      ]
+    },
+    {
+      "name": "sheet",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheet"
+        }
+      ]
+    },
+    {
+      "name": "sheetValue",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheetValue"
+        }
+      ]
+    },
+    {
+      "name": "terminateIfEmptyRow",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "terminateIfEmptyRow"
         }
       ]
     }


### PR DESCRIPTION
[🍒]

🍒 [cherrypick]

### Commits :
 - 380b6ecb97176dad8772ed7640bc750abd3c8bbe

### PR:
 - #1842 [ Reviewer @itsankit-google ]
 
---

## Adding XLS UI elements for file source

Jira : [Plugin-1730](https://cdap.atlassian.net/browse/PLUGIN-1730)

### Description
This PR adds UI element required for XLS Support in `File Source`.
Ref : XLS Support PR https://github.com/cdapio/hydrator-plugins/pull/1835

### Added Fields 
- Terminate If Empty Row
- Select Sheet Using
- Sheet Value

A filter is used to show XLS specific values  `Terminate If Empty Row` , `Select Sheet Using`, `Sheet Value` only when format `XLS` is selected.

### Preview
<img width="948" alt="image" src="https://github.com/user-attachments/assets/05dc3005-d7b0-40ed-a30c-9672566a342b" />
<img width="1455" alt="image" src="https://github.com/user-attachments/assets/290e725e-9cd0-4fdc-96d4-22a5832d6982" />

## Sanity Tests 

### Data Used
[xlsx_bench.xlsx](https://github.com/user-attachments/files/20080031/xlsx_bench.xlsx)

- A xlsx file with 3 sheets
- Sheet 1 (data with headers)
- Sheet 2 (data without headers)
- Sheet 3 (data with headers and an empty line)

#### "Sheet1" [index 0]
![image](https://github.com/user-attachments/assets/2b6fa143-7f10-49ad-9b33-8fd1db80bc2f)

#### "Sheet2" [index 1]
![image](https://github.com/user-attachments/assets/7cff67c1-e6c5-4de1-8a40-71ffe1252b66)

#### "Sheet3" [index 2]
![image](https://github.com/user-attachments/assets/24da1b90-0f88-4c84-ba46-a316fcb551ae)

---

## Test 1 [Read a sheet with headers]

> We will be testing can the plugin read a sheet with headers defined, also skip the first row while reading data.

- Config
  - Turn on "Use First Row as Header" 
![image](https://github.com/user-attachments/assets/eca8fa1b-1998-4be7-a0a1-cafdc003a96f)

- Deploy
![image](https://github.com/user-attachments/assets/5dc2ede0-7ece-471f-b1f8-b2383265d738)

- Output
![image](https://github.com/user-attachments/assets/0eac6388-8b0f-4a90-989a-e379e31840cc)


## Test 2 [Read a sheet using it's name + Read a sheet other than the 1st + Read a sheet without headers]

> We will be testing can the plugin read a sheet using the sheet's name.
> We will be testing if the plugin can read any sheet other than the first one, we will also be testing if the plugin can read sheet without a header.

- Config
  - Set "Select Sheet Using" to "Sheet Name"
  - Add the sheet name
![image](https://github.com/user-attachments/assets/ee4ff303-5252-4909-96d0-2f8beb3eed06)

- Deploy
![image](https://github.com/user-attachments/assets/5e9e8e0b-e646-48a0-ba84-db851ad23f0b)

- Output
![image](https://github.com/user-attachments/assets/e0d1a60e-d17a-418c-91bc-6283c640e39c)

## Test 3 [Do not stop reading when a row is missing]

> We will be testing if the plugin can keep reading if an empty row is encountered.

- Config
  - Turn off "Terminate Reading After Empty Row" 
![image](https://github.com/user-attachments/assets/057aa3c9-f1d1-49c7-bf50-ea7969f54078)

- Deploy
![image](https://github.com/user-attachments/assets/ec965147-6350-474e-9e8e-21d00130072a)

- Output
![image](https://github.com/user-attachments/assets/7b18a7da-7a07-414f-8bde-44a26cad9790)

## Test 4 [Stop reading when a row is missing]

> We will be testing if the plugin can stop reading if an empty row is encountered.

- Config
    - Turn on "Terminate Reading After Empty Row"
![image](https://github.com/user-attachments/assets/202c979e-1427-44f4-a0a0-8eded5196dee)

- Deploy
![image](https://github.com/user-attachments/assets/46b7768d-888d-46a6-843f-ea5c36d91012)

- Output
![image](https://github.com/user-attachments/assets/765f6730-5e02-4ece-a0ee-f17d11bf6530)
