### PR TITLE
bump up to 2.12.5

### DIFF
--- a/cassandra-plugins/pom.xml
+++ b/cassandra-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.cdap.plugin</groupId>
     <artifactId>hydrator-plugins</artifactId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>Cassandra Plugins</name>

--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>Hydrator Core Plugins</name>

--- a/database-plugins/pom.xml
+++ b/database-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>Database Plugins</name>

--- a/format-avro/pom.xml
+++ b/format-avro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-blob/pom.xml
+++ b/format-blob/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-common/pom.xml
+++ b/format-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-delimited/pom.xml
+++ b/format-delimited/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-json/pom.xml
+++ b/format-json/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-orc/pom.xml
+++ b/format-orc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-parquet/pom.xml
+++ b/format-parquet/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-text/pom.xml
+++ b/format-text/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/format-xls/pom.xml
+++ b/format-xls/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.cdap.plugin</groupId>
     <artifactId>hydrator-plugins</artifactId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <artifactId>format-xls</artifactId>
   <name>XLS format plugins</name>

--- a/hbase-plugins/pom.xml
+++ b/hbase-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>HBase Plugins</name>

--- a/http-plugins/pom.xml
+++ b/http-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>HTTP Plugins</name>

--- a/hydrator-common/pom.xml
+++ b/hydrator-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/mongodb-plugins/pom.xml
+++ b/mongodb-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>MongoDB Plugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>hydrator-plugins</artifactId>
-  <version>2.12.5-SNAPSHOT</version>
+  <version>2.12.5</version>
   <packaging>pom</packaging>
   <name>Hydrator Plugin Collection</name>
   <description>A collection of plugins for CDAP</description>

--- a/solrsearch-plugins/pom.xml
+++ b/solrsearch-plugins/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>Solr Search Plugins</name>

--- a/spark-plugins/pom.xml
+++ b/spark-plugins/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hydrator-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>Spark Hydrator Plugins</name>

--- a/transform-plugins/pom.xml
+++ b/transform-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.cdap.plugin</groupId>
     <artifactId>hydrator-plugins</artifactId>
-    <version>2.12.5-SNAPSHOT</version>
+    <version>2.12.5</version>
   </parent>
 
   <name>Transform Plugins</name>


### PR DESCRIPTION
cherry pick link : https://github.com/cdapio/hydrator-plugins/commit/1d559d5e7b918cb9066f63bbade5b51acad1a914

PR Link: https://github.com/cdapio/hydrator-plugins/pull/1997

removed -SNAPSHOT for version 2.12.5