### PR TITLE
[cherry-pick][6.11][Security Vulnerability] [CVE-2025-48734] Ugraded dependency commons-validator to 1.10.1

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.4.1</version>
+      <version>1.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
original PR : #1987 